### PR TITLE
Add publishing GitHub Actions workflows

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -1,0 +1,20 @@
+name: Setup Go
+description: Setup go version, cache go and goreleaser
+inputs: {}
+outputs: {}
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-go@v2
+      with:
+        go-version: "1.17"
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/go
+          ~/.cache/go-build
+          ~/Library/Caches/go-build
+          %LocalAppData%\go-build
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
 
   release:
     runs-on: ubuntu-20.04
+    needs: [lint, build]
     steps:
       - uses: actions/checkout@v3
       - name: Generate changelog

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,18 +6,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v2
-        with:
-          go-version: "1.17"
-      - name: Verify dependencies
-        run: |
-          go mod verify
-          go mod download
-
-          LINT_VERSION=1.44.2
-          curl -fsSL https://github.com/golangci/golangci-lint/releases/download/v${LINT_VERSION}/golangci-lint-${LINT_VERSION}-linux-amd64.tar.gz | \
-            tar xz --strip-components 1 --wildcards \*/golangci-lint
-          mkdir -p bin && mv golangci-lint bin/
+      - uses: .github/actions/setup-go
       - name: Run checks
         run: |
           STATUS=0
@@ -42,19 +31,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v2
-        with:
-          go-version: "1.17"
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/go
-            ~/.cache/go-build
-            ~/Library/Caches/go-build
-            %LocalAppData%\go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go
+      - uses: .github/actions/setup-go
       - uses: goreleaser/goreleaser-action@v2
         with:
           version: 1.6.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,17 @@ jobs:
       - run: go mod download
       - run: go test -race ./...
       - run: go build -v ./cmd/depot
+
+  release:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Generate changelog
+        id: changelog
+        run: |
+          echo "::set-output name=tag-name::${GITHUB_REF#refs/tags/}"
+          gh api repos/$GITHUB_REPOSITORY/releases/generate-notes \
+            -f tag_name="${GITHUB_REF#refs/tags/}" \
+            -f target_commitish=main \
+            -q .body > CHANGELOG.md
+      - run: cat CHANGELOG.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-go
+      - name: Verify dependencies
+        run: |
+          go mod verify
+          go mod download
+
+          LINT_VERSION=1.44.2
+          curl -fsSL https://github.com/golangci/golangci-lint/releases/download/v${LINT_VERSION}/golangci-lint-${LINT_VERSION}-linux-amd64.tar.gz | \
+            tar xz --strip-components 1 --wildcards \*/golangci-lint
+          mkdir -p bin && mv golangci-lint bin/
       - name: Run checks
         run: |
           STATUS=0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
   release:
     runs-on: ubuntu-20.04
     needs: [lint, build]
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev-')
     steps:
       - uses: actions/checkout@v3
       - name: Generate changelog
@@ -60,5 +61,11 @@ jobs:
             -f target_commitish=main \
             -q .body > CHANGELOG.md
         env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - run: cat CHANGELOG.md
+          GITHUB_TOKEN: ${{ secrets.BOT_PUBLIC_GITHUB_TOKEN }}
+      - uses: goreleaser/goreleaser-action@v2
+        with:
+          version: 1.6.3
+          args: release --release-notes=CHANGELOG.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_PUBLIC_GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ steps.changelog.outputs.tag-name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: .github/actions/setup-go
+      - uses: ./.github/actions/setup-go
       - name: Run checks
         run: |
           STATUS=0
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: .github/actions/setup-go
+      - uses: ./.github/actions/setup-go
       - uses: goreleaser/goreleaser-action@v2
         with:
           version: 1.6.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,14 +47,18 @@ jobs:
           go-version: "1.17"
       - uses: actions/cache@v2
         with:
-          path: ~/go
-          key: ${{ runner.os }}-build-${{ hashFiles('go.mod') }}
+          path: |
+            ~/go
+            ~/.cache/go-build
+            ~/Library/Caches/go-build
+            %LocalAppData%\go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-      - run: go mod download
-      - run: go test -race ./...
-      - run: go build -v ./cmd/depot
+            ${{ runner.os }}-go
+      - uses: goreleaser/goreleaser-action@v2
+        with:
+          version: 1.6.3
+          args: build --rm-dist --snapshot
 
   release:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,4 +68,6 @@ jobs:
             -f tag_name="${GITHUB_REF#refs/tags/}" \
             -f target_commitish=main \
             -q .body > CHANGELOG.md
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - run: cat CHANGELOG.md

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist/
 /cli
 /bin
 /depot
+
+/CHANGELOG.md

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,6 +2,7 @@ project_name: depot
 
 release:
   name_template: "Depot CLI {{.Version}}"
+  prerelease: auto
 
 before:
   hooks:
@@ -17,6 +18,8 @@ builds:
     id: macos
     goos: [darwin]
     goarch: [amd64, arm64]
+    env:
+      - CGO_ENABLED=0
 
   - <<: *build_defaults
     id: linux
@@ -24,3 +27,36 @@ builds:
     goarch: ["386", arm, amd64, arm64]
     env:
       - CGO_ENABLED=0
+
+archives:
+  - id: nix
+    builds: [macos, linux]
+    <<: &archive_defaults
+      name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    replacements:
+      darwin: macOS
+    format: tar.gz
+
+brews:
+  - tap:
+      owner: depot
+      name: homebrew-tap
+    commit_author:
+      name: depot-bot
+      email: automation@depot.dev
+    homepage: https://depot.dev
+    description: The official CLI for Depot.
+    license: MIT
+    skip_upload: auto
+    install: |
+      bin.install "depot"
+
+      bash_comp = Utils.safe_popen_read("#{bin}/depot", "completion", "bash")
+      fish_comp = Utils.safe_popen_read("#{bin}/depot", "completion", "fish")
+      zsh_comp = Utils.safe_popen_read("#{bin}/depot", "completion", "zsh")
+
+      (bash_completion/"depot").write bash_comp
+      (fish_completion/"depot.fish").write fish_comp
+      (zsh_completion/"_depot").write zsh_comp
+    test: |
+      system "#{bin}/depot version"


### PR DESCRIPTION
Publishes the CLI via GitHub Actions - currently publishes to GitHub releases in this repository + Homebrew via https://github.com/depot/homebrew-tap.