### PR TITLE
Add --no-wait option to exit if builder is busy

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -17,11 +17,13 @@ type Builder struct {
 	buildID string
 	depot   *api.Depot
 	proxy   *proxyServer
+	noWait  bool
 }
 
-func NewBuilder(depot *api.Depot) *Builder {
+func NewBuilder(depot *api.Depot, noWait bool) *Builder {
 	return &Builder{
-		depot: depot,
+		depot:  depot,
+		noWait: noWait,
 	}
 }
 
@@ -39,6 +41,10 @@ func (b *Builder) Acquire(l progress.Logger, project string) (string, error) {
 			}
 
 			if resp.OK && resp.Busy {
+				if b.noWait {
+					return errors.New("builder is in use, but --no-wait was specified, exiting")
+				}
+
 				if count == 0 {
 					sub.Log(2, []byte("Builder is busy, waiting for current build to complete...\n"))
 				} else if count%10 == 0 {

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -83,6 +83,7 @@ func NewCmdBuild() *cobra.Command {
 	// Depot options
 	flags.StringVar(&options.project, "project", "", "Depot project ID")
 	flags.StringVar(&options.token, "token", "", "Depot API token")
+	flags.BoolVar(&options.noWait, "no-wait", false, "Fail immediately if no builder is available")
 
 	// `docker buildx build` options
 	flags.StringSliceVar(&options.extraHosts, "add-host", []string{}, `Add a custom host-to-IP mapping (format: "host:ip")`)

--- a/pkg/cmd/build/buildx.go
+++ b/pkg/cmd/build/buildx.go
@@ -45,6 +45,7 @@ const defaultTargetName = "default"
 type buildOptions struct {
 	project string
 	token   string
+	noWait  bool
 
 	contextPath    string
 	dockerfileName string
@@ -253,7 +254,7 @@ func buildTargets(ctx context.Context, dockerCli command.Cli, opts map[string]bu
 		return "", err
 	}
 
-	b := builder.NewBuilder(depot)
+	b := builder.NewBuilder(depot, in.noWait)
 	addr, err := b.Acquire(printer.Write, in.project)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
By default the CLI will wait for the builder to become available, if desired `--no-wait` causes the CLI to exit with an error code if the builder is busy.