### PR TITLE
Use new build API endpoints, remove `--no-wait`

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -24,20 +24,30 @@ func NewDepotFromEnv(token string) (*Depot, error) {
 	return NewDepot(baseURL, token), nil
 }
 
-type InitResponse struct {
-	OK          bool   `json:"ok"`
-	BaseURL     string `json:"baseURL"`
-	ID          string `json:"id"`
-	AccessToken string `json:"accessToken"`
-	Busy        bool   `json:"busy"`
+type BuildReponse struct {
+	OK           bool   `json:"ok"`
+	BaseURL      string `json:"baseURL"`
+	ID           string `json:"id"`
+	AccessToken  string `json:"accessToken"`
+	BuilderState string `json:"builderState"`
+	PollSeconds  int    `json:"pollSeconds"`
 }
 
-func (d *Depot) InitBuild(projectID string) (*InitResponse, error) {
-	return apiRequest[InitResponse](
+func (d *Depot) CreateBuild(projectID string) (*BuildReponse, error) {
+	return apiRequest[BuildReponse](
 		"POST",
-		fmt.Sprintf("%s/api/builds", d.BaseURL),
+		fmt.Sprintf("%s/api/internal/cli/projects/%s/builds", d.BaseURL, projectID),
 		d.token,
-		map[string]string{"projectID": projectID},
+		map[string]string{},
+	)
+}
+
+func (d *Depot) GetBuild(buildID string) (*BuildReponse, error) {
+	return apiRequest[BuildReponse](
+		"GET",
+		fmt.Sprintf("%s/api/internal/cli/builds/%s", d.BaseURL, buildID),
+		d.token,
+		map[string]string{},
 	)
 }
 
@@ -48,9 +58,9 @@ type FinishResponse struct {
 func (d *Depot) FinishBuild(buildID string) error {
 	_, err := apiRequest[FinishResponse](
 		"DELETE",
-		fmt.Sprintf("%s/api/builds", d.BaseURL),
+		fmt.Sprintf("%s/api/internal/cli/builds/%s", d.BaseURL, buildID),
 		d.token,
-		map[string]string{"id": buildID},
+		map[string]string{},
 	)
 	return err
 }

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -83,7 +83,6 @@ func NewCmdBuild() *cobra.Command {
 	// Depot options
 	flags.StringVar(&options.project, "project", "", "Depot project ID")
 	flags.StringVar(&options.token, "token", "", "Depot API token")
-	flags.BoolVar(&options.noWait, "no-wait", false, "Fail immediately if no builder is available")
 
 	// `docker buildx build` options
 	flags.StringSliceVar(&options.extraHosts, "add-host", []string{}, `Add a custom host-to-IP mapping (format: "host:ip")`)

--- a/pkg/cmd/build/buildx.go
+++ b/pkg/cmd/build/buildx.go
@@ -45,7 +45,6 @@ const defaultTargetName = "default"
 type buildOptions struct {
 	project string
 	token   string
-	noWait  bool
 
 	contextPath    string
 	dockerfileName string
@@ -254,7 +253,7 @@ func buildTargets(ctx context.Context, dockerCli command.Cli, opts map[string]bu
 		return "", err
 	}
 
-	b := builder.NewBuilder(depot, in.noWait)
+	b := builder.NewBuilder(depot)
 	addr, err := b.Acquire(printer.Write, in.project)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Uses new build API endpoints that track when a builder is ready. Also removes `--no-wait` as the new API no longer asks the CLI to wait to connect to a builder.