### PR TITLE
Support multi-platform builds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b
 	github.com/moby/buildkit v0.10.1-0.20220403220257-10e6f94bf90d
 	github.com/morikuni/aec v1.0.0
+	github.com/opencontainers/image-spec v1.0.2-0.20211117181255-693428a734f5
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.4.0
@@ -86,7 +87,6 @@ require (
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.11.1-0.20220212125758-44cd13922739 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.0.2-0.20211117181255-693428a734f5 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/prometheus/client_golang v1.12.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -25,12 +25,8 @@ func NewDepotFromEnv(token string) (*Depot, error) {
 }
 
 type BuildReponse struct {
-	OK           bool   `json:"ok"`
-	BaseURL      string `json:"baseURL"`
-	ID           string `json:"id"`
-	AccessToken  string `json:"accessToken"`
-	BuilderState string `json:"builderState"`
-	PollSeconds  int    `json:"pollSeconds"`
+	OK bool   `json:"ok"`
+	ID string `json:"id"`
 }
 
 func (d *Depot) CreateBuild(projectID string) (*BuildReponse, error) {
@@ -46,6 +42,24 @@ func (d *Depot) GetBuild(buildID string) (*BuildReponse, error) {
 	return apiRequest[BuildReponse](
 		"GET",
 		fmt.Sprintf("%s/api/internal/cli/builds/%s", d.BaseURL, buildID),
+		d.token,
+		map[string]string{},
+	)
+}
+
+type BuilderResponse struct {
+	OK           bool   `json:"ok"`
+	Endpoint     string `json:"endpoint"`
+	AccessToken  string `json:"accessToken"`
+	BuilderState string `json:"builderState"`
+	PollSeconds  int    `json:"pollSeconds"`
+	Platform     string `json:"platform"`
+}
+
+func (d *Depot) GetBuilder(buildID string, platform string) (*BuilderResponse, error) {
+	return apiRequest[BuilderResponse](
+		"GET",
+		fmt.Sprintf("%s/api/internal/cli/builds/%s/platform/%s", d.BaseURL, buildID, platform),
 		d.token,
 		map[string]string{},
 	)

--- a/pkg/api/context.go
+++ b/pkg/api/context.go
@@ -1,0 +1,13 @@
+package api
+
+import "context"
+
+const depotClientKey = "depot.client"
+
+func WithClient(ctx context.Context, client *Depot) context.Context {
+	return context.WithValue(ctx, depotClientKey, client)
+}
+
+func GetContextClient(ctx context.Context) *Depot {
+	return ctx.Value(depotClientKey).(*Depot)
+}

--- a/pkg/builder/context.go
+++ b/pkg/builder/context.go
@@ -1,0 +1,15 @@
+package builder
+
+import "context"
+
+func WithBuilders(ctx context.Context, builders []*Builder) context.Context {
+	return context.WithValue(ctx, "depot.builders", builders)
+}
+
+func GetContextBuilders(ctx context.Context) []*Builder {
+	builders, ok := ctx.Value("depot.builders").([]*Builder)
+	if !ok {
+		return nil
+	}
+	return builders
+}

--- a/pkg/builder/proxy.go
+++ b/pkg/builder/proxy.go
@@ -17,8 +17,8 @@ type proxyServer struct {
 	server *httptest.Server
 }
 
-func newProxyServer(computeHost string, apiKey string, builderID string) (*proxyServer, error) {
-	builderURL, err := url.Parse(computeHost + "/" + builderID)
+func newProxyServer(endpoint string, apiKey string) (*proxyServer, error) {
+	builderURL, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Adds support for multi-platform builds (x86_64 and arm64) - the CLI will default to request the same platform as the host device, and Depot will provide a builder instance matching the requested architecture.