### PR TITLE
Fix nil pointer error, add timeout for connection checks

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -103,14 +103,18 @@ func (b *Builder) Acquire(l progress.Logger) (string, error) {
 				continue
 			}
 
-			testClient, err := client.New(context.TODO(), "", client.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			testClient, err := client.New(ctx, "", client.WithFailFast(), client.WithContextDialer(func(context.Context, string) (net.Conn, error) {
 				return conn, nil
 			}))
 			if err != nil {
 				continue
 			}
 
-			workers, err := testClient.ListWorkers(context.TODO())
+			ctx2, cancel2 := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel2()
+			workers, err := testClient.ListWorkers(ctx2)
 			if err != nil {
 				continue
 			}

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -47,7 +47,7 @@ func (b *Builder) Acquire(l progress.Logger) (string, error) {
 		// Loop if the builder is not ready
 		count := 0
 		for {
-			if resp.OK && resp.BuilderState == "ready" {
+			if resp != nil && resp.OK && resp.BuilderState == "ready" {
 				break
 			}
 


### PR DESCRIPTION
It's possible for the CLI to hang indefinitely when performing an initial builder connection check - this PR adds a timeout for that operation, plus one fix for a nil pointer error.