### PR TITLE
Set build metadata when building Docker container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,4 +83,4 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            LDARGS="-ldargs='-s -w -X github.com/depot/cli/internal/build.Version=${{ steps.build-info.outputs.version }} -X github.com/depot/cli/internal/build.Date=${{ steps.build-info.outputs.date }} -X github.com/depot/cli/internal/build.SentryEnvironment=${{ steps.build-info.outputs.sentry-environment }}'"
+            LDFLAGS="-s -w -X github.com/depot/cli/internal/build.Version=${{ steps.build-info.outputs.version }} -X github.com/depot/cli/internal/build.Date=${{ steps.build-info.outputs.date }} -X github.com/depot/cli/internal/build.SentryEnvironment=${{ steps.build-info.outputs.sentry-environment }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,12 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+      - id: build-info
+        name: Set build information
+        run: |
+          echo "::set-output name=version::${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}"
+          echo "::set-output name=date::$(date +'%Y-%m-%d')"
+          echo "::set-output name=sentry-environment::${{ startsWith(github.ref, 'refs/tags/v') ? "release" : "development" }}"
       - uses: docker/login-action@v1
         with:
           registry: ghcr.io
@@ -76,3 +82,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            LDARGS="-ldargs='-s -w -X github.com/depot/cli/internal/build.Version=${{ steps.build-info.outputs.version }} -X github.com/depot/cli/internal/build.Date=${{ steps.build-info.outputs.date }} -X github.com/depot/cli/internal/build.SentryEnvironment=${{ steps.build-info.outputs.sentry-environment }}'"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           echo "::set-output name=version::${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}"
           echo "::set-output name=date::$(date +'%Y-%m-%d')"
-          echo "::set-output name=sentry-environment::${{ startsWith(github.ref, 'refs/tags/v') && "release" || "development" }}"
+          echo "::set-output name=sentry-environment::${{ fromJSON('{"true":"release","false":"development"}')[startsWith(github.ref, 'refs/tags/v')] }}"
       - uses: docker/login-action@v1
         with:
           registry: ghcr.io

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           echo "::set-output name=version::${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}"
           echo "::set-output name=date::$(date +'%Y-%m-%d')"
-          echo "::set-output name=sentry-environment::${{ startsWith(github.ref, 'refs/tags/v') ? "release" : "development" }}"
+          echo "::set-output name=sentry-environment::${{ startsWith(github.ref, 'refs/tags/v') && "release" || "development" }}"
       - uses: docker/login-action@v1
         with:
           registry: ghcr.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
 FROM --platform=$BUILDPLATFORM golang:1.18 AS build
 WORKDIR /src
+ARG LDFLAGS " "
 ARG TARGETARCH
 RUN mkdir /out
 RUN \
   --mount=target=. \
   --mount=target=/go/pkg/mod,type=cache \
-  GOARCH=${TARGETARCH} CGO_ENABLED=0 go build -o /out/ ./cmd/...
+  GOARCH=${TARGETARCH} CGO_ENABLED=0 \
+  go build \
+  ${LDFLAGS} \
+  -o /out/ ./cmd/...
 
 FROM --platform=$TARGETPLATFORM ubuntu:20.04
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM --platform=$BUILDPLATFORM golang:1.18 AS build
 WORKDIR /src
-ARG LDFLAGS " "
+ARG LDFLAGS
 ARG TARGETARCH
 RUN mkdir /out
 RUN \
   --mount=target=. \
   --mount=target=/go/pkg/mod,type=cache \
-  GOARCH=${TARGETARCH} CGO_ENABLED=0 \
+  GOARCH=${TARGETARCH} LDFLAGS=${LDFLAGS} CGO_ENABLED=0 \
   go build \
-  ${LDFLAGS} \
+  -ldflags="$LDFLAGS" \
   -o /out/ ./cmd/...
 
 FROM --platform=$TARGETPLATFORM ubuntu:20.04


### PR DESCRIPTION
Previously all Docker images built with a `depot --version` set to `(devel)`. This PR sets the correct build flags for the Docker build.