### PR TITLE
Set 5-second timeout on connection tests

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -47,7 +47,7 @@ func (b *Builder) Acquire(l progress.Logger) (string, error) {
 		// Loop if the builder is not ready
 		count := 0
 		for {
-			if resp.OK && resp.BuilderState == "ready" {
+			if resp != nil && resp.OK && resp.BuilderState == "ready" {
 				break
 			}
 
@@ -103,14 +103,18 @@ func (b *Builder) Acquire(l progress.Logger) (string, error) {
 				continue
 			}
 
-			testClient, err := client.New(context.TODO(), "", client.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			testClient, err := client.New(ctx, "", client.WithContextDialer(func(context.Context, string) (net.Conn, error) {
 				return conn, nil
 			}))
 			if err != nil {
 				continue
 			}
 
-			workers, err := testClient.ListWorkers(context.TODO())
+			ctx2, cancel2 := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel2()
+			workers, err := testClient.ListWorkers(ctx2)
 			if err != nil {
 				continue
 			}


### PR DESCRIPTION
Second attempt at #22, but without `WithFailFast()`.