### PR TITLE
Update ldflags in Docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,4 +83,4 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            LDFLAGS="-s -w -X github.com/depot/cli/internal/build.Version=${{ steps.build-info.outputs.version }} -X github.com/depot/cli/internal/build.Date=${{ steps.build-info.outputs.date }} -X github.com/depot/cli/internal/build.SentryEnvironment=${{ steps.build-info.outputs.sentry-environment }}"
+            LDFLAGS=-s -w -X github.com/depot/cli/internal/build.Version=${{ steps.build-info.outputs.version }} -X github.com/depot/cli/internal/build.Date=${{ steps.build-info.outputs.date }} -X github.com/depot/cli/internal/build.SentryEnvironment=${{ steps.build-info.outputs.sentry-environment }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,8 @@ RUN mkdir /out
 RUN \
   --mount=target=. \
   --mount=target=/go/pkg/mod,type=cache \
-  GOARCH=${TARGETARCH} LDFLAGS=${LDFLAGS} CGO_ENABLED=0 \
-  go build \
-  -ldflags="$LDFLAGS" \
+  GOARCH=${TARGETARCH} CGO_ENABLED=0 \
+  go build -ldflags="${LDFLAGS}" \
   -o /out/ ./cmd/...
 
 FROM --platform=$TARGETPLATFORM ubuntu:20.04


### PR DESCRIPTION
The CLI Docker container does not yet have the correct version inside - this PR attempts to fix how `-ldflags` are passed to the build