### PR TITLE
Add build hints to pre-launch builder machines

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -45,7 +45,7 @@ type BuildHintReponse struct {
 func (d *Depot) ReportBuildHint(projectID string) (*BuildHintReponse, error) {
 	return apiRequest[BuildHintReponse](
 		"POST",
-		fmt.Sprintf("%s/api/internal/cli/projects/%s/build-hint", d.BaseURL, projectID),
+		fmt.Sprintf("%s/api/internal/cli/projects/%s/build-hints", d.BaseURL, projectID),
 		d.token,
 		map[string]string{},
 	)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -38,6 +38,19 @@ func (d *Depot) CreateBuild(projectID string) (*BuildReponse, error) {
 	)
 }
 
+type BuildHintReponse struct {
+	OK bool `json:"ok"`
+}
+
+func (d *Depot) ReportBuildHint(projectID string) (*BuildHintReponse, error) {
+	return apiRequest[BuildHintReponse](
+		"POST",
+		fmt.Sprintf("%s/api/internal/cli/projects/%s/build-hint", d.BaseURL, projectID),
+		d.token,
+		map[string]string{},
+	)
+}
+
 type BuilderResponse struct {
 	OK           bool   `json:"ok"`
 	Endpoint     string `json:"endpoint"`

--- a/pkg/hints/hints.go
+++ b/pkg/hints/hints.go
@@ -35,5 +35,5 @@ func SendBuildHint() {
 		return
 	}
 
-	client.ReportBuildHint(projectID)
+	_, _ = client.ReportBuildHint(projectID)
 }

--- a/pkg/hints/hints.go
+++ b/pkg/hints/hints.go
@@ -1,0 +1,39 @@
+package hints
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/depot/cli/pkg/api"
+	"github.com/depot/cli/pkg/config"
+	"github.com/depot/cli/pkg/project"
+)
+
+func SendBuildHint() {
+	projectID := os.Getenv("DEPOT_PROJECT_ID")
+	if projectID == "" {
+		cwd, _ := filepath.Abs(".")
+		config, _, err := project.ReadConfig(cwd)
+		if err == nil {
+			projectID = config.ID
+		}
+	}
+	if projectID == "" {
+		return
+	}
+
+	token := os.Getenv("DEPOT_TOKEN")
+	if token == "" {
+		token = config.GetApiToken()
+	}
+	if token == "" {
+		return
+	}
+
+	client, err := api.NewDepotFromEnv(token)
+	if err != nil {
+		return
+	}
+
+	client.ReportBuildHint(projectID)
+}


### PR DESCRIPTION
If the CLI auto-completes a command starting with `b` (for `build`) and it is able to determine a project ID from the environment, for instance a `depot.json` file, it send a build hint ping to the Depot API. The Depot API can use this to preemptively prepare the remote build environment to receive the build, cutting down on cold boot time.