### PR TITLE
Fix sending body on GET request

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -58,7 +58,7 @@ func (d *Depot) GetBuilder(buildID string, platform string) (*BuilderResponse, e
 		"GET",
 		fmt.Sprintf("%s/api/internal/cli/builds/%s/platform/%s", d.BaseURL, buildID, platform),
 		d.token,
-		map[string]string{},
+		nil,
 	)
 }
 


### PR DESCRIPTION
One of our GET API requests was being sent with an empty JSON body (`{}`) - GET requests aren't allowed to send bodies, so this fixes that invalid request.