### PR TITLE
Use `dl.depot.dev` to retrieve latest version information

### DIFF
--- a/cmd/depot/main.go
+++ b/cmd/depot/main.go
@@ -35,7 +35,7 @@ func runMain() int {
 	buildVersion := build.Version
 	buildDate := build.Date
 
-	updateMessageChan := make(chan *update.ReleaseInfo)
+	updateMessageChan := make(chan *api.ReleaseResponse)
 	go func() {
 		rel, _ := checkForUpdate(buildVersion)
 		updateMessageChan <- rel
@@ -66,7 +66,7 @@ func runMain() int {
 	return 0
 }
 
-func checkForUpdate(currentVersion string) (*update.ReleaseInfo, error) {
+func checkForUpdate(currentVersion string) (*api.ReleaseResponse, error) {
 	if !shouldCheckForUpdate() {
 		return nil, nil
 	}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -106,7 +106,7 @@ type ReleaseResponse struct {
 func (d *Depot) LatestRelease() (*ReleaseResponse, error) {
 	return apiRequest[ReleaseResponse](
 		"GET",
-		fmt.Sprintf("%s/api/cli/release/%s/%s/latest", d.BaseURL, runtime.GOOS, runtime.GOARCH),
+		fmt.Sprintf("https://dl.depot.dev/cli/release/%s/%s/latest", runtime.GOOS, runtime.GOARCH),
 		d.token,
 		nil,
 	)


### PR DESCRIPTION
Uses the new `dl.depot.dev` service to retrieve latest CLI version