### PR TITLE
Add support for Docker TLS env vars

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/docker/cli v20.10.17+incompatible
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/docker/docker v20.10.17+incompatible
+	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.4.0
 	github.com/getsentry/sentry-go v0.13.0
 	github.com/hashicorp/go-version v1.2.0
@@ -48,7 +49,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect
 	github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c // indirect
-	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/felixge/httpsnoop v1.0.2 // indirect

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -2,13 +2,13 @@ package build
 
 import "runtime/debug"
 
-var Version = "dev"
+var Version = "0.0.0-dev"
 var Date = ""
 var SentryEnvironment = "development"
 
 func init() {
-	if Version == "dev" {
-		if info, ok := debug.ReadBuildInfo(); ok {
+	if Version == "0.0.0-dev" {
+		if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "(devel)" {
 			Version = info.Main.Version
 		}
 	}

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -8,8 +8,6 @@ import (
 	"github.com/depot/cli/pkg/config"
 	"github.com/depot/cli/pkg/project"
 	"github.com/docker/cli/cli"
-	"github.com/docker/cli/cli/command"
-	cliflags "github.com/docker/cli/cli/flags"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -51,13 +49,7 @@ func NewCmdBuild() *cobra.Command {
 				return fmt.Errorf("missing API token, please run `depot login`")
 			}
 
-			dockerCli, err := command.NewDockerCli()
-			if err != nil {
-				fmt.Fprintln(os.Stderr, err)
-				os.Exit(1)
-			}
-			opts := cliflags.NewClientOptions()
-			err = dockerCli.Initialize(opts)
+			dockerCli, err := newDockerCLI()
 			if err != nil {
 				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)

--- a/pkg/cmd/build/dockerclient.go
+++ b/pkg/cmd/build/dockerclient.go
@@ -1,0 +1,61 @@
+package build
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/config"
+	cliflags "github.com/docker/cli/cli/flags"
+	"github.com/docker/docker/client"
+	"github.com/docker/go-connections/tlsconfig"
+)
+
+// Copied from github.com/docker/cli/cli/flags/common.go
+
+var (
+	dockerCertPath  = os.Getenv(client.EnvOverrideCertPath)
+	dockerTLSVerify = os.Getenv(client.EnvTLSVerify) != ""
+	dockerTLS       = os.Getenv("DOCKER_TLS") != ""
+)
+
+func newDockerCLI() (*command.DockerCli, error) {
+	dockerCli, err := command.NewDockerCli()
+	if err != nil {
+		return nil, err
+	}
+
+	// Construct options with TLS
+	opts := cliflags.NewClientOptions()
+	if dockerCertPath == "" {
+		dockerCertPath = config.Dir()
+	}
+
+	opts.Common.TLS = dockerTLS
+	opts.Common.TLSVerify = dockerTLSVerify
+	if opts.Common.TLSVerify {
+		opts.Common.TLS = true
+	}
+	if opts.Common.TLS {
+		opts.Common.TLSOptions = &tlsconfig.Options{
+			CAFile:             filepath.Join(dockerCertPath, cliflags.DefaultCaFile),
+			CertFile:           filepath.Join(dockerCertPath, cliflags.DefaultCertFile),
+			KeyFile:            filepath.Join(dockerCertPath, cliflags.DefaultKeyFile),
+			InsecureSkipVerify: !opts.Common.TLSVerify,
+		}
+		// Reset CertFile and KeyFile to empty string if the respective default files were not found.
+		if _, err := os.Stat(opts.Common.TLSOptions.CertFile); os.IsNotExist(err) {
+			opts.Common.TLSOptions.CertFile = ""
+		}
+		if _, err := os.Stat(opts.Common.TLSOptions.KeyFile); os.IsNotExist(err) {
+			opts.Common.TLSOptions.KeyFile = ""
+		}
+	}
+
+	err = dockerCli.Initialize(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return dockerCli, err
+}

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -30,7 +30,7 @@ func Format(version, buildDate string) string {
 func changelogURL(version string) string {
 	path := "https://github.com/depot/cli"
 	r := regexp.MustCompile(`^v?\d+\.\d+\.\d+(-[\w.]+)?$`)
-	if !r.MatchString(version) {
+	if !r.MatchString(version) || version == "0.0.0-dev" {
 		return fmt.Sprintf("%s/releases/latest", path)
 	}
 	url := fmt.Sprintf("%s/releases/tag/v%s", path, strings.TrimPrefix(version, "v"))


### PR DESCRIPTION
Adds support for Docker's TLS environment variables (`DOCKER_TLS`, `DOCKER_TLS_VERIFY`, `DOCKER_CERT_PATH`) when loading images into the Docker daemon.