### PR TITLE
Report Depot API failure reasons to API

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -87,11 +87,18 @@ func (d *Depot) FinishBuild(buildID string, buildErr error) error {
 		status = "success"
 	}
 
+	payload := map[string]string{"status": status}
+
+	// If this is a Depot error, include the error message
+	if IsDepotError(buildErr) {
+		payload["error"] = buildErr.Error()
+	}
+
 	_, err := apiRequest[FinishResponse](
 		"DELETE",
 		fmt.Sprintf("%s/api/internal/cli/builds/%s", d.BaseURL, buildID),
 		d.token,
-		map[string]string{"status": status},
+		payload,
 	)
 	return err
 }

--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -1,0 +1,27 @@
+package api
+
+// DepotError wraps the error interface
+type DepotError struct {
+	Err error
+}
+
+// Error returns the error message
+func (e *DepotError) Error() string {
+	return e.Err.Error()
+}
+
+// Unwrap returns the underlying error
+func (e *DepotError) Unwrap() error {
+	return e.Err
+}
+
+// NewDepotError returns a new DepotError
+func NewDepotError(err error) *DepotError {
+	return &DepotError{Err: err}
+}
+
+// IsDepotError returns true if the error is a DepotError
+func IsDepotError(err error) bool {
+	_, ok := err.(*DepotError)
+	return ok
+}


### PR DESCRIPTION
Reports Depot API failure reasons to the Depot API, but omits sending the error message for BuildKit errors (to avoid sending any sensitive information about Dockerfile contents to the API).