### PR TITLE
Send custom user-agent header

### DIFF
--- a/pkg/api/request.go
+++ b/pkg/api/request.go
@@ -47,6 +47,7 @@ func apiRequest[Response interface{}](method, url, token string, payload interfa
 		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
 	}
 	req.Header.Add("User-Agent", fmt.Sprintf("depot-cli/%s/%s/%s", build.Version, runtime.GOOS, runtime.GOARCH))
+	req.Header.Add("Depot-User-Agent", fmt.Sprintf("depot-cli/%s/%s/%s", build.Version, runtime.GOOS, runtime.GOARCH))
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/pkg/api/rpc.go
+++ b/pkg/api/rpc.go
@@ -37,6 +37,7 @@ func NewProjectsClient() cliv1beta1connect.ProjectsServiceClient {
 
 func WithHeaders[T any](req *connect.Request[T], token string) *connect.Request[T] {
 	req.Header().Add("User-Agent", fmt.Sprintf("depot-cli/%s/%s/%s", build.Version, runtime.GOOS, runtime.GOARCH))
+	req.Header().Add("Depot-User-Agent", fmt.Sprintf("depot-cli/%s/%s/%s", build.Version, runtime.GOOS, runtime.GOARCH))
 	if token != "" {
 		req.Header().Add("Authorization", "Bearer "+token)
 	}

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -115,6 +115,7 @@ func (b *Builder) ReportHealth(ctx context.Context) error {
 
 	stream := client.ReportBuildHealth(ctx)
 	stream.RequestHeader().Add("User-Agent", fmt.Sprintf("depot-cli/%s/%s/%s", build.Version, runtime.GOOS, runtime.GOARCH))
+	stream.RequestHeader().Add("Depot-User-Agent", fmt.Sprintf("depot-cli/%s/%s/%s", build.Version, runtime.GOOS, runtime.GOARCH))
 	stream.RequestHeader().Add("Authorization", "Bearer "+b.token)
 	defer func() {
 		_, _ = stream.CloseAndReceive()


### PR DESCRIPTION
Works around an issue where `User-Agent` can get overridden.