### PR TITLE
Add the ability to specify `--build-platform`

### DIFF
--- a/pkg/helpers/buildplatform.go
+++ b/pkg/helpers/buildplatform.go
@@ -1,0 +1,22 @@
+package helpers
+
+import (
+	"fmt"
+	"os"
+)
+
+func NormalizePlatform(buildPlatform string) (string, error) {
+	if buildPlatform == "" {
+		buildPlatform = os.Getenv("DEPOT_BUILD_PLATFORM")
+	}
+
+	if buildPlatform == "" {
+		buildPlatform = "dynamic"
+	}
+
+	if buildPlatform != "linux/amd64" && buildPlatform != "linux/arm64" && buildPlatform != "dynamic" {
+		return "", fmt.Errorf("invalid build platform: %s (must be one of: dynamic, linux/amd64, linux/arm64)", buildPlatform)
+	}
+
+	return buildPlatform, nil
+}


### PR DESCRIPTION
Allows forcing builds to run on Intel or Arm builders, regardless of the requested container platform, by specifying either `--build-platform` flag or the `DEPOT_BUILD_PLATFORM` environment variable. The valid build platform values are:

* `dynamic` - run on Intel or Arm builders depending on container platform, or both in the case of multi-platform builds (this is the default)
* `linux/amd64` - run only on Intel builders
* `linux/arm64` - run only on Arm builders