### PR TITLE
Start build health check early

### DIFF
--- a/pkg/buildxdriver/driver.go
+++ b/pkg/buildxdriver/driver.go
@@ -34,6 +34,11 @@ type tlsOpts struct {
 }
 
 func (d *Driver) Bootstrap(ctx context.Context, l progress.Logger) error {
+	err := d.startHealthcheck(context.Background())
+	if err != nil {
+		return err
+	}
+
 	builderInfo, err := d.builder.Acquire(l)
 	if err != nil {
 		return api.NewDepotError(errors.Wrap(err, "failed to bootstrap builder"))
@@ -90,11 +95,6 @@ func (d *Driver) Bootstrap(ctx context.Context, l progress.Logger) error {
 				return err
 			}
 			if info.Status != driver.Inactive {
-				err = d.startHealthcheck(context.Background())
-				if err != nil {
-					return err
-				}
-
 				return nil
 			}
 


### PR DESCRIPTION
Previously we only started the CLI's health check after acquiring a builder. This meant that if a builder was not acquired in 60s, the CLI would be incorrectly marked as disconnected.

Now this starts the health check first, so the CLI is able to wait for a builder as intended.