### PR TITLE
fix(bake): ignore spurious context canceled printer wait error

### DIFF
--- a/pkg/buildx/commands/bake.go
+++ b/pkg/buildx/commands/bake.go
@@ -97,7 +97,7 @@ func RunBake(dockerCli command.Cli, targets []string, in BakeOptions) (err error
 	defer func() {
 		if printer != nil {
 			err1 := printer.Wait()
-			if err == nil {
+			if err == nil && !errors.Is(err1, context.Canceled) {
 				err = err1
 			}
 		}


### PR DESCRIPTION
This can cause bake to exit with status code 1 despite it not being a problem.