### PR TITLE
feat: determine CI provider via env var heuristics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 /depot
 
 /CHANGELOG.md
+.vscode

--- a/cmd/depot/main.go
+++ b/cmd/depot/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/depot/cli/internal/build"
 	"github.com/depot/cli/internal/update"
 	"github.com/depot/cli/pkg/api"
+	"github.com/depot/cli/pkg/ci"
 	"github.com/depot/cli/pkg/cmd/root"
 	"github.com/depot/cli/pkg/config"
 	"github.com/getsentry/sentry-go"
@@ -83,13 +84,8 @@ func shouldCheckForUpdate() bool {
 	if os.Getenv("DEPOT_NO_UPDATE_NOTIFIER") != "" {
 		return false
 	}
-	return !isCI() && isTerminal(os.Stdout) && isTerminal(os.Stderr)
-}
-
-func isCI() bool {
-	return os.Getenv("CI") != "" || // GitHub Actions, Travis CI, CircleCI, Cirrus CI, GitLab CI, AppVeyor, CodeShip, dsari
-		os.Getenv("BUILD_NUMBER") != "" || // Jenkins, TeamCity
-		os.Getenv("RUN_ID") != "" // TaskCluster, dsari
+	_, isCI := ci.Provider()
+	return !isCI && isTerminal(os.Stdout) && isTerminal(os.Stderr)
 }
 
 func isTerminal(f *os.File) bool {

--- a/pkg/api/interceptors.go
+++ b/pkg/api/interceptors.go
@@ -4,14 +4,34 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+	"sync"
 
 	"github.com/bufbuild/connect-go"
 	"github.com/depot/cli/internal/build"
+	"github.com/depot/cli/pkg/ci"
 )
 
+var (
+	// execution is the execution environment of the CLI, either "terminal" or "ci".
+	agent      string
+	checkForCI sync.Once
+)
+
+func Agent() string {
+	checkForCI.Do(func() {
+		execution := "terminal"
+		if _, isCI := ci.Provider(); isCI {
+			execution = "ci"
+		}
+
+		agent = fmt.Sprintf("depot-cli/%s/%s/%s/%s", build.Version, runtime.GOOS, runtime.GOARCH, execution)
+	})
+
+	return agent
+}
+
 func WithUserAgent() connect.ClientOption {
-	agent := fmt.Sprintf("depot-cli/%s/%s/%s", build.Version, runtime.GOOS, runtime.GOARCH)
-	return connect.WithInterceptors(&agentInterceptor{agent})
+	return connect.WithInterceptors(&agentInterceptor{Agent()})
 }
 
 type agentInterceptor struct {

--- a/pkg/api/interceptors.go
+++ b/pkg/api/interceptors.go
@@ -17,6 +17,7 @@ var (
 	checkForCI sync.Once
 )
 
+// Returns the user agent string for the CLI.
 func Agent() string {
 	checkForCI.Do(func() {
 		execution := "terminal"

--- a/pkg/api/request.go
+++ b/pkg/api/request.go
@@ -6,10 +6,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"runtime"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/depot/cli/internal/build"
 	"github.com/pkg/errors"
 )
 
@@ -46,8 +44,9 @@ func apiRequest[Response interface{}](method, url, token string, payload interfa
 	if token != "" {
 		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
 	}
-	req.Header.Add("User-Agent", fmt.Sprintf("depot-cli/%s/%s/%s", build.Version, runtime.GOOS, runtime.GOARCH))
-	req.Header.Add("Depot-User-Agent", fmt.Sprintf("depot-cli/%s/%s/%s", build.Version, runtime.GOOS, runtime.GOARCH))
+
+	req.Header.Add("User-Agent", Agent())
+	req.Header.Add("Depot-User-Agent", Agent())
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/pkg/ci/ci.go
+++ b/pkg/ci/ci.go
@@ -1,0 +1,107 @@
+package ci
+
+import (
+	"os"
+	"strings"
+)
+
+// Provider uses environment variables heuristics to determine if running in CI.
+// Inspired by  https://github.com/watson/ci-info/blob/master/vendors.json
+//
+// Returns the name of the CI provider and a boolean indicating if it is a CI environment.
+func Provider() (string, bool) {
+	providers := map[string]string{
+		"AC_APPCIRCLE":                       "Appcircle",
+		"APPVEYOR":                           "AppVeyor",
+		"CODEBUILD_BUILD_ARN":                "AWS CodeBuild",
+		"SYSTEM_TEAMFOUNDATIONCOLLECTIONURI": "Azure Pipelines",
+		"bamboo_planKey":                     "Bamboo",
+		"BITBUCKET_COMMIT":                   "Bitbucket Pipelines",
+		"BITRISE_IO":                         "Bitrise",
+		"BUDDY_WORKSPACE_ID":                 "Buddy",
+		"BUILDKITE":                          "Buildkite",
+		"CIRCLECI":                           "CircleCI",
+		"CIRRUS_CI":                          "Cirrus CI",
+		"CF_BUILD_ID":                        "Codefresh",
+		"CM_BUILD_ID":                        "Codemagic",
+		"DRONE":                              "Drone",
+		"DSARI":                              "dsari",
+		"EAS_BUILD":                          "Expo Application Services",
+		"GERRIT_PROJECT":                     "Gerrit",
+		"GITHUB_ACTIONS":                     "GitHub Actions",
+		"GITLAB_CI":                          "GitLab CI",
+		"GO_PIPELINE_LABEL":                  "GoCD",
+		"BUILDER_OUTPUT":                     "Google Cloud Build",
+		"HARNESS_BUILD_ID":                   "Harness CI",
+		"HUDSON_URL":                         "Hudson",
+		"LAYERCI":                            "LayerCI",
+		"MAGNUM":                             "Magnum CI",
+		"NETLIFY":                            "Netlify",
+		"NEVERCODE":                          "Nevercode",
+		"RELEASEHUB":                         "Release Hub",
+		"RENDER":                             "Render",
+		"SAILCI":                             "Sail CI",
+		"SCREWDRIVER":                        "Screwdriver",
+		"SEMAPHORE":                          "Semaphore",
+		"SHIPPABLE":                          "Shippable",
+		"TDDIUM":                             "Solano",
+		"STRIDER":                            "Strider CI",
+		"TEAMCITY_VERSION":                   "TeamCity",
+		"TRAVIS":                             "Travis CI",
+		"NOW_BUILDER":                        "Vercel",
+		"VERCEL":                             "Vercel",
+		"APPCENTER_BUILD_ID":                 "Visual Studio App Center",
+		"CI_XCODE_PROJECT":                   "Xcode Cloud",
+		"XCS":                                "Xcode Server",
+	}
+
+	env := map[string]string{}
+
+	for _, e := range os.Environ() {
+		pair := strings.SplitN(e, "=", 2)
+		env[(pair[0])] = pair[1]
+	}
+
+	for envKey, provider := range providers {
+		if _, ok := env[envKey]; ok {
+			return provider, true
+		}
+	}
+
+	// Heroku is more complicated. This is what some of the CI detectors are using.
+	if node, ok := env["NODE"]; ok {
+		if strings.Contains(node, "/app/.heroku/node/bin/node") {
+			return "Heroku", true
+		}
+	}
+
+	if ciName, ok := env["CI_NAME"]; ok {
+		switch ciName {
+		case "codeship":
+			return "Codeship", true
+		case "sourcehut":
+			return "SourceHut", true
+		}
+	}
+
+	if ciName, ok := env["CI"]; ok {
+		switch ciName {
+		case "woodpecker":
+			return "Woodpecker", true
+		}
+	}
+
+	if _, ok := env["TASK_ID"]; ok {
+		if _, ok := env["RUN_ID"]; ok {
+			return "TaskCluster", true
+		}
+	}
+
+	if _, ok := env["JENKINS_URL"]; ok {
+		if _, ok := env["BUILD_ID"]; ok {
+			return "Jenkins", true
+		}
+	}
+
+	return "", false
+}

--- a/pkg/ci/ci_test.go
+++ b/pkg/ci/ci_test.go
@@ -1,0 +1,76 @@
+package ci
+
+import (
+	"os"
+	"testing"
+)
+
+func TestProvider(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want bool
+	}{
+		{
+			name: "Check Jenkins",
+			env:  map[string]string{"BUILD_ID": "1", "JENKINS_URL": "1"},
+			want: true,
+		},
+		{
+			name: "Check dsari",
+			env:  map[string]string{"DSARI": "1"},
+			want: true,
+		},
+		{
+			name: "Check GitHub Actions",
+			env:  map[string]string{"GITHUB_ACTIONS": "1"},
+			want: true,
+		},
+		{
+			name: "Check Travis CI",
+			env:  map[string]string{"TRAVIS": "1"},
+			want: true,
+		},
+		{
+			name: "not CI by default",
+			want: false,
+		},
+		{
+			name: "Check codeship",
+			env:  map[string]string{"CI_NAME": "codeship"},
+			want: true,
+		},
+		{
+			name: "Check TaskCluster",
+			env:  map[string]string{"TASK_ID": "1", "RUN_ID": "1"},
+			want: true,
+		},
+		{
+			name: "Heroku is a special case heuristic that checks NODE",
+			env:  map[string]string{"NODE": "/app/.heroku/node/bin/node"},
+			want: true,
+		},
+		{
+			name: "Check sourcehut",
+			env:  map[string]string{"CI_NAME": "sourcehut"},
+			want: true,
+		},
+		{
+			name: "Check Woodpecker",
+			env:  map[string]string{"CI": "woodpecker"},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Clearenv()
+			for k, v := range tt.env {
+				os.Setenv(k, v)
+			}
+
+			if _, got := Provider(); got != tt.want {
+				t.Errorf("IsCI() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We are trying to collect data about using CI or interactive terminal so we know what impacts future local builds will have on developer workflows.

Using environment variable heuristics from watson/ci-info we add "ci" or "terminal" to the user-agent string for outbound API requests.

We can detect the CI provider, so in the future we could also track that information; currently, we do not.