### PR TITLE
Remove `DEPOT_EXPERIMENTAL_OIDC`

### DIFF
--- a/pkg/helpers/token.go
+++ b/pkg/helpers/token.go
@@ -17,7 +17,7 @@ func ResolveToken(ctx context.Context, token string) string {
 		token = config.GetApiToken()
 	}
 
-	if os.Getenv("DEPOT_EXPERIMENTAL_OIDC") != "" && token == "" {
+	if token == "" {
 		for _, provider := range oidc.Providers {
 			token, _ = provider.RetrieveToken(ctx)
 			if token != "" {


### PR DESCRIPTION
We have confirmed this works in Buildkite and GitHub Actions, so it is safe to remove this and attempt an OIDC exchange if no token is passed in.