### PR TITLE
Retry BuildKit inconsistent graph state error

### DIFF
--- a/pkg/buildx/commands/bake.go
+++ b/pkg/buildx/commands/bake.go
@@ -180,6 +180,10 @@ func RunBake(dockerCli command.Cli, targets []string, in BakeOptions) (err error
 	}
 
 	resp, err := build.Build(ctx, builder.ToBuildxNodes(nodes), bo, dockerutil.NewClient(dockerCli), confutil.ConfigDir(dockerCli), printer)
+	if err != nil && shouldRetryError(err) {
+		resp, err = build.Build(ctx, builder.ToBuildxNodes(nodes), bo, dockerutil.NewClient(dockerCli), confutil.ConfigDir(dockerCli), printer)
+	}
+
 	if err != nil {
 		return wrapBuildError(err, true)
 	}


### PR DESCRIPTION
This works around the BuildKit `inconsistent graph state` error by retrying once. Existing build steps should remain cached, so this should resume the build at the point of error.