### PR TITLE
fix(load): have docker publish random port

### DIFF
--- a/pkg/load/proxy.go
+++ b/pkg/load/proxy.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -74,19 +73,4 @@ func RunProxyImage(ctx context.Context, dockerapi docker.APIClient, registryPort
 // Forcefully stops and removes the proxy container.
 func StopProxyContainer(ctx context.Context, dockerapi docker.APIClient, containerID string) error {
 	return dockerapi.ContainerRemove(ctx, containerID, types.ContainerRemoveOptions{Force: true, RemoveVolumes: true})
-}
-
-// GetFreePort asks the kernel for a free open port that is ready to use.
-func GetFreePort() (int, error) {
-	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
-	if err != nil {
-		return 0, err
-	}
-
-	l, err := net.ListenTCP("tcp", addr)
-	if err != nil {
-		return 0, err
-	}
-	defer l.Close()
-	return l.Addr().(*net.TCPAddr).Port, nil
 }

--- a/pkg/load/proxy.go
+++ b/pkg/load/proxy.go
@@ -16,51 +16,59 @@ const ProxyImageName = "ghcr.io/depot/helper:1"
 
 // Runs a proxy container via the docker API so that the docker daemon can pull from the local depot registry.
 // This is specifically to handle docker for desktop running in a VM restricting access to the host network.
-func RunProxyImage(ctx context.Context, dockerapi docker.APIClient, registryPort, proxyPort int) (string, error) {
+func RunProxyImage(ctx context.Context, dockerapi docker.APIClient, registryPort int) (string, string, error) {
 	body, err := dockerapi.ImagePull(ctx, ProxyImageName, types.ImagePullOptions{})
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	defer body.Close()
 	_, err = io.Copy(io.Discard, body)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	resp, err := dockerapi.ContainerCreate(ctx,
 		&container.Config{
 			Image: ProxyImageName,
 			ExposedPorts: nat.PortSet{
-				nat.Port(fmt.Sprintf("%d/tcp", proxyPort)): struct{}{},
+				nat.Port("8888/tcp"): struct{}{},
 			},
 			Cmd: []string{
 				"socat",
-				fmt.Sprintf("TCP-LISTEN:%d,fork", proxyPort),
+				"TCP-LISTEN:8888,fork",
 				fmt.Sprintf("TCP:host.docker.internal:%d", registryPort),
 			},
 		},
 		&container.HostConfig{
-			PortBindings: nat.PortMap{
-				nat.Port(fmt.Sprintf("%d/tcp", proxyPort)): []nat.PortBinding{{HostPort: fmt.Sprintf("%d", proxyPort)}},
-			},
+			PublishAllPorts: true,
 			// This is the trick to make sure that the proxy container can
 			// access the host network in a cross platform way.
 			ExtraHosts: []string{"host.docker.internal:host-gateway"},
 		},
 		nil,
 		nil,
-		fmt.Sprintf("depot-registry-proxy-%d", proxyPort), // unique container name
+		fmt.Sprintf("depot-registry-proxy-%s", RandImageName()), // unique container name
 	)
 
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	if err := dockerapi.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{}); err != nil {
-		return "", err
+		return "", "", err
 	}
 
-	return resp.ID, nil
+	inspect, err := dockerapi.ContainerInspect(ctx, resp.ID)
+	if err != nil {
+		return "", "", err
+	}
+	binds := inspect.NetworkSettings.Ports[nat.Port("8888/tcp")]
+	var proxyPortOnHost string
+	for _, bind := range binds {
+		proxyPortOnHost = bind.HostPort
+	}
+
+	return resp.ID, proxyPortOnHost, nil
 }
 
 // Forcefully stops and removes the proxy container.


### PR DESCRIPTION
Occasionally, the randomly picked port would be rebound. This is a better solution as it has docker and the go network stack pick the random ports.