### PR TITLE
perf: stop server-side build log recording

### DIFF
--- a/pkg/buildx/build/build.go
+++ b/pkg/buildx/build/build.go
@@ -1041,6 +1041,8 @@ func BuildWithResultHandler(ctx context.Context, nodes []builder.Node, opt map[s
 
 					cc := c
 					var printRes map[string][]byte
+					// DEPOT: stop recording the build steps and traces on the server.
+					so.Internal = true
 					rr, err := c.Build(ctx, so, "buildx", func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
 						var isFallback bool
 						var origErr error


### PR DESCRIPTION
On the server-side saving the build log becomes expensive as more builds are cached.

A permanent build log on the server has limited usefulness on depot's ephemeral architecture.
Previously, the server would save an entire copy of the provenance.

The optional provenance stored in the registry is unchanged.