### PR TITLE
fix(load): OCI image requires temporary name for buildkitd

### DIFF
--- a/pkg/load/cli.go
+++ b/pkg/load/cli.go
@@ -98,6 +98,11 @@ func WithDepotImagePull(buildOpts map[string]build.Options, loadOpts DepotLoadOp
 					export.Attrs = map[string]string{}
 				}
 
+				// To export an image via --load the buildkitd logic requires a name.
+				if _, ok := export.Attrs["name"]; !ok {
+					export.Attrs["name"] = defaultImageName(loadOpts, target)
+				}
+
 				export.Attrs["oci-mediatypes"] = "true"
 			}
 			buildOpt.Exports[i] = export

--- a/pkg/load/registry.go
+++ b/pkg/load/registry.go
@@ -121,7 +121,7 @@ func (r *Registry) handleBlobs(resp http.ResponseWriter, req *http.Request) {
 		defer cancel()
 		rc, err := r.Client.Read(childCtx, rr)
 		if err != nil {
-			writeError(resp, http.StatusNotFound, "INTERNAL_SERVER_ERROR", "Unable to read content from registry")
+			writeError(resp, http.StatusInternalServerError, "INTERNAL_SERVER_ERROR", "Unable to read content from registry")
 			return
 		}
 


### PR DESCRIPTION
The internal logic in buildkitd requires a name before it will "unlazy," or download all layers.