### PR TITLE
feat: search for project from specified files or context

### DIFF
--- a/pkg/buildx/commands/bake.go
+++ b/pkg/buildx/commands/bake.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 	"sync"
 
 	"github.com/containerd/containerd/platforms"
@@ -24,7 +23,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/moby/buildkit/util/appcontext"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 )
@@ -255,31 +253,9 @@ func BakeCmd(dockerCli command.Cli) *cobra.Command {
 				return fmt.Errorf("missing API token, please run `depot login`")
 			}
 
-			dirs, err := helpers.WorkingDirectories(options.files)
-			if err != nil {
-				return err
-			}
-
-			// Only a single project ID is allowed.
-			projectIDs := make(map[string]struct{})
-			for _, dir := range dirs {
-				project := helpers.ResolveProjectID(options.project, dir)
-				if project == "" {
-					return errors.Errorf("unknown project ID (run `depot init` or use --project or $DEPOT_PROJECT_ID)")
-				}
-
-				projectIDs[project] = struct{}{}
-			}
-
-			ids := []string{}
-			for id := range projectIDs {
-				ids = append(ids, id)
-				options.project = id
-			}
-
-			// TODO: Warn for multiple project IDs. Is this an error?
-			if len(ids) > 1 {
-				logrus.Warnf("More than one project ID discovered: %s.  Using project: %s", strings.Join(ids, ", "), options.project)
+			options.project = helpers.ResolveProjectID(options.project, options.files...)
+			if options.project == "" {
+				return errors.Errorf("unknown project ID (run `depot init` or use --project or $DEPOT_PROJECT_ID)")
 			}
 
 			buildPlatform, err := helpers.ResolveBuildPlatform(options.buildPlatform)

--- a/pkg/buildx/commands/build.go
+++ b/pkg/buildx/commands/build.go
@@ -516,7 +516,7 @@ func BuildCmd(dockerCli command.Cli) *cobra.Command {
 			if token == "" {
 				return fmt.Errorf("missing API token, please run `depot login`")
 			}
-			options.project = helpers.ResolveProjectID(options.project, args[0])
+			options.project = helpers.ResolveProjectID(options.project, options.contextPath, options.dockerfileName)
 			if options.project == "" {
 				return errors.Errorf("unknown project ID (run `depot init` or use --project or $DEPOT_PROJECT_ID)")
 			}

--- a/pkg/cmd/cache/reset.go
+++ b/pkg/cmd/cache/reset.go
@@ -9,7 +9,7 @@ import (
 	"github.com/bufbuild/connect-go"
 	"github.com/depot/cli/pkg/api"
 	"github.com/depot/cli/pkg/config"
-	"github.com/depot/cli/pkg/project"
+	"github.com/depot/cli/pkg/helpers"
 	cliv1beta1 "github.com/depot/cli/pkg/proto/depot/cli/v1beta1"
 	"github.com/docker/cli/cli"
 	"github.com/pkg/errors"
@@ -25,15 +25,10 @@ func NewCmdResetCache() *cobra.Command {
 		Short: "Reset the cache for a project",
 		Args:  cli.RequiresMaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cwd, _ := filepath.Abs(args[0])
+			projectID := helpers.ResolveProjectID(projectID, cwd)
 			if projectID == "" {
-				projectID = os.Getenv("DEPOT_PROJECT_ID")
-			}
-			if projectID == "" {
-				cwd, _ := filepath.Abs(args[0])
-				config, _, err := project.ReadConfig(cwd)
-				if err == nil {
-					projectID = config.ID
-				}
+				return errors.Errorf("unknown project ID (run `depot init` or use --project or $DEPOT_PROJECT_ID)")
 			}
 			if projectID == "" {
 				return errors.Errorf("unknown project ID (run `depot init` or use --project or $DEPOT_PROJECT_ID)")

--- a/pkg/cmd/list/builds.go
+++ b/pkg/cmd/list/builds.go
@@ -16,7 +16,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/depot/cli/pkg/api"
 	"github.com/depot/cli/pkg/config"
-	"github.com/depot/cli/pkg/project"
+	"github.com/depot/cli/pkg/helpers"
 	cliv1 "github.com/depot/cli/pkg/proto/depot/cli/v1"
 	"github.com/depot/cli/pkg/proto/depot/cli/v1/cliv1connect"
 	"github.com/pkg/errors"
@@ -33,16 +33,8 @@ func NewCmdBuilds() *cobra.Command {
 		Aliases: []string{"b"},
 		Short:   "List builds for a project",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if projectID == "" {
-				projectID = os.Getenv("DEPOT_PROJECT_ID")
-			}
-			if projectID == "" {
-				cwd, _ := os.Getwd()
-				config, _, err := project.ReadConfig(cwd)
-				if err == nil {
-					projectID = config.ID
-				}
-			}
+			cwd, _ := os.Getwd()
+			projectID := helpers.ResolveProjectID(projectID, cwd)
 			if projectID == "" {
 				return errors.Errorf("unknown project ID (run `depot init` or use --project or $DEPOT_PROJECT_ID)")
 			}

--- a/pkg/helpers/project.go
+++ b/pkg/helpers/project.go
@@ -3,23 +3,49 @@ package helpers
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/depot/cli/pkg/project"
+	"github.com/sirupsen/logrus"
 )
 
-func ResolveProjectID(id string, cwd string) string {
+// Returns the project ID from the environment or config file.
+// Searches from the directory of each of the files.
+func ResolveProjectID(id string, files ...string) string {
 	if id != "" {
 		return id
 	}
 
 	id = os.Getenv("DEPOT_PROJECT_ID")
+	if id != "" {
+		return id
+	}
 
-	if id == "" {
-		cwd, _ := filepath.Abs(cwd)
+	dirs, err := WorkingDirectories(files...)
+	if err != nil {
+		return ""
+	}
+
+	// Only a single project ID is allowed.
+	uniqueIDs := make(map[string]struct{})
+
+	for _, dir := range dirs {
+		cwd, _ := filepath.Abs(dir)
 		config, _, err := project.ReadConfig(cwd)
 		if err == nil {
 			id = config.ID
+			uniqueIDs[id] = struct{}{}
 		}
+	}
+
+	// TODO: Warn for multiple project IDs. Is this an error?
+	if len(uniqueIDs) > 1 {
+		ids := []string{}
+		for id := range uniqueIDs {
+			ids = append(ids, id)
+		}
+
+		logrus.Warnf("More than one project ID discovered: %s.  Using project: %s", strings.Join(ids, ", "), id)
 	}
 
 	return id
@@ -28,7 +54,7 @@ func ResolveProjectID(id string, cwd string) string {
 // Returns all directories for any files.  If no files are specified then
 // the current working directory is returned.  Special handling for stdin
 // is also included by assuming the current working directory.
-func WorkingDirectories(files []string) ([]string, error) {
+func WorkingDirectories(files ...string) ([]string, error) {
 	directories := []string{}
 	if len(files) == 0 {
 		cwd, err := os.Getwd()
@@ -39,7 +65,7 @@ func WorkingDirectories(files []string) ([]string, error) {
 	}
 
 	for _, file := range files {
-		if file == "-" {
+		if file == "-" || file == "" {
 			cwd, err := os.Getwd()
 			if err != nil {
 				return nil, err

--- a/pkg/helpers/project.go
+++ b/pkg/helpers/project.go
@@ -24,3 +24,31 @@ func ResolveProjectID(id string, cwd string) string {
 
 	return id
 }
+
+// Returns all directories for any files.  If no files are specified then
+// the current working directory is returned.  Special handling for stdin
+// is also included by assuming the current working directory.
+func WorkingDirectories(files []string) ([]string, error) {
+	directories := []string{}
+	if len(files) == 0 {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return nil, err
+		}
+		directories = append(directories, cwd)
+	}
+
+	for _, file := range files {
+		if file == "-" {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return nil, err
+			}
+			directories = append(directories, cwd)
+			continue
+		}
+		directories = append(directories, filepath.Dir(file))
+	}
+
+	return directories, nil
+}


### PR DESCRIPTION
When there is more than one dockerfile it could get tricky to
specify the location of the depot.json file.

This simplifies the approach by searching for the depot.json
starting from any specified bake or dockerfiles.

Signed-off-by: Chris Goller <goller@gmail.com>