### PR TITLE
perf(load): limit the concurrency of bake image pulls

### DIFF
--- a/pkg/buildx/commands/bake.go
+++ b/pkg/buildx/commands/bake.go
@@ -215,6 +215,8 @@ func RunBake(dockerCli command.Cli, targets []string, in BakeOptions) (err error
 
 	if len(pullOpts) > 0 {
 		eg, ctx2 := errgroup.WithContext(ctx)
+		// Three concurrent pulls at a time to avoid overwhelming the registry.
+		eg.SetLimit(3)
 		for i := range resp {
 			func(i int) {
 				eg.Go(func() error {


### PR DESCRIPTION
In large bake files with many images, the number of layer downloads can be overwhelming.

This restricts to run three concurrent pull requests. By default dockerd restricts the number of concurrent layers to download to three.  Thus, nine is our max number of concurrent layer downloads .