### PR TITLE
fix(load): use manifest and config from build response

### DIFF
--- a/pkg/buildx/commands/build.go
+++ b/pkg/buildx/commands/build.go
@@ -815,6 +815,19 @@ func decodeExporterResponse(exporterResponse map[string]string) map[string]inter
 			out[k] = v
 			continue
 		}
+		// DEPOT: Remove the depot specific keys.
+		// We use these for fast load and the format is not compatible with the OCI spec.
+		if k == exptypes.ExporterImageDescriptorKey {
+			if anno, ok := raw["annotations"]; ok {
+				if anno, ok := anno.(map[string]interface{}); ok {
+					delete(anno, "depot.containerimage.index")
+					delete(anno, "depot.containerimage.config")
+					delete(anno, "depot.containerimage.manifest")
+					out[k] = raw
+					continue
+				}
+			}
+		}
 		out[k] = json.RawMessage(dt)
 	}
 	return out


### PR DESCRIPTION
Image manifests and configs had a chance of being garbage collected by buildkit before they could be downloaded.  This race-condition could cause load errors.

We've changed buildkit's solve to return the manifests and configs and there should no longer be any race conditions.