### PR TITLE
feat(load): use docker attach to proxy docker pull 

### DIFF
--- a/pkg/buildx/commands/bake.go
+++ b/pkg/buildx/commands/bake.go
@@ -239,7 +239,8 @@ func RunBake(dockerCli command.Cli, targets []string, in BakeOptions) (err error
 			}(i)
 		}
 
-		if err := eg.Wait(); err != nil {
+		err := eg.Wait()
+		if err != nil && !errors.Is(err, context.Canceled) {
 			// For now, we will fallback by rebuilding with load.
 			if in.exportLoad {
 				progress.Write(printer, "[load] fast load failed; retrying", func() error { return err })

--- a/pkg/buildx/commands/build.go
+++ b/pkg/buildx/commands/build.go
@@ -403,7 +403,7 @@ func buildTargets(ctx context.Context, dockerCli command.Cli, nodes []builder.No
 
 	// NOTE: the err is returned at the end of this function after the final prints.
 	err = load.DepotFastLoad(ctx, dockerCli.Client(), resp, pullOpts, printer)
-	if err != nil {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		// For now, we will fallback by rebuilding with load.
 		if exportLoad {
 			// We can only retry if neither the context nor dockerfile are stdin.

--- a/pkg/load/image.go
+++ b/pkg/load/image.go
@@ -1,0 +1,22 @@
+package load
+
+import (
+	"math/rand"
+	"time"
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+// During a download of an image we temporarily store the image with this
+// random name to avoid conflicts with any other images.
+func RandImageName() string {
+	const letterBytes = "abcdefghijklmnopqrstuvwxyz"
+	name := make([]byte, 10)
+	for i := range name {
+		name[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+
+	return string(name)
+}

--- a/pkg/load/proxy.go
+++ b/pkg/load/proxy.go
@@ -2,8 +2,10 @@ package load
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io"
+	"net"
 	"sync"
 
 	"github.com/docker/docker/api/types"
@@ -13,13 +15,19 @@ import (
 	"github.com/docker/go-connections/nat"
 )
 
-const DefaultProxyImageName = "ghcr.io/depot/helper:1"
+const DefaultProxyImageName = "goller/proxy:v1"
+
+type ProxyContainer struct {
+	ID   string
+	Port string
+	Conn net.Conn
+}
 
 // Runs a proxy container via the docker API so that the docker daemon can pull from the local depot registry.
 // This is specifically to handle docker for desktop running in a VM restricting access to the host network.
-func RunProxyImage(ctx context.Context, dockerapi docker.APIClient, proxyImage string, registryPort int) (string, string, error) {
+func RunProxyImage(ctx context.Context, dockerapi docker.APIClient, proxyImage string, rawManifest, rawConfig []byte) (*ProxyContainer, error) {
 	if err := PullProxyImage(ctx, dockerapi, proxyImage); err != nil {
-		return "", "", err
+		return nil, err
 	}
 
 	resp, err := dockerapi.ContainerCreate(ctx,
@@ -28,11 +36,15 @@ func RunProxyImage(ctx context.Context, dockerapi docker.APIClient, proxyImage s
 			ExposedPorts: nat.PortSet{
 				nat.Port("8888/tcp"): struct{}{},
 			},
-			Cmd: []string{
-				"socat",
-				"TCP-LISTEN:8888,fork",
-				fmt.Sprintf("TCP:host.docker.internal:%d", registryPort),
+			AttachStdin:  true,
+			AttachStdout: true,
+			OpenStdin:    true,
+			StdinOnce:    true,
+			Env: []string{
+				fmt.Sprintf("MANIFEST=%s", base64.StdEncoding.EncodeToString(rawManifest)),
+				fmt.Sprintf("CONFIG=%s", base64.StdEncoding.EncodeToString(rawConfig)),
 			},
+			Cmd: []string{"/srv/helper"},
 		},
 		&container.HostConfig{
 			PublishAllPorts: true,
@@ -46,16 +58,16 @@ func RunProxyImage(ctx context.Context, dockerapi docker.APIClient, proxyImage s
 	)
 
 	if err != nil {
-		return "", "", err
+		return nil, err
 	}
 
 	if err := dockerapi.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{}); err != nil {
-		return "", "", err
+		return nil, err
 	}
 
 	inspect, err := dockerapi.ContainerInspect(ctx, resp.ID)
 	if err != nil {
-		return "", "", err
+		return nil, err
 	}
 	binds := inspect.NetworkSettings.Ports[nat.Port("8888/tcp")]
 	var proxyPortOnHost string
@@ -63,7 +75,17 @@ func RunProxyImage(ctx context.Context, dockerapi docker.APIClient, proxyImage s
 		proxyPortOnHost = bind.HostPort
 	}
 
-	return resp.ID, proxyPortOnHost, nil
+	attach, err := dockerapi.ContainerAttach(ctx, resp.ID, types.ContainerAttachOptions{Stdin: true, Stdout: true, Logs: true, Stream: true})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &ProxyContainer{
+		ID:   resp.ID,
+		Port: proxyPortOnHost,
+		Conn: attach.Conn,
+	}, nil
 }
 
 var (
@@ -71,7 +93,7 @@ var (
 	downloadProxyImageErr error
 )
 
-// PullProxyImage will pull the socat proxy image into docker.
+// PullProxyImage will pull the proxy image into docker.
 // This is done once per process as a performance optimization.
 // Additionally, if the proxy image is already present, this will not pull the image.
 func PullProxyImage(ctx context.Context, dockerapi docker.APIClient, imageName string) error {

--- a/pkg/load/proxy.go
+++ b/pkg/load/proxy.go
@@ -15,7 +15,7 @@ import (
 	"github.com/docker/go-connections/nat"
 )
 
-const DefaultProxyImageName = "goller/proxy:v1"
+const DefaultProxyImageName = "ghcr.io/depot/helper:2.0.0"
 
 type ProxyContainer struct {
 	ID   string

--- a/pkg/load/pull.go
+++ b/pkg/load/pull.go
@@ -57,7 +57,7 @@ func ImagePullPrivileged(ctx context.Context, dockerapi docker.APIClient, imageN
 	return nil
 }
 
-func printPull(ctx context.Context, rc io.ReadCloser, l progress.SubLogger) error {
+func printPull(ctx context.Context, rc io.Reader, l progress.SubLogger) error {
 	started := map[string]*client.VertexStatus{}
 
 	defer func() {

--- a/pkg/load/transport.go
+++ b/pkg/load/transport.go
@@ -1,0 +1,304 @@
+package load
+
+import (
+	"bufio"
+	"context"
+	"encoding/binary"
+	"io"
+	"net"
+	"sync"
+
+	contentapi "github.com/containerd/containerd/api/services/content/v1"
+	"github.com/opencontainers/go-digest"
+)
+
+type Transport struct {
+	conn net.Conn
+
+	closed chan struct{}
+	write  chan WriteReq
+	read   chan *Packet
+}
+
+func NewTransport(c net.Conn) *Transport {
+	t := &Transport{
+		conn:   c,
+		closed: make(chan struct{}),
+		write:  make(chan WriteReq, 16),
+		read:   make(chan *Packet, 128),
+	}
+
+	return t
+}
+
+func (t *Transport) Run(ctx context.Context, client contentapi.ContentClient) error {
+	wg := sync.WaitGroup{}
+	defer wg.Wait()
+
+	// Serialize writes to the transport.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case req, ok := <-t.write:
+				if !ok {
+					return
+				}
+				n, err := req.packet.Write(t.conn)
+				req.recv <- WriteRes{n: n, err: err}
+				close(req.recv)
+			case <-t.closed:
+				return
+			}
+		}
+	}()
+
+	// Deserialize reads from the transport.
+	// In a separate goroutine because its read loop is blocking.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer close(t.read)
+
+		r := NewAttachReader(t.conn)
+		for {
+			packet, err := ReadPacket(r)
+			if err != nil {
+				return
+			}
+
+			select {
+			case t.read <- packet:
+			case <-t.closed:
+				return
+			}
+		}
+	}()
+
+	// For each read request in the stream, start a goroutine to read
+	// from the content store and write blob to the serialized transport channel.
+	for {
+		select {
+		case <-ctx.Done():
+			return t.close()
+		case packet, ok := <-t.read:
+			if !ok {
+				return t.close()
+			}
+
+			id, dgst, err := packet.BlobRequest()
+			if err != nil {
+				_, _ = t.Write(ctx, Error(id, 400))
+				continue
+			}
+
+			wg.Add(1)
+			go func(id ID, dgst digest.Digest, client contentapi.ContentClient) {
+				defer wg.Done()
+
+				rr := &contentapi.ReadContentRequest{
+					Digest: dgst,
+				}
+				ctx, cancel := context.WithCancel(ctx)
+				defer cancel()
+
+				rc, err := client.Read(ctx, rr)
+				if err != nil {
+					_, _ = t.Write(ctx, Error(id, 404))
+					return
+				}
+
+				for {
+					res, err := rc.Recv()
+					if err == io.EOF {
+						break
+					}
+					if err != nil {
+						_, _ = t.Write(ctx, Error(id, 404))
+						return
+					}
+					_, err = t.Write(ctx, BlobChunk(id, res.Data))
+					if err != nil {
+						return
+					}
+				}
+
+				_, _ = t.Write(ctx, EOF(id))
+			}(id, dgst, client)
+		}
+	}
+}
+
+type WriteReq struct {
+	packet *Packet
+	recv   chan WriteRes
+}
+
+type WriteRes struct {
+	n   int
+	err error
+}
+
+func (t *Transport) Write(ctx context.Context, packet *Packet) (int, error) {
+	// Single element channel to avoid blocking the writer.
+	// We use this "return" channel so we can also watch for closed and timeouts.
+	recv := make(chan WriteRes, 1)
+	select {
+	case t.write <- WriteReq{packet: packet, recv: recv}:
+	case <-t.closed:
+		return 0, io.EOF
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	}
+
+	select {
+	case res, ok := <-recv:
+		if !ok {
+			return 0, io.EOF
+		}
+		return res.n, res.err
+	case <-t.closed:
+		return 0, io.EOF
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	}
+}
+
+func (t *Transport) close() error {
+	close(t.closed)
+	err := t.conn.Close()
+	return err
+}
+
+// AttachReader is able to remove the docker framing from a docker attach stream.
+type AttachReader struct {
+	reader *bufio.Reader
+	extra  []byte
+}
+
+func NewAttachReader(c net.Conn) *AttachReader {
+	return &AttachReader{
+		reader: bufio.NewReader(c),
+	}
+}
+
+func (r *AttachReader) Read(bs []byte) (int, error) {
+	// Parse docker encapsulated header.
+	if len(r.extra) == 0 {
+		bs := make([]byte, 8)
+		_, err := io.ReadFull(r.reader, bs)
+		if err != nil {
+			return 0, err
+		}
+		len := binary.BigEndian.Uint32(bs[4:8])
+		isStderr := bs[0] == 2
+		if isStderr {
+			bs = make([]byte, len)
+			_, err := io.ReadFull(r.reader, bs)
+			if err != nil {
+				return 0, err
+			}
+			return 0, nil
+		} else {
+			r.extra = make([]byte, len)
+			_, err = io.ReadFull(r.reader, r.extra)
+			if err != nil {
+				return 0, err
+			}
+		}
+	}
+
+	n := copy(bs, r.extra)
+	r.extra = r.extra[n:]
+	return n, nil
+}
+
+// ReadPacket decodes a packet from the reader.
+// If no more to read then will return io.EOF as error.
+func ReadPacket(r io.Reader) (*Packet, error) {
+	bs := make([]byte, 6)
+	_, err := io.ReadFull(r, bs)
+	if err != nil {
+		return nil, err
+	}
+
+	id := binary.BigEndian.Uint16(bs[0:2])
+	len := int32(binary.BigEndian.Uint32(bs[2:6]))
+	packet := &Packet{
+		ID:  ID(id),
+		Len: len,
+	}
+
+	if len > 0 {
+		bs = make([]byte, len)
+		_, err = io.ReadFull(r, bs)
+		if err != nil {
+			return nil, err
+		}
+		packet.Data = bs
+	}
+
+	return packet, nil
+}
+
+type ID uint16
+
+type Packet struct {
+	ID   ID
+	Len  int32 // sign bit is used to indicate success or error.
+	Data []byte
+}
+
+func (p *Packet) IsError() bool {
+	return p.Len < 0
+}
+
+func (p *Packet) ErrorStatus() int {
+	return int(-1 * p.Len)
+}
+
+func (p *Packet) BlobRequest() (id ID, d digest.Digest, err error) {
+	id = p.ID
+	d, err = digest.Parse(string(p.Data))
+	return
+}
+
+func (p *Packet) Write(w io.Writer) (int, error) {
+	bs := make([]byte, 6)
+	binary.BigEndian.PutUint16(bs[0:2], uint16(p.ID))
+	binary.BigEndian.PutUint32(bs[2:6], uint32(p.Len))
+
+	_, err := w.Write(bs)
+	if err != nil {
+		return 0, err
+	}
+
+	if p.Len > 0 {
+		return w.Write(p.Data)
+	}
+
+	return 0, nil
+}
+
+func BlobChunk(id ID, data []byte) *Packet {
+	return &Packet{
+		ID:   id,
+		Len:  int32(len(data)),
+		Data: data,
+	}
+}
+
+func EOF(id ID) *Packet {
+	return &Packet{
+		ID:  id,
+		Len: 0,
+	}
+}
+
+func Error(id ID, httpStatus int) *Packet {
+	return &Packet{
+		ID:  id,
+		Len: -1 * int32(httpStatus),
+	}
+}


### PR DESCRIPTION
When the docker daemon was remote, it could not always
reach the depot CLI registry.

In some environments like CircleCI the communication to a running
container was limited to just the docker API.

Docker attach provides a TCP connection that proxies a container's
STDIN and STDOUT.

This uses a serialized, framed packet format to receive blob requests
from the remote container's STDOUT and send blob responses to the
container's STDIN.

The protocol is binary and requires TTY to not be "true."

The framing protocol consists of a session id, data length, and data.

Regarding performance, it seems similar as before; sometimes slower
and sometimes faster.

Signed-off-by: Chris Goller <goller@gmail.com>