### PR TITLE
Rewrite exclude-patterns header to mention .dockerignore

### DIFF
--- a/pkg/buildx/commands/bake.go
+++ b/pkg/buildx/commands/bake.go
@@ -309,7 +309,7 @@ func BakeCmd(dockerCli command.Cli) *cobra.Command {
 			buildErr = retryRetryableErrors(context.Background(), func() error {
 				return RunBake(dockerCli, args, options)
 			})
-			return buildErr
+			return rewriteFriendlyErrors(buildErr)
 		},
 	}
 

--- a/pkg/buildx/commands/build.go
+++ b/pkg/buildx/commands/build.go
@@ -581,7 +581,7 @@ func BuildCmd(dockerCli command.Cli) *cobra.Command {
 			buildErr = retryRetryableErrors(context.Background(), func() error {
 				return runBuild(dockerCli, options)
 			})
-			return buildErr
+			return rewriteFriendlyErrors(buildErr)
 		},
 	}
 
@@ -919,6 +919,16 @@ func shouldRetryError(err error) bool {
 	}
 
 	return false
+}
+
+func rewriteFriendlyErrors(err error) error {
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(err.Error(), "header key \"exclude-patterns\" contains value with non-printable ASCII characters") {
+		return errors.New(err.Error() + ". Please check your .dockerignore file for invalid characters.")
+	}
+	return err
 }
 
 func isExperimental() bool {


### PR DESCRIPTION
The previous error is confusing, this updates it to mention that the cause is a `.dockerignore` file with invalid characters.