### PR TITLE
feat: add manifest to metadata-file output

### DIFF
--- a/pkg/buildx/build/build.go
+++ b/pkg/buildx/build/build.go
@@ -736,19 +736,6 @@ func Invoke(ctx context.Context, cfg ContainerConfig) error {
 	return err
 }
 
-// DEPOT: Replaces the docker map[string]*client.SolveResponse by returning each
-// node and their response.  This is useful to have the the information needed
-// to appropriately load the image into the docker daemon.
-type DepotBuildResponse struct {
-	Name          string // For bake this is the target name and for a single build it is "default".
-	NodeResponses []DepotNodeResponse
-}
-
-type DepotNodeResponse struct {
-	Node          builder.Node
-	SolveResponse *client.SolveResponse
-}
-
 func Build(ctx context.Context, nodes []builder.Node, opt map[string]Options, docker *dockerutil.Client, configDir string, w progress.Writer) (resp []DepotBuildResponse, err error) {
 	return BuildWithResultHandler(ctx, nodes, opt, docker, configDir, w, nil, false)
 }
@@ -1026,10 +1013,7 @@ func BuildWithResultHandler(ctx context.Context, nodes []builder.Node, opt map[s
 					if err != nil {
 						return err
 					}
-					res[i] = DepotNodeResponse{
-						Node:          nodes[dp.driverIndex],
-						SolveResponse: rr,
-					}
+					res[i] = NewDepotNodeResponse(nodes[dp.driverIndex], rr)
 
 					if rr.ExporterResponse == nil {
 						rr.ExporterResponse = map[string]string{}

--- a/pkg/buildx/commands/bake.go
+++ b/pkg/buildx/commands/bake.go
@@ -23,6 +23,7 @@ import (
 	"github.com/docker/buildx/util/progress"
 	"github.com/docker/buildx/util/tracing"
 	"github.com/docker/cli/cli/command"
+	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/util/appcontext"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -217,6 +218,12 @@ func RunBake(dockerCli command.Cli, targets []string, in BakeOptions) (err error
 				nodeMetadata := decodeExporterResponse(nodeRes.SolveResponse.ExporterResponse)
 				for k, v := range nodeMetadata {
 					metadata[k] = v
+				}
+
+				if len(nodeRes.ManifestConfigs) > 0 {
+					metadata[exptypes.ExporterImageDescriptorKey] = nodeRes.ManifestConfigs[0].Desc
+					metadata[exptypes.ExporterImageConfigKey] = nodeRes.ManifestConfigs[0].ImageConfig
+					metadata["containerimage.manifest"] = nodeRes.ManifestConfigs[0].Manifest
 				}
 			}
 			dt[buildRes.Name] = metadata

--- a/pkg/buildx/commands/build.go
+++ b/pkg/buildx/commands/build.go
@@ -386,6 +386,12 @@ func buildTargets(ctx context.Context, dockerCli command.Cli, nodes []builder.No
 				for k, v := range nodeMetadata {
 					metadata[k] = v
 				}
+
+				if len(nodeRes.ManifestConfigs) > 0 {
+					metadata[exptypes.ExporterImageDescriptorKey] = nodeRes.ManifestConfigs[0].Desc
+					metadata[exptypes.ExporterImageConfigKey] = nodeRes.ManifestConfigs[0].ImageConfig
+					metadata["containerimage.manifest"] = nodeRes.ManifestConfigs[0].Manifest
+				}
 			}
 
 			if err := writeMetadataFile(metadataFile, metadata); err != nil {
@@ -833,15 +839,7 @@ func decodeExporterResponse(exporterResponse map[string]string) map[string]inter
 		// DEPOT: Remove the depot specific keys.
 		// We use these for fast load and the format is not compatible with the OCI spec.
 		if k == exptypes.ExporterImageDescriptorKey {
-			if anno, ok := raw["annotations"]; ok {
-				if anno, ok := anno.(map[string]interface{}); ok {
-					delete(anno, "depot.containerimage.index")
-					delete(anno, "depot.containerimage.config")
-					delete(anno, "depot.containerimage.manifest")
-					out[k] = raw
-					continue
-				}
-			}
+			continue
 		}
 		out[k] = json.RawMessage(dt)
 	}


### PR DESCRIPTION
In order to alert CI pipelines to a large increase in layer size the image manifest is attached to the metadata-file.

This assumes that an image has been created.

There are some bugs in buildx bake's manifest with multi-platforms; specifically, the format does not really support multi-platform, but has suffixes for JSON keys for a few blessed fields.