### PR TITLE
fix: panic error on empty args when using depot cache reset command

### DIFF
--- a/pkg/cmd/cache/reset.go
+++ b/pkg/cmd/cache/reset.go
@@ -25,11 +25,11 @@ func NewCmdResetCache() *cobra.Command {
 		Short: "Reset the cache for a project",
 		Args:  cli.RequiresMaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cwd, _ := filepath.Abs(args[0])
-			projectID := helpers.ResolveProjectID(projectID, cwd)
-			if projectID == "" {
-				return errors.Errorf("unknown project ID (run `depot init` or use --project or $DEPOT_PROJECT_ID)")
+			var cwd string
+			if len(args) > 0 {
+				cwd, _ = filepath.Abs(args[0])
 			}
+			projectID := helpers.ResolveProjectID(projectID, cwd)
 			if projectID == "" {
 				return errors.Errorf("unknown project ID (run `depot init` or use --project or $DEPOT_PROJECT_ID)")
 			}


### PR DESCRIPTION
This PR contains two changes that affect the `pkg/cmd/cache` package:

1. remove duplicate `if projectID == ""` statement. for some reason there are two of it.

2. fix a panic error that occurs if the `depot cache reset` command executed **without arguments**. please see attached image for more details

![Screenshot_9](https://github.com/depot/cli/assets/982868/6aa04e65-7e75-427f-8604-7e8e60a94ad4)
