### PR TITLE
feat(lint): report failing linter issues to API

### DIFF
--- a/pkg/buildx/commands/bake.go
+++ b/pkg/buildx/commands/bake.go
@@ -57,7 +57,11 @@ func RunBake(dockerCli command.Cli, in BakeOptions, validator BakeValidator) (er
 	}
 
 	defer func() {
-		if printer != nil {
+		// There is extra logic far below that will also do a printer.Wait()
+		// if there are no errors.  We want to control when the buildx printer
+		// finishes writing so that we can write our own information such as
+		// linting without it being interleaved.
+		if printer != nil && err != nil {
 			err1 := printer.Wait()
 			if err == nil && !errors.Is(err1, context.Canceled) {
 				err = err1
@@ -184,6 +188,7 @@ func RunBake(dockerCli command.Cli, in BakeOptions, validator BakeValidator) (er
 		}
 	}
 
+	_ = printer.Wait()
 	linter.Print(os.Stderr, in.progress)
 	return nil
 }


### PR DESCRIPTION
Linting issues that would fail the build was not previously reported.

One reason was that the terminal UX of vertex errors and status would print duplicate information.  This has been worked around with a new specialized printing function int he depot progress.

It'll end up looking something like this:
<img width="921" alt="image" src="https://github.com/depot/cli/assets/1922921/814c3813-8013-4f8d-85ff-0f2697176599">
