### PR TITLE
fix: report build context only for unreported content

### DIFF
--- a/pkg/dockerfile/upload.go
+++ b/pkg/dockerfile/upload.go
@@ -135,6 +135,10 @@ func (u *Uploader) ReportDockerfiles(ctx context.Context, dockerUploads []*Docke
 		})
 	}
 
+	if len(files) == 0 {
+		return
+	}
+
 	req := &cliv1.ReportBuildContextRequest{
 		BuildId:     u.buildID,
 		Dockerfiles: files,


### PR DESCRIPTION
We saw significant traffic build context gRPC calls despite already reporting all content.  The calls contained empty bodies.

This now checks if there are any files to report before sending the request to the API.