### PR TITLE
refactor(load): use manifests and configs from solve response

### DIFF
--- a/pkg/load/cli.go
+++ b/pkg/load/cli.go
@@ -108,6 +108,7 @@ func WithDepotImagePull(buildOpts map[string]build.Options, loadOpts DepotLoadOp
 
 				export.Attrs["oci-mediatypes"] = "true"
 				export.Attrs["depot.export.lease"] = "true"
+				export.Attrs["depot.export.image.version"] = "2"
 			}
 			buildOpt.Exports[i] = export
 		}


### PR DESCRIPTION
Previously, manifests and configs were sent as annotations on the image index. This caused failures when pushing to GCR and oci-mediatypes was false.

Now a new export image option, `depot.export.image.version` has been added causing the builder service to return the manifests and configs in the solve response at the key `depot.export.image.version`.

This is backwards compatible for older builder services.