### PR TITLE
fix(load): default to depot manifest responses

### DIFF
--- a/pkg/buildx/commands/bake.go
+++ b/pkg/buildx/commands/bake.go
@@ -311,6 +311,7 @@ func overrides(in BakeOptions) []string {
 	overrides := in.overrides
 	if in.exportPush {
 		overrides = append(overrides, "*.push=true")
+		overrides = append(overrides, "*.output=type=image,depot.export.image.version=2")
 	}
 
 	if in.noCache != nil {

--- a/pkg/buildx/commands/build.go
+++ b/pkg/buildx/commands/build.go
@@ -532,13 +532,15 @@ func validateBuildOptions(in *buildOptions) (map[string]build.Options, error) {
 			outputs = []client.ExportEntry{{
 				Type: "image",
 				Attrs: map[string]string{
-					"push": "true",
+					"push":                       "true",
+					"depot.export.image.version": "2",
 				},
 			}}
 		} else {
 			switch outputs[0].Type {
 			case "image":
 				outputs[0].Attrs["push"] = "true"
+				outputs[0].Attrs["depot.export.image.version"] = "2"
 			default:
 				return nil, errors.Errorf("push and %q output can't be used together", outputs[0].Type)
 			}


### PR DESCRIPTION
This helps to push multiple platforms to gcr.io.