### PR TITLE
Move `depot.export.image.version` to post-process function

### DIFF
--- a/pkg/buildx/build/depot.go
+++ b/pkg/buildx/build/depot.go
@@ -66,6 +66,12 @@ func BuildxOpts(opts map[string]dockerbuild.Options) map[string]Options {
 				}
 			}
 
+			for _, e := range opt.Exports {
+				if e.Type == "image" {
+					e.Attrs["depot.export.image.version"] = "2"
+				}
+			}
+
 			depotopts[k] = Options{
 				Inputs: Inputs{
 					ContextPath:      opt.Inputs.ContextPath,

--- a/pkg/buildx/commands/bake.go
+++ b/pkg/buildx/commands/bake.go
@@ -137,8 +137,6 @@ func RunBake(dockerCli command.Cli, in BakeOptions, validator BakeValidator) (er
 	dockerConfigDir := confutil.ConfigDir(dockerCli)
 	buildxopts := build.BuildxOpts(buildOpts)
 
-	fmt.Printf("builxopts: %+v\n", buildxopts)
-
 	// "Boot" the depot nodes.
 	_, clients, err := build.ResolveDrivers(ctx, buildxNodes, buildxopts, printer)
 	if err != nil {

--- a/pkg/buildx/commands/bake.go
+++ b/pkg/buildx/commands/bake.go
@@ -137,6 +137,8 @@ func RunBake(dockerCli command.Cli, in BakeOptions, validator BakeValidator) (er
 	dockerConfigDir := confutil.ConfigDir(dockerCli)
 	buildxopts := build.BuildxOpts(buildOpts)
 
+	fmt.Printf("builxopts: %+v\n", buildxopts)
+
 	// "Boot" the depot nodes.
 	_, clients, err := build.ResolveDrivers(ctx, buildxNodes, buildxopts, printer)
 	if err != nil {
@@ -311,7 +313,6 @@ func overrides(in BakeOptions) []string {
 	overrides := in.overrides
 	if in.exportPush {
 		overrides = append(overrides, "*.push=true")
-		overrides = append(overrides, "*.output=type=image,depot.export.image.version=2")
 	}
 
 	if in.noCache != nil {


### PR DESCRIPTION
This fixes `bake --push` randomly not pushing.