### PR TITLE
Use ubuntu-latest-16-cores for release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest-16-cores
     if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev-')
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
To speed up release builds