### PR TITLE
Hide summary link if `DEPOT_NO_SUMMARY_LINK` is present

### DIFF
--- a/pkg/buildx/commands/print.go
+++ b/pkg/buildx/commands/print.go
@@ -92,6 +92,9 @@ func printValue(printer printFunc, version string, format string, res map[string
 }
 
 func PrintBuildURL(buildURL, progress string) {
+	if os.Getenv("DEPOT_NO_SUMMARY_LINK") != "" {
+		return
+	}
 	PrintURLLink(os.Stderr, "\nBuild Summary", buildURL, progress)
 }
 


### PR DESCRIPTION
A different attempt at https://github.com/depot/cli/pull/145. This hides just the link from being printed if this environment variable is set.