### PR TITLE
Fix issue with Docker daemon TLS config

### DIFF
--- a/pkg/docker/dockerclient.go
+++ b/pkg/docker/dockerclient.go
@@ -52,7 +52,7 @@ func NewDockerCLI() (*command.DockerCli, error) {
 		}
 	}
 
-	err = dockerCli.Initialize(cliflags.NewClientOptions())
+	err = dockerCli.Initialize(opts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Apparently I broke this when we upgraded Buildx versions. 🙂 

https://github.com/depot/cli/commit/d923252d9e1b4327d449a9e9d7b1be421987870c#diff-55142015445141572a329dfc967fa11ef225fa05ce94b3788417a46c9a84df4bL55-R55