### PR TITLE
Pin Go to 1.20.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "1.20.5"
           check-latest: true
           cache: true
       - name: Verify dependencies
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "1.20.5"
           check-latest: true
           cache: true
       - uses: goreleaser/goreleaser-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "1.20.5"
           check-latest: true
           cache: true
       - name: Compute tag name


### PR DESCRIPTION
We need to work around a Docker client bug with Go 1.20.6 until https://github.com/moby/moby/pull/45942 is released.