### PR TITLE
Add configure-docker command

### DIFF
--- a/cmd/depot/buildx.go
+++ b/cmd/depot/buildx.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"syscall"
+
+	"github.com/docker/cli/cli/config"
+	"github.com/pkg/errors"
+)
+
+func buildxMain() error {
+	args := os.Args[1:]
+	cmd := ""
+	subcmd := ""
+
+	for _, arg := range args {
+		if !strings.HasPrefix(arg, "-") {
+			if cmd == "" {
+				cmd = arg
+			} else if subcmd == "" {
+				subcmd = arg
+			}
+		}
+	}
+
+	if cmd == "buildx" && subcmd == "build" {
+		return runWithDepot(args)
+	} else {
+		return runWithDocker(args)
+	}
+}
+
+func runWithDepot(args []string) error {
+	binary, err := exec.LookPath("depot")
+	if err != nil {
+		binary, err = os.Executable()
+		if err != nil {
+			return errors.Wrap(err, "could not find depot binary")
+		}
+	}
+	env := os.Environ()
+
+	filteredArgs := []string{}
+	done := false
+	for _, arg := range args {
+		if !done && arg == "buildx" {
+			filteredArgs = append(filteredArgs, "depot")
+			done = true
+		} else {
+			filteredArgs = append(filteredArgs, arg)
+		}
+	}
+
+	return syscall.Exec(binary, append([]string{"depot"}, filteredArgs...), env)
+}
+
+func runWithDocker(args []string) error {
+	original := path.Join(config.Dir(), "cli-plugins", "original-docker-buildx")
+	if _, err := os.Stat(original); err != nil {
+		return errors.Wrap(err, "could not find original docker-buildx plugin")
+	}
+
+	env := os.Environ()
+	return syscall.Exec(original, append([]string{"docker-buildx"}, args...), env)
+}

--- a/cmd/depot/main.go
+++ b/cmd/depot/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/depot/cli/internal/build"
 	"github.com/depot/cli/internal/update"
@@ -20,8 +21,18 @@ import (
 )
 
 func main() {
-	code := runMain()
-	os.Exit(code)
+	binary := os.Args[0]
+
+	if strings.HasSuffix(binary, "-buildx") {
+		err := buildxMain()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	} else {
+		code := runMain()
+		os.Exit(code)
+	}
 }
 
 func runMain() int {

--- a/pkg/cmd/docker/docker.go
+++ b/pkg/cmd/docker/docker.go
@@ -12,6 +12,8 @@ import (
 )
 
 func NewCmdConfigureDocker() *cobra.Command {
+	shimBuildx := false
+
 	cmd := &cobra.Command{
 		Use:   "configure-docker",
 		Short: "Configure Docker to use Depot for builds",
@@ -30,8 +32,10 @@ func NewCmdConfigureDocker() *cobra.Command {
 				return errors.Wrap(err, "could not install depot plugin")
 			}
 
-			if err := installDepotBuildxPlugin(dir, self); err != nil {
-				return errors.Wrap(err, "could not install depot plugin")
+			if shimBuildx {
+				if err := installDepotBuildxPlugin(dir, self); err != nil {
+					return errors.Wrap(err, "could not install depot plugin")
+				}
 			}
 
 			if err := useDepotBuilderAlias(dir); err != nil {
@@ -43,6 +47,9 @@ func NewCmdConfigureDocker() *cobra.Command {
 			return nil
 		},
 	}
+
+	flags := cmd.Flags()
+	flags.BoolVar(&shimBuildx, "shim-buildx", false, "Shim docker buildx build to use Depot")
 
 	return cmd
 }

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -53,7 +53,7 @@ func NewCmdRoot(version, buildDate string) *cobra.Command {
 	cmd.AddCommand(loginCmd.NewCmdLogin())
 	cmd.AddCommand(logout.NewCmdLogout())
 	cmd.AddCommand(versionCmd.NewCmdVersion(version, buildDate))
-	cmd.AddCommand(dockerCmd.NewCmdDocker())
+	cmd.AddCommand(dockerCmd.NewCmdConfigureDocker())
 
 	return cmd
 }


### PR DESCRIPTION
Adds a command that installs Depot as the primary Docker builder. Today that means:

1. Depot is installed as a Docker CLI plugin (`docker depot ...`)
2. The Depot plugin is set as the primary builder (`docker build ...` will call Depot)
3. Optionally, a shim buildx plugin is installed that routes `docker buildx build ...` to Depot

Once we have #148, we can add a "proper" buildx driver.