### PR TITLE
fix(load): tag images when running quiet mode

### DIFF
--- a/pkg/load/pull.go
+++ b/pkg/load/pull.go
@@ -32,7 +32,9 @@ func ImagePullPrivileged(ctx context.Context, dockerapi docker.APIClient, imageN
 
 	if opts.Quiet {
 		_, err := io.Copy(io.Discard, responseBody)
-		return err
+		if err != nil {
+			return err
+		}
 	} else {
 		if err := printPull(ctx, responseBody, logger); err != nil {
 			return err


### PR DESCRIPTION
When running quiet printing mode, the error was
not checked for nil causing the image not not
be tagged correctly.

This bug would have created several spurious images 
that show up with temporary names such as
`localhost:32775/agahmfbenc:manifest`.