### PR TITLE
Fix issue reporting build health

### DIFF
--- a/examples/build/main.go
+++ b/examples/build/main.go
@@ -54,7 +54,7 @@ func main() {
 	defer cancel()
 
 	// 3. Acquire a buildkit machine.
-	var buildkit *machine.Buildkit
+	var buildkit *machine.Machine
 	buildErr = reporter.WithLog("[depot] launching amd64 machine", func() error {
 		buildkit, buildErr = machine.Acquire(ctx, build.ID, build.Token, "amd64")
 		return buildErr

--- a/pkg/buildxdriver/driver.go
+++ b/pkg/buildxdriver/driver.go
@@ -18,7 +18,7 @@ type Driver struct {
 	cfg driver.InitConfig
 
 	factory  driver.Factory
-	buildkit *machine.Buildkit
+	buildkit *machine.Machine
 }
 
 func (d *Driver) Bootstrap(ctx context.Context, reporter progress.Logger) error {


### PR DESCRIPTION
Fixes an issue where the CLI would stop sending health pings to the API, causing builds to be cancelled.