### PR TITLE
feat(sbom): add option to save sboms to directory

### DIFF
--- a/pkg/buildx/commands/bake.go
+++ b/pkg/buildx/commands/bake.go
@@ -15,6 +15,7 @@ import (
 	"github.com/depot/cli/pkg/helpers"
 	"github.com/depot/cli/pkg/load"
 	depotprogress "github.com/depot/cli/pkg/progress"
+	"github.com/depot/cli/pkg/sbom"
 	"github.com/docker/buildx/bake"
 	buildx "github.com/docker/buildx/build"
 	"github.com/docker/buildx/util/buildflags"
@@ -164,6 +165,13 @@ func RunBake(dockerCli command.Cli, in BakeOptions, validator BakeValidator) (er
 			dt[buildRes.Name] = metadata
 		}
 		if err := writeMetadataFile(in.metadataFile, dt); err != nil {
+			return err
+		}
+	}
+
+	if in.sbomDir != "" {
+		err := sbom.Save(in.sbomDir, resp)
+		if err != nil {
 			return err
 		}
 	}

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -1,0 +1,79 @@
+package sbom
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	depotbuild "github.com/depot/cli/pkg/buildx/build"
+)
+
+const SBOMsLabel = "depot/sboms"
+
+type SBOMs map[string][]byte
+
+func Save(outputDir string, resp []depotbuild.DepotBuildResponse) error {
+	err := os.MkdirAll(outputDir, 0750)
+	if err != nil {
+		return err
+	}
+
+	numBuilds := len(resp)
+	for _, buildRes := range resp {
+		buildName := buildRes.Name
+		for _, nodeRes := range buildRes.NodeResponses {
+			sboms, err := DecodeNodeResponses(nodeRes)
+			if err != nil {
+				return err
+			}
+
+			if sboms == nil {
+				continue
+			}
+
+			numPlatforms := len(sboms)
+			for platform, sbom := range sboms {
+				platform = strings.ReplaceAll(platform, "/", "_")
+				var name string
+				if numBuilds == 1 && numPlatforms == 1 {
+					name = "sbom.spdx.json"
+				} else if numBuilds == 1 {
+					name = fmt.Sprintf("%s.spdx.json", platform)
+				} else if numPlatforms == 1 {
+					name = fmt.Sprintf("%s.spdx.json", buildName)
+				} else {
+					name = fmt.Sprintf("%s_%s.spdx.json", buildName, platform)
+				}
+				pathName := path.Join(outputDir, name)
+				err := os.WriteFile(pathName, sbom, 0644)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func DecodeNodeResponses(nodeRes depotbuild.DepotNodeResponse) (SBOMs, error) {
+	sboms := map[string][]byte{}
+	encodedSBOMs, ok := nodeRes.SolveResponse.ExporterResponse[SBOMsLabel]
+	if !ok {
+		return sboms, nil
+	}
+
+	jsonSBOMs, err := base64.StdEncoding.DecodeString(encodedSBOMs)
+	if err != nil {
+		return nil, fmt.Errorf("invalid exported images encoding: %w", err)
+	}
+
+	if err := json.Unmarshal(jsonSBOMs, &sboms); err != nil {
+		return nil, fmt.Errorf("invalid exported images json: %w", err)
+	}
+
+	return sboms, nil
+}


### PR DESCRIPTION
The `--sbom-dir` will allow SBOMs to be saved into a directory.

We can use https://github.com/advanced-security/spdx-dependency-submission-action to upload SBOMs to github.