### PR TITLE
feat(metadata): output manifest, config, sbom in metadata file

### DIFF
--- a/pkg/buildx/commands/build.go
+++ b/pkg/buildx/commands/build.go
@@ -934,6 +934,29 @@ func decodeExporterResponse(exporterResponse map[string]string) map[string]inter
 			out[k] = v
 			continue
 		}
+		if k == load.ImagesExported {
+			_, manifests, imageConfigs, err := load.DecodeExportImages(v)
+			if err != nil {
+				out[k] = v
+			} else {
+				out["manifests"] = manifests
+				out["imageConfigs"] = imageConfigs
+			}
+
+			continue
+		}
+
+		if k == sbom.SBOMsLabel {
+			sboms, err := sbom.DecodeSBOMs(v)
+			if err != nil {
+				out[k] = v
+			} else {
+				out["sboms"] = sboms
+			}
+
+			continue
+		}
+
 		var raw map[string]interface{}
 		if err = json.Unmarshal(dt, &raw); err != nil || len(raw) == 0 {
 			out[k] = v

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -68,6 +68,19 @@ type SBOM struct {
 	Image *ImageSBOM `json:"image"`
 }
 
+// This is a custom marshaler to prevent conversion of JSON statement into base64.
+func (s *SBOM) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Statement json.RawMessage `json:"statement"`
+		Platform  string          `json:"platform"`
+		Image     *ImageSBOM      `json:"image,omitempty"`
+	}{
+		Statement: json.RawMessage(s.Statement),
+		Platform:  s.Platform,
+		Image:     s.Image,
+	})
+}
+
 // ImageSBOM describes an image that is described by an SBOM.
 type ImageSBOM struct {
 	// Name is the image name and tag.


### PR DESCRIPTION
When the image output or sbom is used we now output the manifest, config, and sbom into the metadata file.

I have example output below from running `depot build --output=type=image --metadata-file=metadata.json .`

metadata.json:

```json
{
  "containerimage.buildinfo": {
    "frontend": "dockerfile.v0",
    "attrs": {
      "filename": "Dockerfile",
      "vcs:revision": "70daeb67cf219972a1123cd06d6c943944a3578f-dirty",
      "vcs:source": "git@github.com:goller/nginx-pod-proxy.git"
    },
    "sources": [
      {
        "type": "docker-image",
        "ref": "docker.io/library/ubuntu:18.04",
        "pin": "sha256:152dc042452c496007f07ca9127571cb9c29697f42acbfad72324b2bb2e43c98"
      }
    ]
  },
  "containerimage.descriptor": {
    "mediaType": "application/vnd.oci.image.index.v1+json",
    "digest": "sha256:01654f77f087eb9527f14ec2a96f2ed0dbf438c72405cab8e5cd7ab131580bae",
    "size": 855
  },
  "containerimage.digest": "sha256:01654f77f087eb9527f14ec2a96f2ed0dbf438c72405cab8e5cd7ab131580bae",
  "imageConfigs": [
    {
      "created": "2023-09-23T13:10:23.075142674Z",
      "architecture": "arm64",
      "variant": "v8",
      "os": "linux",
      "config": {
        "Env": [
          "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
        ],
        "Cmd": [
          "/bin/bash"
        ],
        "Labels": {
          "org.opencontainers.image.ref.name": "ubuntu",
          "org.opencontainers.image.version": "18.04"
        }
      },
      "rootfs": {
        "type": "layers",
        "diff_ids": [
          "sha256:c09969dbc5e84ea45848232c61ee613e2283d20a03d72bb98bc819d2fbeb3218",
          "sha256:fc97a110cd508ddd943c7dde17e04ac6dfda6147fd01c6498b3998a18e94768e",
          "sha256:583e7fe3d312f782a00870087c5ca1df66e0bf99180e008be68b8e32ca3fd075"
        ]
      },
      "history": [
        {
          "created": "2023-05-30T09:39:04.161612881Z",
          "created_by": "/bin/sh -c #(nop)  ARG RELEASE",
          "empty_layer": true
        },
        {
          "created": "2023-05-30T09:39:04.331275317Z",
          "created_by": "/bin/sh -c #(nop)  ARG LAUNCHPAD_BUILD_ARCH",
          "empty_layer": true
        },
        {
          "created": "2023-05-30T09:39:04.50735389Z",
          "created_by": "/bin/sh -c #(nop)  LABEL org.opencontainers.image.ref.name=ubuntu",
          "empty_layer": true
        },
        {
          "created": "2023-05-30T09:39:04.680942141Z",
          "created_by": "/bin/sh -c #(nop)  LABEL org.opencontainers.image.version=18.04",
          "empty_layer": true
        },
        {
          "created": "2023-05-30T09:39:09.908769645Z",
          "created_by": "/bin/sh -c #(nop) ADD file:f56078e320535ad36864a2a30efa5b760ae65dd324cea9d75f01388b17e1183c in / "
        },
        {
          "created": "2023-05-30T09:39:10.501607889Z",
          "created_by": "/bin/sh -c #(nop)  CMD [\"/bin/bash\"]",
          "empty_layer": true
        },
        {
          "created": "2023-09-23T13:10:22.868203216Z",
          "created_by": "COPY docker-entry /usr/local/bin/ # buildkit",
          "comment": "buildkit.dockerfile.v0"
        },
        {
          "created": "2023-09-23T13:10:23.075142674Z",
          "created_by": "RUN /bin/sh -c cat /usr/local/bin/docker-entry \u003e /usr/local/bin/howdy # buildkit",
          "comment": "buildkit.dockerfile.v0"
        }
      ]
    }
  ],
  "manifests": [
    {
      "schemaVersion": 2,
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "config": {
        "mediaType": "application/vnd.oci.image.config.v1+json",
        "digest": "sha256:fdb9a193b5de1e35d4dbc2fd8348fbdbc7378a6d1090a8e32a65e79618c63581",
        "size": 1983
      },
      "layers": [
        {
          "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
          "digest": "sha256:064a9bb4736de1b2446f528e4eb37335378392cf9b95043d3e9970e253861702",
          "size": 22713516
        },
        {
          "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
          "digest": "sha256:339cac24087cf932eb049d5bd282a51d08af921b937ddea607c5734bd376ddf9",
          "size": 263
        },
        {
          "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
          "digest": "sha256:67b0744c267235149498b0a7b5f56d8bbbfbb7a6cb26d7b3cbd2ce2d752f509e",
          "size": 253
        }
      ]
    }
  ]
}
```