### PR TITLE
feat: clarify missing file error message

### DIFF
--- a/pkg/buildx/commands/build.go
+++ b/pkg/buildx/commands/build.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -1092,6 +1093,13 @@ func rewriteFriendlyErrors(err error) error {
 	}
 	if strings.Contains(err.Error(), "header key \"exclude-patterns\" contains value with non-printable ASCII characters") {
 		return errors.New(err.Error() + ". Please check your .dockerignore file for invalid characters.")
+	}
+	if strings.Contains(err.Error(), "failed to calculate checksum of ref") {
+		pattern := `failed to solve: failed to compute cache key: failed to calculate checksum of ref [^:]+::[^:]+:`
+		re := regexp.MustCompile(pattern)
+
+		simplified := re.ReplaceAllString(err.Error(), "")
+		return errors.New(simplified + ". Please check if the files exist in the context.")
 	}
 	return err
 }


### PR DESCRIPTION
The error returned from buildkit was confusing.
This simplifies the error message to the useful
details.

Previous:
```
 => ERROR [5/5] COPY howdy /doody                                                                                     0.0s
------
 > [5/5] COPY howdy /doody:
------

Error: failed to solve: failed to compute cache key: failed to calculate checksum of ref vv3yzwr47shug36z88iqkt7yq::l6be4rvphai7t4cl6oyb2j8mu: "/howdy": not found
```

Now:
```
 => ERROR [5/5] COPY howdy /doody                                                                                     0.0s
------
 > [5/5] COPY howdy /doody:
------

Error:  "/howdy": not found. Please check if the files exist in the context.
```