### PR TITLE
Add DEPOT_DISABLE_OTEL env var support

### DIFF
--- a/cmd/depot/main.go
+++ b/cmd/depot/main.go
@@ -25,6 +25,10 @@ import (
 )
 
 func main() {
+	if os.Getenv("DEPOT_DISABLE_OTEL") != "" {
+		helpers.DisableOTEL()
+	}
+
 	binary := os.Args[0]
 	if strings.HasSuffix(binary, "-buildx") {
 		cmd, subcmd := parseCmdSubcmd()

--- a/pkg/helpers/otel.go
+++ b/pkg/helpers/otel.go
@@ -1,0 +1,20 @@
+package helpers
+
+import (
+	"os"
+	"strings"
+)
+
+func DisableOTEL() {
+	vars := os.Environ()
+	for _, env := range vars {
+		parts := strings.Split(env, "=")
+		if len(parts) == 0 {
+			continue
+		}
+
+		if strings.Contains(parts[0], "OTEL") {
+			os.Unsetenv(parts[0])
+		}
+	}
+}


### PR DESCRIPTION
Allows conditionally disabling the OTEL implementation by removing all OTEL env vars if `DEPOT_DISABLE_OTEL` is set.