### PR TITLE
Only override the output format for non terminals when --output isn't specified

### DIFF
--- a/pkg/cmd/list/builds.go
+++ b/pkg/cmd/list/builds.go
@@ -40,7 +40,7 @@ func NewCmdBuilds() *cobra.Command {
 			}
 
 			client := api.NewBuildClient()
-			if !helpers.IsTerminal() {
+			if !helpers.IsTerminal() && outputFormat == "" {
 				outputFormat = "csv"
 			}
 			if outputFormat != "" {

--- a/pkg/cmd/list/projects.go
+++ b/pkg/cmd/list/projects.go
@@ -65,7 +65,7 @@ func NewCmdProjects() *cobra.Command {
 			)
 
 			projectClient := api.NewProjectsClient()
-			if !helpers.IsTerminal() {
+			if !helpers.IsTerminal() && outputFormat == "" {
 				outputFormat = "csv"
 			}
 			if outputFormat != "" {


### PR DESCRIPTION
Addresses https://github.com/depot/cli/pull/232#issuecomment-1862467429.

We are currently overriding the `--output` when specified so if you do something like:

```shell
depot list project --output json | cat
```

You actually get a `csv` out even though you specified `json`.

This PR adds a check to see if `--output` has been specified before overriding it to `csv`.