### PR TITLE
Add support for new bake features (matrix, replace)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,9 @@ require (
 	github.com/erikgeiser/promptkit v0.9.0
 	github.com/getsentry/sentry-go v0.13.0
 	github.com/gogo/protobuf v1.3.2
+	github.com/hashicorp/go-cty-funcs v0.0.0-20200930094925-2721b1e36840
 	github.com/hashicorp/go-version v1.2.0
+	github.com/hashicorp/hcl/v2 v2.8.2
 	github.com/mattn/go-isatty v0.0.19
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b
 	github.com/moby/buildkit v0.11.2
@@ -38,6 +40,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.14.0
 	github.com/stretchr/testify v1.8.4
+	github.com/zclconf/go-cty v1.10.0
 	go.opentelemetry.io/otel/trace v1.20.0
 	go.opentelemetry.io/proto/otlp v0.12.0
 	golang.org/x/exp v0.0.0-20220428152302-39d4317da171
@@ -46,6 +49,7 @@ require (
 	google.golang.org/grpc v1.59.0
 	google.golang.org/protobuf v1.31.0
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -98,9 +102,7 @@ require (
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
-	github.com/hashicorp/go-cty-funcs v0.0.0-20200930094925-2721b1e36840 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
-	github.com/hashicorp/hcl/v2 v2.8.2 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -152,7 +154,6 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
-	github.com/zclconf/go-cty v1.10.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.46.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.46.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.46.0 // indirect
@@ -177,7 +178,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230822172742-b8732ec3820d // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apimachinery v0.25.4 // indirect
 	k8s.io/client-go v0.25.4 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect

--- a/pkg/buildx/bake/bake.go
+++ b/pkg/buildx/bake/bake.go
@@ -636,7 +636,7 @@ var _ hclparser.WithEvalContexts = &Group{}
 var _ hclparser.WithGetName = &Group{}
 
 func (t *Target) normalize() {
-	// t.Attest = removeAttestDupes(t.Attest)
+	t.Attest = removeDupes(t.Attest)
 	t.Tags = removeDupes(t.Tags)
 	t.Secrets = removeDupes(t.Secrets)
 	t.SSH = removeDupes(t.SSH)
@@ -698,7 +698,7 @@ func (t *Target) Merge(t2 *Target) {
 	}
 	if t2.Attest != nil { // merge
 		t.Attest = append(t.Attest, t2.Attest...)
-		// t.Attest = removeAttestDupes(t.Attest)
+		t.Attest = removeDupes(t.Attest)
 	}
 	if t2.Secrets != nil { // merge
 		t.Secrets = append(t.Secrets, t2.Secrets...)

--- a/pkg/buildx/bake/bake.go
+++ b/pkg/buildx/bake/bake.go
@@ -1,0 +1,1101 @@
+package bake
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/depot/cli/pkg/buildx/bake/hclparser"
+	"github.com/docker/buildx/build"
+	"github.com/docker/buildx/util/buildflags"
+	"github.com/docker/buildx/util/platformutil"
+	"github.com/docker/cli/cli/config"
+	"github.com/docker/docker/builder/remotecontext/urlutil"
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/session/auth/authprovider"
+	"github.com/pkg/errors"
+)
+
+var (
+	httpPrefix                   = regexp.MustCompile(`^https?://`)
+	gitURLPathWithFragmentSuffix = regexp.MustCompile(`\.git(?:#.+)?$`)
+
+	validTargetNameChars = `[a-zA-Z0-9_-]+`
+	targetNamePattern    = regexp.MustCompile(`^` + validTargetNameChars + `$`)
+)
+
+type File struct {
+	Name string
+	Data []byte
+}
+
+type Override struct {
+	Value    string
+	ArrValue []string
+}
+
+func defaultFilenames() []string {
+	return []string{
+		"docker-compose.yml",  // support app
+		"docker-compose.yaml", // support app
+		"docker-bake.json",
+		"docker-bake.override.json",
+		"docker-bake.hcl",
+		"docker-bake.override.hcl",
+	}
+}
+
+func ReadLocalFiles(names []string) ([]File, error) {
+	isDefault := false
+	if len(names) == 0 {
+		isDefault = true
+		names = defaultFilenames()
+	}
+	out := make([]File, 0, len(names))
+
+	for _, n := range names {
+		var dt []byte
+		var err error
+		if n == "-" {
+			dt, err = io.ReadAll(os.Stdin)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			dt, err = os.ReadFile(n)
+			if err != nil {
+				if isDefault && errors.Is(err, os.ErrNotExist) {
+					continue
+				}
+				return nil, err
+			}
+		}
+		out = append(out, File{Name: n, Data: dt})
+	}
+	return out, nil
+}
+
+func ReadTargets(ctx context.Context, files []File, targets, overrides []string, defaults map[string]string) (map[string]*Target, map[string]*Group, error) {
+	c, err := ParseFiles(files, defaults)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for i, t := range targets {
+		targets[i] = sanitizeTargetName(t)
+	}
+
+	o, err := c.newOverrides(overrides)
+	if err != nil {
+		return nil, nil, err
+	}
+	m := map[string]*Target{}
+	n := map[string]*Group{}
+	for _, target := range targets {
+		ts, gs := c.ResolveGroup(target)
+		for _, tname := range ts {
+			t, err := c.ResolveTarget(tname, o)
+			if err != nil {
+				return nil, nil, err
+			}
+			if t != nil {
+				m[tname] = t
+			}
+		}
+		for _, gname := range gs {
+			for _, group := range c.Groups {
+				if group.Name == gname {
+					n[gname] = group
+					break
+				}
+			}
+		}
+	}
+
+	for _, target := range targets {
+		if target == "default" {
+			continue
+		}
+		if _, ok := n["default"]; !ok {
+			n["default"] = &Group{Name: "default"}
+		}
+		n["default"].Targets = append(n["default"].Targets, target)
+	}
+	if g, ok := n["default"]; ok {
+		g.Targets = dedupSlice(g.Targets)
+	}
+
+	for name, t := range m {
+		if err := c.loadLinks(name, t, m, o, nil); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	// Propagate SOURCE_DATE_EPOCH from the client env.
+	// The logic is purposely duplicated from `build/build`.go for keeping this visible in `bake --print`.
+	if v := os.Getenv("SOURCE_DATE_EPOCH"); v != "" {
+		for _, f := range m {
+			if f.Args == nil {
+				f.Args = make(map[string]*string)
+			}
+			if _, ok := f.Args["SOURCE_DATE_EPOCH"]; !ok {
+				f.Args["SOURCE_DATE_EPOCH"] = &v
+			}
+		}
+	}
+
+	return m, n, nil
+}
+
+func dedupSlice(s []string) []string {
+	if len(s) == 0 {
+		return s
+	}
+	var res []string
+	seen := make(map[string]struct{})
+	for _, val := range s {
+		if _, ok := seen[val]; !ok {
+			res = append(res, val)
+			seen[val] = struct{}{}
+		}
+	}
+	return res
+}
+
+func dedupMap(ms ...map[string]string) map[string]string {
+	if len(ms) == 0 {
+		return nil
+	}
+	res := map[string]string{}
+	for _, m := range ms {
+		if len(m) == 0 {
+			continue
+		}
+		for k, v := range m {
+			if _, ok := res[k]; !ok {
+				res[k] = v
+			}
+		}
+	}
+	return res
+}
+
+func sliceToMap(env []string) (res map[string]string) {
+	res = make(map[string]string)
+	for _, s := range env {
+		kv := strings.SplitN(s, "=", 2)
+		key := kv[0]
+		switch {
+		case len(kv) == 1:
+			res[key] = ""
+		default:
+			res[key] = kv[1]
+		}
+	}
+	return
+}
+
+func ParseFiles(files []File, defaults map[string]string) (_ *Config, err error) {
+	defer func() {
+		err = formatHCLError(err, files)
+	}()
+
+	var c Config
+	var composeFiles []File
+	var hclFiles []*hcl.File
+	for _, f := range files {
+		isCompose, composeErr := validateComposeFile(f.Data, f.Name)
+		if isCompose {
+			if composeErr != nil {
+				return nil, composeErr
+			}
+			composeFiles = append(composeFiles, f)
+		}
+		if !isCompose {
+			hf, isHCL, err := ParseHCLFile(f.Data, f.Name)
+			if isHCL {
+				if err != nil {
+					return nil, err
+				}
+				hclFiles = append(hclFiles, hf)
+			} else if composeErr != nil {
+				return nil, fmt.Errorf("failed to parse %s: parsing yaml: %v, parsing hcl: %w", f.Name, composeErr, err)
+			} else {
+				return nil, err
+			}
+		}
+	}
+
+	if len(composeFiles) > 0 {
+		cfg, cmperr := ParseComposeFiles(composeFiles)
+		if cmperr != nil {
+			return nil, errors.Wrap(cmperr, "failed to parse compose file")
+		}
+		c = mergeConfig(c, *cfg)
+		c = dedupeConfig(c)
+	}
+
+	if len(hclFiles) > 0 {
+		if err := hclparser.Parse(hcl.MergeFiles(hclFiles), hclparser.Opt{
+			LookupVar:     os.LookupEnv,
+			Vars:          defaults,
+			ValidateLabel: validateTargetName,
+		}, &c); err.HasErrors() {
+			return nil, err
+		}
+	}
+
+	return &c, nil
+}
+
+func dedupeConfig(c Config) Config {
+	c2 := c
+	c2.Groups = make([]*Group, 0, len(c2.Groups))
+	for _, g := range c.Groups {
+		g1 := *g
+		g1.Targets = dedupSlice(g1.Targets)
+		c2.Groups = append(c2.Groups, &g1)
+	}
+	c2.Targets = make([]*Target, 0, len(c2.Targets))
+	mt := map[string]*Target{}
+	for _, t := range c.Targets {
+		if t2, ok := mt[t.Name]; ok {
+			t2.Merge(t)
+		} else {
+			mt[t.Name] = t
+			c2.Targets = append(c2.Targets, t)
+		}
+	}
+	return c2
+}
+
+func ParseFile(dt []byte, fn string) (*Config, error) {
+	return ParseFiles([]File{{Data: dt, Name: fn}}, nil)
+}
+
+type Config struct {
+	Groups  []*Group  `json:"group" hcl:"group,block" cty:"group"`
+	Targets []*Target `json:"target" hcl:"target,block" cty:"target"`
+}
+
+func mergeConfig(c1, c2 Config) Config {
+	if c1.Groups == nil {
+		c1.Groups = []*Group{}
+	}
+
+	for _, g2 := range c2.Groups {
+		var g1 *Group
+		for _, g := range c1.Groups {
+			if g2.Name == g.Name {
+				g1 = g
+				break
+			}
+		}
+		if g1 == nil {
+			c1.Groups = append(c1.Groups, g2)
+			continue
+		}
+
+	nextTarget:
+		for _, t2 := range g2.Targets {
+			for _, t1 := range g1.Targets {
+				if t1 == t2 {
+					continue nextTarget
+				}
+			}
+			g1.Targets = append(g1.Targets, t2)
+		}
+		c1.Groups = append(c1.Groups, g1)
+	}
+
+	if c1.Targets == nil {
+		c1.Targets = []*Target{}
+	}
+
+	for _, t2 := range c2.Targets {
+		var t1 *Target
+		for _, t := range c1.Targets {
+			if t2.Name == t.Name {
+				t1 = t
+				break
+			}
+		}
+		if t1 != nil {
+			t1.Merge(t2)
+			t2 = t1
+		}
+		c1.Targets = append(c1.Targets, t2)
+	}
+
+	return c1
+}
+
+func (c Config) expandTargets(pattern string) ([]string, error) {
+	for _, target := range c.Targets {
+		if target.Name == pattern {
+			return []string{pattern}, nil
+		}
+	}
+
+	var names []string
+	for _, target := range c.Targets {
+		ok, err := path.Match(pattern, target.Name)
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not match targets with '%s'", pattern)
+		}
+		if ok {
+			names = append(names, target.Name)
+		}
+	}
+	if len(names) == 0 {
+		return nil, errors.Errorf("could not find any target matching '%s'", pattern)
+	}
+	return names, nil
+}
+
+func (c Config) loadLinks(name string, t *Target, m map[string]*Target, o map[string]map[string]Override, visited []string) error {
+	visited = append(visited, name)
+	for _, v := range t.Contexts {
+		if strings.HasPrefix(v, "target:") {
+			target := strings.TrimPrefix(v, "target:")
+			if target == t.Name {
+				return errors.Errorf("target %s cannot link to itself", target)
+			}
+			for _, v := range visited {
+				if v == target {
+					return errors.Errorf("infinite loop from %s to %s", name, target)
+				}
+			}
+			t2, ok := m[target]
+			if !ok {
+				var err error
+				t2, err = c.ResolveTarget(target, o)
+				if err != nil {
+					return err
+				}
+				t2.Outputs = nil
+				t2.linked = true
+				m[target] = t2
+			}
+			if err := c.loadLinks(target, t2, m, o, visited); err != nil {
+				return err
+			}
+			if len(t.Platforms) > 1 && len(t2.Platforms) > 1 {
+				if !sliceEqual(t.Platforms, t2.Platforms) {
+					return errors.Errorf("target %s can't be used by %s because it is defined for different platforms %v and %v", target, name, t2.Platforms, t.Platforms)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (c Config) newOverrides(v []string) (map[string]map[string]Override, error) {
+	m := map[string]map[string]Override{}
+	for _, v := range v {
+		parts := strings.SplitN(v, "=", 2)
+		keys := strings.SplitN(parts[0], ".", 3)
+		if len(keys) < 2 {
+			return nil, errors.Errorf("invalid override key %s, expected target.name", parts[0])
+		}
+
+		pattern := keys[0]
+		if len(parts) != 2 && keys[1] != "args" {
+			return nil, errors.Errorf("invalid override %s, expected target.name=value", v)
+		}
+
+		names, err := c.expandTargets(pattern)
+		if err != nil {
+			return nil, err
+		}
+
+		kk := strings.SplitN(parts[0], ".", 2)
+
+		for _, name := range names {
+			t, ok := m[name]
+			if !ok {
+				t = map[string]Override{}
+				m[name] = t
+			}
+
+			o := t[kk[1]]
+
+			switch keys[1] {
+			case "output", "cache-to", "cache-from", "tags", "platform", "secrets", "ssh", "attest":
+				if len(parts) == 2 {
+					o.ArrValue = append(o.ArrValue, parts[1])
+				}
+			case "args":
+				if len(keys) != 3 {
+					return nil, errors.Errorf("invalid key %s, args requires name", parts[0])
+				}
+				if len(parts) < 2 {
+					v, ok := os.LookupEnv(keys[2])
+					if !ok {
+						continue
+					}
+					o.Value = v
+				}
+				fallthrough
+			case "contexts":
+				if len(keys) != 3 {
+					return nil, errors.Errorf("invalid key %s, contexts requires name", parts[0])
+				}
+				fallthrough
+			default:
+				if len(parts) == 2 {
+					o.Value = parts[1]
+				}
+			}
+
+			t[kk[1]] = o
+		}
+	}
+	return m, nil
+}
+
+func (c Config) ResolveGroup(name string) ([]string, []string) {
+	targets, groups := c.group(name, map[string]visit{})
+	return dedupSlice(targets), dedupSlice(groups)
+}
+
+type visit struct {
+	target []string
+	group  []string
+}
+
+func (c Config) group(name string, visited map[string]visit) ([]string, []string) {
+	if v, ok := visited[name]; ok {
+		return v.target, v.group
+	}
+	var g *Group
+	for _, group := range c.Groups {
+		if group.Name == name {
+			g = group
+			break
+		}
+	}
+	if g == nil {
+		return []string{name}, nil
+	}
+	visited[name] = visit{}
+	targets := make([]string, 0, len(g.Targets))
+	groups := []string{name}
+	for _, t := range g.Targets {
+		ttarget, tgroup := c.group(t, visited)
+		if len(ttarget) > 0 {
+			targets = append(targets, ttarget...)
+		} else {
+			targets = append(targets, t)
+		}
+		if len(tgroup) > 0 {
+			groups = append(groups, tgroup...)
+		}
+	}
+	visited[name] = visit{target: targets, group: groups}
+	return targets, groups
+}
+
+func (c Config) ResolveTarget(name string, overrides map[string]map[string]Override) (*Target, error) {
+	t, err := c.target(name, map[string]*Target{}, overrides)
+	if err != nil {
+		return nil, err
+	}
+	t.Inherits = nil
+	if t.Context == nil {
+		s := "."
+		t.Context = &s
+	}
+	if t.Dockerfile == nil {
+		s := "Dockerfile"
+		t.Dockerfile = &s
+	}
+	return t, nil
+}
+
+func (c Config) target(name string, visited map[string]*Target, overrides map[string]map[string]Override) (*Target, error) {
+	if t, ok := visited[name]; ok {
+		return t, nil
+	}
+	visited[name] = nil
+	var t *Target
+	for _, target := range c.Targets {
+		if target.Name == name {
+			t = target
+			break
+		}
+	}
+	if t == nil {
+		return nil, errors.Errorf("failed to find target %s", name)
+	}
+	tt := &Target{}
+	for _, name := range t.Inherits {
+		t, err := c.target(name, visited, overrides)
+		if err != nil {
+			return nil, err
+		}
+		if t != nil {
+			tt.Merge(t)
+		}
+	}
+	m := defaultTarget()
+	m.Merge(tt)
+	m.Merge(t)
+	tt = m
+	if err := tt.AddOverrides(overrides[name]); err != nil {
+		return nil, err
+	}
+	tt.normalize()
+	visited[name] = tt
+	return tt, nil
+}
+
+type Group struct {
+	Name    string   `json:"-" hcl:"name,label" cty:"name"`
+	Targets []string `json:"targets" hcl:"targets" cty:"targets"`
+	// Target // TODO?
+}
+
+type Target struct {
+	Name string `json:"-" hcl:"name,label" cty:"name"`
+
+	// Inherits is the only field that cannot be overridden with --set
+	Attest   []string `json:"attest,omitempty" hcl:"attest,optional" cty:"attest"`
+	Inherits []string `json:"inherits,omitempty" hcl:"inherits,optional" cty:"inherits"`
+
+	Context          *string            `json:"context,omitempty" hcl:"context,optional" cty:"context"`
+	Contexts         map[string]string  `json:"contexts,omitempty" hcl:"contexts,optional" cty:"contexts"`
+	Dockerfile       *string            `json:"dockerfile,omitempty" hcl:"dockerfile,optional" cty:"dockerfile"`
+	DockerfileInline *string            `json:"dockerfile-inline,omitempty" hcl:"dockerfile-inline,optional" cty:"dockerfile-inline"`
+	Args             map[string]*string `json:"args,omitempty" hcl:"args,optional" cty:"args"`
+	Labels           map[string]*string `json:"labels,omitempty" hcl:"labels,optional" cty:"labels"`
+	Tags             []string           `json:"tags,omitempty" hcl:"tags,optional" cty:"tags"`
+	CacheFrom        []string           `json:"cache-from,omitempty"  hcl:"cache-from,optional" cty:"cache-from"`
+	CacheTo          []string           `json:"cache-to,omitempty"  hcl:"cache-to,optional" cty:"cache-to"`
+	Target           *string            `json:"target,omitempty" hcl:"target,optional" cty:"target"`
+	Secrets          []string           `json:"secret,omitempty" hcl:"secret,optional" cty:"secret"`
+	SSH              []string           `json:"ssh,omitempty" hcl:"ssh,optional" cty:"ssh"`
+	Platforms        []string           `json:"platforms,omitempty" hcl:"platforms,optional" cty:"platforms"`
+	Outputs          []string           `json:"output,omitempty" hcl:"output,optional" cty:"output"`
+	Pull             *bool              `json:"pull,omitempty" hcl:"pull,optional" cty:"pull"`
+	NoCache          *bool              `json:"no-cache,omitempty" hcl:"no-cache,optional" cty:"no-cache"`
+	NetworkMode      *string            `json:"-" hcl:"-" cty:"-"`
+	NoCacheFilter    []string           `json:"no-cache-filter,omitempty" hcl:"no-cache-filter,optional" cty:"no-cache-filter"`
+	// IMPORTANT: if you add more fields here, do not forget to update newOverrides and docs/bake-reference.md.
+
+	// linked is a private field to mark a target used as a linked one
+	linked bool
+}
+
+func (t *Target) normalize() {
+	t.Attest = removeDupes(t.Attest)
+	t.Tags = removeDupes(t.Tags)
+	t.Secrets = removeDupes(t.Secrets)
+	t.SSH = removeDupes(t.SSH)
+	t.Platforms = removeDupes(t.Platforms)
+	t.CacheFrom = removeDupes(t.CacheFrom)
+	t.CacheTo = removeDupes(t.CacheTo)
+	t.Outputs = removeDupes(t.Outputs)
+	t.NoCacheFilter = removeDupes(t.NoCacheFilter)
+
+	for k, v := range t.Contexts {
+		if v == "" {
+			delete(t.Contexts, k)
+		}
+	}
+	if len(t.Contexts) == 0 {
+		t.Contexts = nil
+	}
+}
+
+func (t *Target) Merge(t2 *Target) {
+	if t2.Context != nil {
+		t.Context = t2.Context
+	}
+	if t2.Dockerfile != nil {
+		t.Dockerfile = t2.Dockerfile
+	}
+	if t2.DockerfileInline != nil {
+		t.DockerfileInline = t2.DockerfileInline
+	}
+	for k, v := range t2.Args {
+		if v == nil {
+			continue
+		}
+		if t.Args == nil {
+			t.Args = map[string]*string{}
+		}
+		t.Args[k] = v
+	}
+	for k, v := range t2.Contexts {
+		if t.Contexts == nil {
+			t.Contexts = map[string]string{}
+		}
+		t.Contexts[k] = v
+	}
+	for k, v := range t2.Labels {
+		if v == nil {
+			continue
+		}
+		if t.Labels == nil {
+			t.Labels = map[string]*string{}
+		}
+		t.Labels[k] = v
+	}
+	if t2.Tags != nil { // no merge
+		t.Tags = t2.Tags
+	}
+	if t2.Target != nil {
+		t.Target = t2.Target
+	}
+	if t2.Attest != nil { // merge
+		t.Attest = append(t.Attest, t2.Attest...)
+	}
+	if t2.Secrets != nil { // merge
+		t.Secrets = append(t.Secrets, t2.Secrets...)
+	}
+	if t2.SSH != nil { // merge
+		t.SSH = append(t.SSH, t2.SSH...)
+	}
+	if t2.Platforms != nil { // no merge
+		t.Platforms = t2.Platforms
+	}
+	if t2.CacheFrom != nil { // merge
+		t.CacheFrom = append(t.CacheFrom, t2.CacheFrom...)
+	}
+	if t2.CacheTo != nil { // no merge
+		t.CacheTo = t2.CacheTo
+	}
+	if t2.Outputs != nil { // no merge
+		t.Outputs = t2.Outputs
+	}
+	if t2.Pull != nil {
+		t.Pull = t2.Pull
+	}
+	if t2.NoCache != nil {
+		t.NoCache = t2.NoCache
+	}
+	if t2.NetworkMode != nil {
+		t.NetworkMode = t2.NetworkMode
+	}
+	if t2.NoCacheFilter != nil { // merge
+		t.NoCacheFilter = append(t.NoCacheFilter, t2.NoCacheFilter...)
+	}
+	t.Inherits = append(t.Inherits, t2.Inherits...)
+}
+
+func (t *Target) AddOverrides(overrides map[string]Override) error {
+	for key, o := range overrides {
+		value := o.Value
+		keys := strings.SplitN(key, ".", 2)
+		switch keys[0] {
+		case "context":
+			t.Context = &value
+		case "dockerfile":
+			t.Dockerfile = &value
+		case "args":
+			if len(keys) != 2 {
+				return errors.Errorf("args require name")
+			}
+			if t.Args == nil {
+				t.Args = map[string]*string{}
+			}
+			t.Args[keys[1]] = &value
+		case "contexts":
+			if len(keys) != 2 {
+				return errors.Errorf("contexts require name")
+			}
+			if t.Contexts == nil {
+				t.Contexts = map[string]string{}
+			}
+			t.Contexts[keys[1]] = value
+		case "labels":
+			if len(keys) != 2 {
+				return errors.Errorf("labels require name")
+			}
+			if t.Labels == nil {
+				t.Labels = map[string]*string{}
+			}
+			t.Labels[keys[1]] = &value
+		case "tags":
+			t.Tags = o.ArrValue
+		case "cache-from":
+			t.CacheFrom = o.ArrValue
+		case "cache-to":
+			t.CacheTo = o.ArrValue
+		case "target":
+			t.Target = &value
+		case "secrets":
+			t.Secrets = o.ArrValue
+		case "ssh":
+			t.SSH = o.ArrValue
+		case "platform":
+			t.Platforms = o.ArrValue
+		case "output":
+			t.Outputs = o.ArrValue
+		case "attest":
+			t.Attest = append(t.Attest, o.ArrValue...)
+		case "no-cache":
+			noCache, err := strconv.ParseBool(value)
+			if err != nil {
+				return errors.Errorf("invalid value %s for boolean key no-cache", value)
+			}
+			t.NoCache = &noCache
+		case "no-cache-filter":
+			t.NoCacheFilter = o.ArrValue
+		case "pull":
+			pull, err := strconv.ParseBool(value)
+			if err != nil {
+				return errors.Errorf("invalid value %s for boolean key pull", value)
+			}
+			t.Pull = &pull
+		case "push":
+			_, err := strconv.ParseBool(value)
+			if err != nil {
+				return errors.Errorf("invalid value %s for boolean key push", value)
+			}
+			if len(t.Outputs) == 0 {
+				t.Outputs = append(t.Outputs, "type=image,push=true")
+			} else {
+				for i, output := range t.Outputs {
+					if typ := parseOutputType(output); typ == "image" || typ == "registry" {
+						t.Outputs[i] = t.Outputs[i] + ",push=" + value
+					}
+				}
+			}
+		default:
+			return errors.Errorf("unknown key: %s", keys[0])
+		}
+	}
+	return nil
+}
+
+func TargetsToBuildOpt(m map[string]*Target, inp *Input) (map[string]build.Options, error) {
+	m2 := make(map[string]build.Options, len(m))
+	for k, v := range m {
+		bo, err := toBuildOpt(v, inp)
+		if err != nil {
+			return nil, err
+		}
+		m2[k] = *bo
+	}
+	return m2, nil
+}
+
+func updateContext(t *build.Inputs, inp *Input) {
+	if inp == nil || inp.State == nil {
+		return
+	}
+
+	for k, v := range t.NamedContexts {
+		if v.Path == "." {
+			t.NamedContexts[k] = build.NamedContext{Path: inp.URL}
+		}
+		if strings.HasPrefix(v.Path, "cwd://") || strings.HasPrefix(v.Path, "target:") || strings.HasPrefix(v.Path, "docker-image:") {
+			continue
+		}
+		if IsRemoteURL(v.Path) {
+			continue
+		}
+		st := llb.Scratch().File(llb.Copy(*inp.State, v.Path, "/"), llb.WithCustomNamef("set context %s to %s", k, v.Path))
+		t.NamedContexts[k] = build.NamedContext{State: &st}
+	}
+
+	if t.ContextPath == "." {
+		t.ContextPath = inp.URL
+		return
+	}
+	if strings.HasPrefix(t.ContextPath, "cwd://") {
+		return
+	}
+	if IsRemoteURL(t.ContextPath) {
+		return
+	}
+	st := llb.Scratch().File(llb.Copy(*inp.State, t.ContextPath, "/"), llb.WithCustomNamef("set context to %s", t.ContextPath))
+	t.ContextState = &st
+}
+
+// validateContextsEntitlements is a basic check to ensure contexts do not
+// escape local directories when loaded from remote sources. This is to be
+// replaced with proper entitlements support in the future.
+func validateContextsEntitlements(t build.Inputs, inp *Input) error {
+	if inp == nil || inp.State == nil {
+		return nil
+	}
+	if v, ok := os.LookupEnv("BAKE_ALLOW_REMOTE_FS_ACCESS"); ok {
+		if vv, _ := strconv.ParseBool(v); vv {
+			return nil
+		}
+	}
+	if t.ContextState == nil {
+		if err := checkPath(t.ContextPath); err != nil {
+			return err
+		}
+	}
+	for _, v := range t.NamedContexts {
+		if v.State != nil {
+			continue
+		}
+		if err := checkPath(v.Path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func checkPath(p string) error {
+	if IsRemoteURL(p) || strings.HasPrefix(p, "target:") || strings.HasPrefix(p, "docker-image:") {
+		return nil
+	}
+	p, err := filepath.EvalSymlinks(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	rel, err := filepath.Rel(wd, p)
+	if err != nil {
+		return err
+	}
+	if strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return errors.Errorf("path %s is outside of the working directory, please set BAKE_ALLOW_REMOTE_FS_ACCESS=1", p)
+	}
+	return nil
+}
+
+func toBuildOpt(t *Target, inp *Input) (*build.Options, error) {
+	if v := t.Context; v != nil && *v == "-" {
+		return nil, errors.Errorf("context from stdin not allowed in bake")
+	}
+	if v := t.Dockerfile; v != nil && *v == "-" {
+		return nil, errors.Errorf("dockerfile from stdin not allowed in bake")
+	}
+
+	contextPath := "."
+	if t.Context != nil {
+		contextPath = *t.Context
+	}
+	if !strings.HasPrefix(contextPath, "cwd://") && !IsRemoteURL(contextPath) {
+		contextPath = path.Clean(contextPath)
+	}
+	dockerfilePath := "Dockerfile"
+	if t.Dockerfile != nil {
+		dockerfilePath = *t.Dockerfile
+	}
+
+	if !isRemoteResource(contextPath) && !path.IsAbs(dockerfilePath) {
+		dockerfilePath = path.Join(contextPath, dockerfilePath)
+	}
+
+	args := map[string]string{}
+	for k, v := range t.Args {
+		if v == nil {
+			continue
+		}
+		args[k] = *v
+	}
+
+	labels := map[string]string{}
+	for k, v := range t.Labels {
+		if v == nil {
+			continue
+		}
+		labels[k] = *v
+	}
+
+	noCache := false
+	if t.NoCache != nil {
+		noCache = *t.NoCache
+	}
+	pull := false
+	if t.Pull != nil {
+		pull = *t.Pull
+	}
+	networkMode := ""
+	if t.NetworkMode != nil {
+		networkMode = *t.NetworkMode
+	}
+
+	bi := build.Inputs{
+		ContextPath:    contextPath,
+		DockerfilePath: dockerfilePath,
+		NamedContexts:  toNamedContexts(t.Contexts),
+	}
+	if t.DockerfileInline != nil {
+		bi.DockerfileInline = *t.DockerfileInline
+	}
+	updateContext(&bi, inp)
+	if strings.HasPrefix(bi.ContextPath, "cwd://") {
+		bi.ContextPath = path.Clean(strings.TrimPrefix(bi.ContextPath, "cwd://"))
+	}
+	for k, v := range bi.NamedContexts {
+		if strings.HasPrefix(v.Path, "cwd://") {
+			bi.NamedContexts[k] = build.NamedContext{Path: path.Clean(strings.TrimPrefix(v.Path, "cwd://"))}
+		}
+	}
+
+	if err := validateContextsEntitlements(bi, inp); err != nil {
+		return nil, err
+	}
+
+	t.Context = &bi.ContextPath
+
+	bo := &build.Options{
+		Inputs:        bi,
+		Tags:          t.Tags,
+		BuildArgs:     args,
+		Labels:        labels,
+		NoCache:       noCache,
+		NoCacheFilter: t.NoCacheFilter,
+		Pull:          pull,
+		NetworkMode:   networkMode,
+		Linked:        t.linked,
+	}
+
+	platforms, err := platformutil.Parse(t.Platforms)
+	if err != nil {
+		return nil, err
+	}
+	bo.Platforms = platforms
+
+	dockerConfig := config.LoadDefaultConfigFile(os.Stderr)
+	bo.Session = append(bo.Session, authprovider.NewDockerAuthProvider(dockerConfig))
+
+	secrets, err := buildflags.ParseSecretSpecs(t.Secrets)
+	if err != nil {
+		return nil, err
+	}
+	bo.Session = append(bo.Session, secrets)
+
+	sshSpecs := t.SSH
+	if len(sshSpecs) == 0 && buildflags.IsGitSSH(contextPath) {
+		sshSpecs = []string{"default"}
+	}
+	ssh, err := buildflags.ParseSSHSpecs(sshSpecs)
+	if err != nil {
+		return nil, err
+	}
+	bo.Session = append(bo.Session, ssh)
+
+	if t.Target != nil {
+		bo.Target = *t.Target
+	}
+
+	cacheImports, err := buildflags.ParseCacheEntry(t.CacheFrom)
+	if err != nil {
+		return nil, err
+	}
+	bo.CacheFrom = cacheImports
+
+	cacheExports, err := buildflags.ParseCacheEntry(t.CacheTo)
+	if err != nil {
+		return nil, err
+	}
+	bo.CacheTo = cacheExports
+
+	outputs, err := buildflags.ParseOutputs(t.Outputs)
+	if err != nil {
+		return nil, err
+	}
+	bo.Exports = outputs
+
+	attests, err := buildflags.ParseAttests(t.Attest)
+	if err != nil {
+		return nil, err
+	}
+	bo.Attests = attests
+
+	return bo, nil
+}
+
+func defaultTarget() *Target {
+	return &Target{}
+}
+
+func removeDupes(s []string) []string {
+	i := 0
+	seen := make(map[string]struct{}, len(s))
+	for _, v := range s {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		if v == "" {
+			continue
+		}
+		seen[v] = struct{}{}
+		s[i] = v
+		i++
+	}
+	return s[:i]
+}
+
+func isRemoteResource(str string) bool {
+	return urlutil.IsGitURL(str) || urlutil.IsURL(str)
+}
+
+func parseOutputType(str string) string {
+	csvReader := csv.NewReader(strings.NewReader(str))
+	fields, err := csvReader.Read()
+	if err != nil {
+		return ""
+	}
+	for _, field := range fields {
+		parts := strings.SplitN(field, "=", 2)
+		if len(parts) == 2 {
+			if parts[0] == "type" {
+				return parts[1]
+			}
+		}
+	}
+	return ""
+}
+
+func validateTargetName(name string) error {
+	if !targetNamePattern.MatchString(name) {
+		return errors.Errorf("only %q are allowed", validTargetNameChars)
+	}
+	return nil
+}
+
+func sanitizeTargetName(target string) string {
+	// as stipulated in compose spec, service name can contain a dot so as
+	// best-effort and to avoid any potential ambiguity, we replace the dot
+	// with an underscore.
+	return strings.ReplaceAll(target, ".", "_")
+}
+
+func sliceEqual(s1, s2 []string) bool {
+	if len(s1) != len(s2) {
+		return false
+	}
+	sort.Strings(s1)
+	sort.Strings(s2)
+	for i := range s1 {
+		if s1[i] != s2[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func toNamedContexts(m map[string]string) map[string]build.NamedContext {
+	m2 := make(map[string]build.NamedContext, len(m))
+	for k, v := range m {
+		m2[k] = build.NamedContext{Path: v}
+	}
+	return m2
+}

--- a/pkg/buildx/bake/compose.go
+++ b/pkg/buildx/bake/compose.go
@@ -1,0 +1,324 @@
+package bake
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/compose-spec/compose-go/dotenv"
+	"github.com/compose-spec/compose-go/loader"
+	compose "github.com/compose-spec/compose-go/types"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
+)
+
+func ParseComposeFiles(fs []File) (*Config, error) {
+	envs, err := composeEnv()
+	if err != nil {
+		return nil, err
+	}
+	var cfgs []compose.ConfigFile
+	for _, f := range fs {
+		cfgs = append(cfgs, compose.ConfigFile{
+			Filename: f.Name,
+			Content:  f.Data,
+		})
+	}
+	return ParseCompose(cfgs, envs)
+}
+
+func ParseCompose(cfgs []compose.ConfigFile, envs map[string]string) (*Config, error) {
+	cfg, err := loader.Load(compose.ConfigDetails{
+		ConfigFiles: cfgs,
+		Environment: envs,
+	}, func(options *loader.Options) {
+		options.SkipNormalization = true
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var c Config
+	if len(cfg.Services) > 0 {
+		c.Groups = []*Group{}
+		c.Targets = []*Target{}
+
+		g := &Group{Name: "default"}
+
+		for _, s := range cfg.Services {
+			if s.Build == nil {
+				continue
+			}
+
+			targetName := sanitizeTargetName(s.Name)
+			if err = validateTargetName(targetName); err != nil {
+				return nil, errors.Wrapf(err, "invalid service name %q", targetName)
+			}
+
+			var contextPathP *string
+			if s.Build.Context != "" {
+				contextPath := s.Build.Context
+				contextPathP = &contextPath
+			}
+			var dockerfilePathP *string
+			if s.Build.Dockerfile != "" {
+				dockerfilePath := s.Build.Dockerfile
+				dockerfilePathP = &dockerfilePath
+			}
+
+			var secrets []string
+			for _, bs := range s.Build.Secrets {
+				secret, err := composeToBuildkitSecret(bs, cfg.Secrets[bs.Source])
+				if err != nil {
+					return nil, err
+				}
+				secrets = append(secrets, secret)
+			}
+
+			// compose does not support nil values for labels
+			labels := map[string]*string{}
+			for k, v := range s.Build.Labels {
+				v := v
+				labels[k] = &v
+			}
+
+			g.Targets = append(g.Targets, targetName)
+			t := &Target{
+				Name:       targetName,
+				Context:    contextPathP,
+				Dockerfile: dockerfilePathP,
+				Tags:       s.Build.Tags,
+				Labels:     labels,
+				Args: flatten(s.Build.Args.Resolve(func(val string) (string, bool) {
+					if val, ok := s.Environment[val]; ok && val != nil {
+						return *val, true
+					}
+					val, ok := cfg.Environment[val]
+					return val, ok
+				})),
+				CacheFrom:   s.Build.CacheFrom,
+				CacheTo:     s.Build.CacheTo,
+				NetworkMode: &s.Build.Network,
+				Secrets:     secrets,
+			}
+			if err = t.composeExtTarget(s.Build.Extensions); err != nil {
+				return nil, err
+			}
+			if s.Build.Target != "" {
+				target := s.Build.Target
+				t.Target = &target
+			}
+			if len(t.Tags) == 0 && s.Image != "" {
+				t.Tags = []string{s.Image}
+			}
+			c.Targets = append(c.Targets, t)
+		}
+		c.Groups = append(c.Groups, g)
+
+	}
+
+	return &c, nil
+}
+
+func validateComposeFile(dt []byte, fn string) (bool, error) {
+	envs, err := composeEnv()
+	if err != nil {
+		return true, err
+	}
+	fnl := strings.ToLower(fn)
+	if strings.HasSuffix(fnl, ".yml") || strings.HasSuffix(fnl, ".yaml") {
+		return true, validateCompose(dt, envs)
+	}
+	if strings.HasSuffix(fnl, ".json") || strings.HasSuffix(fnl, ".hcl") {
+		return false, nil
+	}
+	err = validateCompose(dt, envs)
+	return err == nil, err
+}
+
+func validateCompose(dt []byte, envs map[string]string) error {
+	_, err := loader.Load(compose.ConfigDetails{
+		ConfigFiles: []compose.ConfigFile{
+			{
+				Content: dt,
+			},
+		},
+		Environment: envs,
+	}, func(options *loader.Options) {
+		options.SkipNormalization = true
+		// consistency is checked later in ParseCompose to ensure multiple
+		// compose files can be merged together
+		options.SkipConsistencyCheck = true
+	})
+	return err
+}
+
+func composeEnv() (map[string]string, error) {
+	envs := sliceToMap(os.Environ())
+	if wd, err := os.Getwd(); err == nil {
+		envs, err = loadDotEnv(envs, wd)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return envs, nil
+}
+
+func loadDotEnv(curenv map[string]string, workingDir string) (map[string]string, error) {
+	if curenv == nil {
+		curenv = make(map[string]string)
+	}
+
+	ef, err := filepath.Abs(filepath.Join(workingDir, ".env"))
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err = os.Stat(ef); os.IsNotExist(err) {
+		return curenv, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	dt, err := os.ReadFile(ef)
+	if err != nil {
+		return nil, err
+	}
+
+	envs, err := dotenv.UnmarshalBytes(dt)
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range envs {
+		if _, set := curenv[k]; set {
+			continue
+		}
+		curenv[k] = v
+	}
+
+	return curenv, nil
+}
+
+func flatten(in compose.MappingWithEquals) map[string]*string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := map[string]*string{}
+	for k, v := range in {
+		if v == nil {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+// xbake Compose build extension provides fields not (yet) available in
+// Compose build specification: https://github.com/compose-spec/compose-spec/blob/master/build.md
+type xbake struct {
+	Tags          stringArray `yaml:"tags,omitempty"`
+	CacheFrom     stringArray `yaml:"cache-from,omitempty"`
+	CacheTo       stringArray `yaml:"cache-to,omitempty"`
+	Secrets       stringArray `yaml:"secret,omitempty"`
+	SSH           stringArray `yaml:"ssh,omitempty"`
+	Platforms     stringArray `yaml:"platforms,omitempty"`
+	Outputs       stringArray `yaml:"output,omitempty"`
+	Pull          *bool       `yaml:"pull,omitempty"`
+	NoCache       *bool       `yaml:"no-cache,omitempty"`
+	NoCacheFilter stringArray `yaml:"no-cache-filter,omitempty"`
+	Contexts      stringMap   `yaml:"contexts,omitempty"`
+	// don't forget to update documentation if you add a new field:
+	// docs/manuals/bake/compose-file.md#extension-field-with-x-bake
+}
+
+type stringMap map[string]string
+type stringArray []string
+
+func (sa *stringArray) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var multi []string
+	err := unmarshal(&multi)
+	if err != nil {
+		var single string
+		if err := unmarshal(&single); err != nil {
+			return err
+		}
+		*sa = strings.Fields(single)
+	} else {
+		*sa = multi
+	}
+	return nil
+}
+
+// composeExtTarget converts Compose build extension x-bake to bake Target
+// https://github.com/compose-spec/compose-spec/blob/master/spec.md#extension
+func (t *Target) composeExtTarget(exts map[string]interface{}) error {
+	var xb xbake
+
+	ext, ok := exts["x-bake"]
+	if !ok || ext == nil {
+		return nil
+	}
+
+	yb, _ := yaml.Marshal(ext)
+	if err := yaml.Unmarshal(yb, &xb); err != nil {
+		return err
+	}
+
+	if len(xb.Tags) > 0 {
+		t.Tags = dedupSlice(append(t.Tags, xb.Tags...))
+	}
+	if len(xb.CacheFrom) > 0 {
+		t.CacheFrom = dedupSlice(append(t.CacheFrom, xb.CacheFrom...))
+	}
+	if len(xb.CacheTo) > 0 {
+		t.CacheTo = dedupSlice(append(t.CacheTo, xb.CacheTo...))
+	}
+	if len(xb.Secrets) > 0 {
+		t.Secrets = dedupSlice(append(t.Secrets, xb.Secrets...))
+	}
+	if len(xb.SSH) > 0 {
+		t.SSH = dedupSlice(append(t.SSH, xb.SSH...))
+	}
+	if len(xb.Platforms) > 0 {
+		t.Platforms = dedupSlice(append(t.Platforms, xb.Platforms...))
+	}
+	if len(xb.Outputs) > 0 {
+		t.Outputs = dedupSlice(append(t.Outputs, xb.Outputs...))
+	}
+	if xb.Pull != nil {
+		t.Pull = xb.Pull
+	}
+	if xb.NoCache != nil {
+		t.NoCache = xb.NoCache
+	}
+	if len(xb.NoCacheFilter) > 0 {
+		t.NoCacheFilter = dedupSlice(append(t.NoCacheFilter, xb.NoCacheFilter...))
+	}
+	if len(xb.Contexts) > 0 {
+		t.Contexts = dedupMap(t.Contexts, xb.Contexts)
+	}
+
+	return nil
+}
+
+// composeToBuildkitSecret converts secret from compose format to buildkit's
+// csv format.
+func composeToBuildkitSecret(inp compose.ServiceSecretConfig, psecret compose.SecretConfig) (string, error) {
+	if psecret.External.External {
+		return "", errors.Errorf("unsupported external secret %s", psecret.Name)
+	}
+
+	var bkattrs []string
+	if inp.Source != "" {
+		bkattrs = append(bkattrs, "id="+inp.Source)
+	}
+	if psecret.File != "" {
+		bkattrs = append(bkattrs, "src="+psecret.File)
+	}
+	if psecret.Environment != "" {
+		bkattrs = append(bkattrs, "env="+psecret.Environment)
+	}
+
+	return strings.Join(bkattrs, ","), nil
+}

--- a/pkg/buildx/bake/hcl.go
+++ b/pkg/buildx/bake/hcl.go
@@ -1,0 +1,78 @@
+package bake
+
+import (
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclparse"
+	"github.com/moby/buildkit/solver/errdefs"
+	"github.com/moby/buildkit/solver/pb"
+)
+
+func ParseHCLFile(dt []byte, fn string) (*hcl.File, bool, error) {
+	var err error
+	if strings.HasSuffix(fn, ".json") {
+		f, diags := hclparse.NewParser().ParseJSON(dt, fn)
+		if diags.HasErrors() {
+			err = diags
+		}
+		return f, true, err
+	}
+	if strings.HasSuffix(fn, ".hcl") {
+		f, diags := hclparse.NewParser().ParseHCL(dt, fn)
+		if diags.HasErrors() {
+			err = diags
+		}
+		return f, true, err
+	}
+	f, diags := hclparse.NewParser().ParseHCL(dt, fn+".hcl")
+	if diags.HasErrors() {
+		f, diags2 := hclparse.NewParser().ParseJSON(dt, fn+".json")
+		if !diags2.HasErrors() {
+			return f, true, nil
+		}
+		return nil, false, diags
+	}
+	return f, true, nil
+}
+
+func formatHCLError(err error, files []File) error {
+	if err == nil {
+		return nil
+	}
+	diags, ok := err.(hcl.Diagnostics)
+	if !ok {
+		return err
+	}
+	for _, d := range diags {
+		if d.Severity != hcl.DiagError {
+			continue
+		}
+		if d.Subject != nil {
+			var dt []byte
+			for _, f := range files {
+				if d.Subject.Filename == f.Name {
+					dt = f.Data
+					break
+				}
+			}
+			src := errdefs.Source{
+				Info: &pb.SourceInfo{
+					Filename: d.Subject.Filename,
+					Data:     dt,
+				},
+				Ranges: []*pb.Range{toErrRange(d.Subject)},
+			}
+			err = errdefs.WithSource(err, src)
+			break
+		}
+	}
+	return err
+}
+
+func toErrRange(in *hcl.Range) *pb.Range {
+	return &pb.Range{
+		Start: pb.Position{Line: int32(in.Start.Line), Character: int32(in.Start.Column)},
+		End:   pb.Position{Line: int32(in.End.Line), Character: int32(in.End.Column)},
+	}
+}

--- a/pkg/buildx/bake/hclparser/body.go
+++ b/pkg/buildx/bake/hclparser/body.go
@@ -1,0 +1,103 @@
+package hclparser
+
+import (
+	"github.com/hashicorp/hcl/v2"
+)
+
+type filterBody struct {
+	body    hcl.Body
+	schema  *hcl.BodySchema
+	exclude bool
+}
+
+func FilterIncludeBody(body hcl.Body, schema *hcl.BodySchema) hcl.Body {
+	return &filterBody{
+		body:   body,
+		schema: schema,
+	}
+}
+
+func FilterExcludeBody(body hcl.Body, schema *hcl.BodySchema) hcl.Body {
+	return &filterBody{
+		body:    body,
+		schema:  schema,
+		exclude: true,
+	}
+}
+
+func (b *filterBody) Content(schema *hcl.BodySchema) (*hcl.BodyContent, hcl.Diagnostics) {
+	if b.exclude {
+		schema = subtractSchemas(schema, b.schema)
+	} else {
+		schema = intersectSchemas(schema, b.schema)
+	}
+	content, _, diag := b.body.PartialContent(schema)
+	return content, diag
+}
+
+func (b *filterBody) PartialContent(schema *hcl.BodySchema) (*hcl.BodyContent, hcl.Body, hcl.Diagnostics) {
+	if b.exclude {
+		schema = subtractSchemas(schema, b.schema)
+	} else {
+		schema = intersectSchemas(schema, b.schema)
+	}
+	return b.body.PartialContent(schema)
+}
+
+func (b *filterBody) JustAttributes() (hcl.Attributes, hcl.Diagnostics) {
+	return b.body.JustAttributes()
+}
+
+func (b *filterBody) MissingItemRange() hcl.Range {
+	return b.body.MissingItemRange()
+}
+
+func intersectSchemas(a, b *hcl.BodySchema) *hcl.BodySchema {
+	result := &hcl.BodySchema{}
+	for _, blockA := range a.Blocks {
+		for _, blockB := range b.Blocks {
+			if blockA.Type == blockB.Type {
+				result.Blocks = append(result.Blocks, blockA)
+				break
+			}
+		}
+	}
+	for _, attrA := range a.Attributes {
+		for _, attrB := range b.Attributes {
+			if attrA.Name == attrB.Name {
+				result.Attributes = append(result.Attributes, attrA)
+				break
+			}
+		}
+	}
+	return result
+}
+
+func subtractSchemas(a, b *hcl.BodySchema) *hcl.BodySchema {
+	result := &hcl.BodySchema{}
+	for _, blockA := range a.Blocks {
+		found := false
+		for _, blockB := range b.Blocks {
+			if blockA.Type == blockB.Type {
+				found = true
+				break
+			}
+		}
+		if !found {
+			result.Blocks = append(result.Blocks, blockA)
+		}
+	}
+	for _, attrA := range a.Attributes {
+		found := false
+		for _, attrB := range b.Attributes {
+			if attrA.Name == attrB.Name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			result.Attributes = append(result.Attributes, attrA)
+		}
+	}
+	return result
+}

--- a/pkg/buildx/bake/hclparser/expr.go
+++ b/pkg/buildx/bake/hclparser/expr.go
@@ -1,0 +1,145 @@
+package hclparser
+
+import (
+	"reflect"
+	"unsafe"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/pkg/errors"
+)
+
+func funcCalls(exp hcl.Expression) ([]string, hcl.Diagnostics) {
+	node, ok := exp.(hclsyntax.Node)
+	if !ok {
+		fns, err := jsonFuncCallsRecursive(exp)
+		if err != nil {
+			return nil, wrapErrorDiagnostic("Invalid expression", err, exp.Range().Ptr(), exp.Range().Ptr())
+		}
+		return fns, nil
+	}
+
+	var funcnames []string
+	hcldiags := hclsyntax.VisitAll(node, func(n hclsyntax.Node) hcl.Diagnostics {
+		if fe, ok := n.(*hclsyntax.FunctionCallExpr); ok {
+			funcnames = append(funcnames, fe.Name)
+		}
+		return nil
+	})
+	if hcldiags.HasErrors() {
+		return nil, hcldiags
+	}
+	return funcnames, nil
+}
+
+func jsonFuncCallsRecursive(exp hcl.Expression) ([]string, error) {
+	je, ok := exp.(jsonExp)
+	if !ok {
+		return nil, errors.Errorf("invalid expression type %T", exp)
+	}
+	m := map[string]struct{}{}
+	for _, e := range elementExpressions(je, exp) {
+		if err := appendJSONFuncCalls(e, m); err != nil {
+			return nil, err
+		}
+	}
+	arr := make([]string, 0, len(m))
+	for n := range m {
+		arr = append(arr, n)
+	}
+	return arr, nil
+}
+
+func appendJSONFuncCalls(exp hcl.Expression, m map[string]struct{}) error {
+	v := reflect.ValueOf(exp)
+	if v.Kind() != reflect.Ptr || v.IsNil() {
+		return errors.Errorf("invalid json expression kind %T %v", exp, v.Kind())
+	}
+	src := v.Elem().FieldByName("src")
+	if src.IsZero() {
+		return errors.Errorf("%v has no property src", v.Elem().Type())
+	}
+	if src.Kind() != reflect.Interface {
+		return errors.Errorf("%v src is not interface: %v", src.Type(), src.Kind())
+	}
+	src = src.Elem()
+	if src.IsNil() {
+		return nil
+	}
+	if src.Kind() == reflect.Ptr {
+		src = src.Elem()
+	}
+	if src.Kind() != reflect.Struct {
+		return errors.Errorf("%v is not struct: %v", src.Type(), src.Kind())
+	}
+
+	// hcl/v2/json/ast#stringVal
+	val := src.FieldByName("Value")
+	if !val.IsValid() || val.IsZero() {
+		return nil
+	}
+	rng := src.FieldByName("SrcRange")
+	if rng.IsZero() {
+		return nil
+	}
+	var stringVal struct {
+		Value    string
+		SrcRange hcl.Range
+	}
+
+	if !val.Type().AssignableTo(reflect.ValueOf(stringVal.Value).Type()) {
+		return nil
+	}
+	if !rng.Type().AssignableTo(reflect.ValueOf(stringVal.SrcRange).Type()) {
+		return nil
+	}
+	// reflect.Set does not work for unexported fields
+	stringVal.Value = *(*string)(unsafe.Pointer(val.UnsafeAddr()))
+	stringVal.SrcRange = *(*hcl.Range)(unsafe.Pointer(rng.UnsafeAddr()))
+
+	expr, diags := hclsyntax.ParseExpression([]byte(stringVal.Value), stringVal.SrcRange.Filename, stringVal.SrcRange.Start)
+	if diags.HasErrors() {
+		return nil
+	}
+
+	fns, err := funcCalls(expr)
+	if err != nil {
+		return err
+	}
+
+	for _, fn := range fns {
+		m[fn] = struct{}{}
+	}
+
+	return nil
+}
+
+type jsonExp interface {
+	ExprList() []hcl.Expression
+	ExprMap() []hcl.KeyValuePair
+}
+
+func elementExpressions(je jsonExp, exp hcl.Expression) []hcl.Expression {
+	list := je.ExprList()
+	if len(list) != 0 {
+		exp := make([]hcl.Expression, 0, len(list))
+		for _, e := range list {
+			if je, ok := e.(jsonExp); ok {
+				exp = append(exp, elementExpressions(je, e)...)
+			}
+		}
+		return exp
+	}
+	kvlist := je.ExprMap()
+	if len(kvlist) != 0 {
+		exp := make([]hcl.Expression, 0, len(kvlist)*2)
+		for _, p := range kvlist {
+			exp = append(exp, p.Key)
+			if je, ok := p.Value.(jsonExp); ok {
+				exp = append(exp, elementExpressions(je, p.Value)...)
+			}
+		}
+		return exp
+	}
+	return []hcl.Expression{exp}
+}

--- a/pkg/buildx/bake/hclparser/hclparser.go
+++ b/pkg/buildx/bake/hclparser/hclparser.go
@@ -894,7 +894,7 @@ func key(ks ...any) uint64 {
 			hash.Write([]byte(v.String()))
 		case reflect.Pointer:
 			ptr := reflect.ValueOf(k).Pointer()
-			binary.Write(hash, binary.LittleEndian, uint64(ptr))
+			_ = binary.Write(hash, binary.LittleEndian, uint64(ptr))
 		default:
 			panic(fmt.Sprintf("unknown key kind %s", v.Kind().String()))
 		}

--- a/pkg/buildx/bake/hclparser/hclparser.go
+++ b/pkg/buildx/bake/hclparser/hclparser.go
@@ -1,0 +1,755 @@
+package hclparser
+
+import (
+	"fmt"
+	"math"
+	"math/big"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/docker/buildx/util/userfunc"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/pkg/errors"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/gocty"
+)
+
+type Opt struct {
+	LookupVar     func(string) (string, bool)
+	Vars          map[string]string
+	ValidateLabel func(string) error
+}
+
+type variable struct {
+	Name    string         `json:"-" hcl:"name,label"`
+	Default *hcl.Attribute `json:"default,omitempty" hcl:"default,optional"`
+	Body    hcl.Body       `json:"-" hcl:",body"`
+}
+
+type functionDef struct {
+	Name     string         `json:"-" hcl:"name,label"`
+	Params   *hcl.Attribute `json:"params,omitempty" hcl:"params"`
+	Variadic *hcl.Attribute `json:"variadic_param,omitempty" hcl:"variadic_params"`
+	Result   *hcl.Attribute `json:"result,omitempty" hcl:"result"`
+}
+
+type inputs struct {
+	Variables []*variable    `hcl:"variable,block"`
+	Functions []*functionDef `hcl:"function,block"`
+
+	Remain hcl.Body `json:"-" hcl:",remain"`
+}
+
+type parser struct {
+	opt Opt
+
+	vars  map[string]*variable
+	attrs map[string]*hcl.Attribute
+	funcs map[string]*functionDef
+
+	blocks      map[string]map[string][]*hcl.Block
+	blockValues map[*hcl.Block]reflect.Value
+	blockTypes  map[string]reflect.Type
+
+	ectx *hcl.EvalContext
+
+	progress  map[string]struct{}
+	progressF map[string]struct{}
+	progressB map[*hcl.Block]map[string]struct{}
+	doneF     map[string]struct{}
+	doneB     map[*hcl.Block]map[string]struct{}
+}
+
+var errUndefined = errors.New("undefined")
+
+func (p *parser) loadDeps(exp hcl.Expression, exclude map[string]struct{}, allowMissing bool) hcl.Diagnostics {
+	fns, hcldiags := funcCalls(exp)
+	if hcldiags.HasErrors() {
+		return hcldiags
+	}
+
+	for _, fn := range fns {
+		if err := p.resolveFunction(fn); err != nil {
+			if allowMissing && errors.Is(err, errUndefined) {
+				continue
+			}
+			return wrapErrorDiagnostic("Invalid expression", err, exp.Range().Ptr(), exp.Range().Ptr())
+		}
+	}
+
+	for _, v := range exp.Variables() {
+		if _, ok := exclude[v.RootName()]; ok {
+			continue
+		}
+		if _, ok := p.blockTypes[v.RootName()]; ok {
+			blockType := v.RootName()
+
+			split := v.SimpleSplit().Rel
+			if len(split) == 0 {
+				return hcl.Diagnostics{
+					&hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Invalid expression",
+						Detail:   fmt.Sprintf("cannot access %s as a variable", blockType),
+						Subject:  exp.Range().Ptr(),
+						Context:  exp.Range().Ptr(),
+					},
+				}
+			}
+			blockName, ok := split[0].(hcl.TraverseAttr)
+			if !ok {
+				return hcl.Diagnostics{
+					&hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Invalid expression",
+						Detail:   fmt.Sprintf("cannot traverse %s without attribute", blockType),
+						Subject:  exp.Range().Ptr(),
+						Context:  exp.Range().Ptr(),
+					},
+				}
+			}
+			blocks := p.blocks[blockType][blockName.Name]
+			if len(blocks) == 0 {
+				continue
+			}
+
+			var target *hcl.BodySchema
+			if len(split) > 1 {
+				if attr, ok := split[1].(hcl.TraverseAttr); ok {
+					target = &hcl.BodySchema{
+						Attributes: []hcl.AttributeSchema{{Name: attr.Name}},
+						Blocks:     []hcl.BlockHeaderSchema{{Type: attr.Name}},
+					}
+				}
+			}
+			if err := p.resolveBlock(blocks[0], target); err != nil {
+				if allowMissing && errors.Is(err, errUndefined) {
+					continue
+				}
+				return wrapErrorDiagnostic("Invalid expression", err, exp.Range().Ptr(), exp.Range().Ptr())
+			}
+		} else {
+			if err := p.resolveValue(v.RootName()); err != nil {
+				if allowMissing && errors.Is(err, errUndefined) {
+					continue
+				}
+				return wrapErrorDiagnostic("Invalid expression", err, exp.Range().Ptr(), exp.Range().Ptr())
+			}
+		}
+	}
+
+	return nil
+}
+
+// resolveFunction forces evaluation of a function, storing the result into the
+// parser.
+func (p *parser) resolveFunction(name string) error {
+	if _, ok := p.doneF[name]; ok {
+		return nil
+	}
+	f, ok := p.funcs[name]
+	if !ok {
+		if _, ok := p.ectx.Functions[name]; ok {
+			return nil
+		}
+		return errors.Wrapf(errUndefined, "function %q does not exit", name)
+	}
+	if _, ok := p.progressF[name]; ok {
+		return errors.Errorf("function cycle not allowed for %s", name)
+	}
+	p.progressF[name] = struct{}{}
+
+	if f.Result == nil {
+		return errors.Errorf("empty result not allowed for %s", name)
+	}
+	if f.Params == nil {
+		return errors.Errorf("empty params not allowed for %s", name)
+	}
+
+	paramExprs, paramsDiags := hcl.ExprList(f.Params.Expr)
+	if paramsDiags.HasErrors() {
+		return paramsDiags
+	}
+	var diags hcl.Diagnostics
+	params := map[string]struct{}{}
+	for _, paramExpr := range paramExprs {
+		param := hcl.ExprAsKeyword(paramExpr)
+		if param == "" {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid param element",
+				Detail:   "Each parameter name must be an identifier.",
+				Subject:  paramExpr.Range().Ptr(),
+			})
+		}
+		params[param] = struct{}{}
+	}
+	var variadic hcl.Expression
+	if f.Variadic != nil {
+		variadic = f.Variadic.Expr
+		param := hcl.ExprAsKeyword(variadic)
+		if param == "" {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid param element",
+				Detail:   "Each parameter name must be an identifier.",
+				Subject:  f.Variadic.Range.Ptr(),
+			})
+		}
+		params[param] = struct{}{}
+	}
+	if diags.HasErrors() {
+		return diags
+	}
+
+	if diags := p.loadDeps(f.Result.Expr, params, false); diags.HasErrors() {
+		return diags
+	}
+
+	v, diags := userfunc.NewFunction(f.Params.Expr, variadic, f.Result.Expr, func() *hcl.EvalContext {
+		return p.ectx
+	})
+	if diags.HasErrors() {
+		return diags
+	}
+	p.doneF[name] = struct{}{}
+	p.ectx.Functions[name] = v
+
+	return nil
+}
+
+// resolveValue forces evaluation of a named value, storing the result into the
+// parser.
+func (p *parser) resolveValue(name string) (err error) {
+	if _, ok := p.ectx.Variables[name]; ok {
+		return nil
+	}
+	if _, ok := p.progress[name]; ok {
+		return errors.Errorf("variable cycle not allowed for %s", name)
+	}
+	p.progress[name] = struct{}{}
+
+	var v *cty.Value
+	defer func() {
+		if v != nil {
+			p.ectx.Variables[name] = *v
+		}
+	}()
+
+	def, ok := p.attrs[name]
+	if _, builtin := p.opt.Vars[name]; !ok && !builtin {
+		vr, ok := p.vars[name]
+		if !ok {
+			return errors.Wrapf(errUndefined, "variable %q does not exit", name)
+		}
+		def = vr.Default
+	}
+
+	if def == nil {
+		val, ok := p.opt.Vars[name]
+		if !ok {
+			val, _ = p.opt.LookupVar(name)
+		}
+		vv := cty.StringVal(val)
+		v = &vv
+		return
+	}
+
+	if diags := p.loadDeps(def.Expr, nil, true); diags.HasErrors() {
+		return diags
+	}
+	vv, diags := def.Expr.Value(p.ectx)
+	if diags.HasErrors() {
+		return diags
+	}
+
+	_, isVar := p.vars[name]
+
+	if envv, ok := p.opt.LookupVar(name); ok && isVar {
+		switch {
+		case vv.Type().Equals(cty.Bool):
+			b, err := strconv.ParseBool(envv)
+			if err != nil {
+				return errors.Wrapf(err, "failed to parse %s as bool", name)
+			}
+			vv = cty.BoolVal(b)
+		case vv.Type().Equals(cty.String), vv.Type().Equals(cty.DynamicPseudoType):
+			vv = cty.StringVal(envv)
+		case vv.Type().Equals(cty.Number):
+			n, err := strconv.ParseFloat(envv, 64)
+			if err == nil && (math.IsNaN(n) || math.IsInf(n, 0)) {
+				err = errors.Errorf("invalid number value")
+			}
+			if err != nil {
+				return errors.Wrapf(err, "failed to parse %s as number", name)
+			}
+			vv = cty.NumberVal(big.NewFloat(n))
+		default:
+			// TODO: support lists with csv values
+			return errors.Errorf("unsupported type %s for variable %s", vv.Type().FriendlyName(), name)
+		}
+	}
+	v = &vv
+	return nil
+}
+
+// resolveBlock force evaluates a block, storing the result in the parser. If a
+// target schema is provided, only the attributes and blocks present in the
+// schema will be evaluated.
+func (p *parser) resolveBlock(block *hcl.Block, target *hcl.BodySchema) (err error) {
+	name := block.Labels[0]
+	if err := p.opt.ValidateLabel(name); err != nil {
+		return wrapErrorDiagnostic("Invalid name", err, &block.LabelRanges[0], &block.LabelRanges[0])
+	}
+
+	if _, ok := p.doneB[block]; !ok {
+		p.doneB[block] = map[string]struct{}{}
+	}
+	if _, ok := p.progressB[block]; !ok {
+		p.progressB[block] = map[string]struct{}{}
+	}
+
+	if target != nil {
+		// filter out attributes and blocks that are already evaluated
+		original := target
+		target = &hcl.BodySchema{}
+		for _, a := range original.Attributes {
+			if _, ok := p.doneB[block][a.Name]; !ok {
+				target.Attributes = append(target.Attributes, a)
+			}
+		}
+		for _, b := range original.Blocks {
+			if _, ok := p.doneB[block][b.Type]; !ok {
+				target.Blocks = append(target.Blocks, b)
+			}
+		}
+		if len(target.Attributes) == 0 && len(target.Blocks) == 0 {
+			return nil
+		}
+	}
+
+	if target != nil {
+		// detect reference cycles
+		for _, a := range target.Attributes {
+			if _, ok := p.progressB[block][a.Name]; ok {
+				return errors.Errorf("reference cycle not allowed for %s.%s.%s", block.Type, name, a.Name)
+			}
+		}
+		for _, b := range target.Blocks {
+			if _, ok := p.progressB[block][b.Type]; ok {
+				return errors.Errorf("reference cycle not allowed for %s.%s.%s", block.Type, name, b.Type)
+			}
+		}
+		for _, a := range target.Attributes {
+			p.progressB[block][a.Name] = struct{}{}
+		}
+		for _, b := range target.Blocks {
+			p.progressB[block][b.Type] = struct{}{}
+		}
+	}
+
+	// create a filtered body that contains only the target properties
+	body := func() hcl.Body {
+		if target != nil {
+			return FilterIncludeBody(block.Body, target)
+		}
+
+		filter := &hcl.BodySchema{}
+		for k := range p.doneB[block] {
+			filter.Attributes = append(filter.Attributes, hcl.AttributeSchema{Name: k})
+			filter.Blocks = append(filter.Blocks, hcl.BlockHeaderSchema{Type: k})
+		}
+		return FilterExcludeBody(block.Body, filter)
+	}
+
+	// load dependencies from all targeted properties
+	t, ok := p.blockTypes[block.Type]
+	if !ok {
+		return nil
+	}
+	schema, _ := gohcl.ImpliedBodySchema(reflect.New(t).Interface())
+	content, _, diag := body().PartialContent(schema)
+	if diag.HasErrors() {
+		return diag
+	}
+	for _, a := range content.Attributes {
+		diag := p.loadDeps(a.Expr, nil, true)
+		if diag.HasErrors() {
+			return diag
+		}
+	}
+	for _, b := range content.Blocks {
+		err := p.resolveBlock(b, nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	// decode!
+	var output reflect.Value
+	if prev, ok := p.blockValues[block]; ok {
+		output = prev
+	} else {
+		output = reflect.New(t)
+		setLabel(output, block.Labels[0]) // early attach labels, so we can reference them
+	}
+	diag = gohcl.DecodeBody(body(), p.ectx, output.Interface())
+	if diag.HasErrors() {
+		return diag
+	}
+	p.blockValues[block] = output
+
+	// mark all targeted properties as done
+	for _, a := range content.Attributes {
+		p.doneB[block][a.Name] = struct{}{}
+	}
+	for _, b := range content.Blocks {
+		p.doneB[block][b.Type] = struct{}{}
+	}
+	if target != nil {
+		for _, a := range target.Attributes {
+			p.doneB[block][a.Name] = struct{}{}
+		}
+		for _, b := range target.Blocks {
+			p.doneB[block][b.Type] = struct{}{}
+		}
+	}
+
+	// store the result into the evaluation context (so if can be referenced)
+	outputType, err := gocty.ImpliedType(output.Interface())
+	if err != nil {
+		return err
+	}
+	outputValue, err := gocty.ToCtyValue(output.Interface(), outputType)
+	if err != nil {
+		return err
+	}
+	var m map[string]cty.Value
+	if m2, ok := p.ectx.Variables[block.Type]; ok {
+		m = m2.AsValueMap()
+	}
+	if m == nil {
+		m = map[string]cty.Value{}
+	}
+	m[name] = outputValue
+	p.ectx.Variables[block.Type] = cty.MapVal(m)
+
+	return nil
+}
+
+func Parse(b hcl.Body, opt Opt, val interface{}) hcl.Diagnostics {
+	reserved := map[string]struct{}{}
+	schema, _ := gohcl.ImpliedBodySchema(val)
+
+	for _, bs := range schema.Blocks {
+		reserved[bs.Type] = struct{}{}
+	}
+	for k := range opt.Vars {
+		reserved[k] = struct{}{}
+	}
+
+	var defs inputs
+	if err := gohcl.DecodeBody(b, nil, &defs); err != nil {
+		return err
+	}
+	defsSchema, _ := gohcl.ImpliedBodySchema(defs)
+
+	if opt.LookupVar == nil {
+		opt.LookupVar = func(string) (string, bool) {
+			return "", false
+		}
+	}
+
+	if opt.ValidateLabel == nil {
+		opt.ValidateLabel = func(string) error {
+			return nil
+		}
+	}
+
+	p := &parser{
+		opt: opt,
+
+		vars:  map[string]*variable{},
+		attrs: map[string]*hcl.Attribute{},
+		funcs: map[string]*functionDef{},
+
+		blocks:      map[string]map[string][]*hcl.Block{},
+		blockValues: map[*hcl.Block]reflect.Value{},
+		blockTypes:  map[string]reflect.Type{},
+
+		progress:  map[string]struct{}{},
+		progressF: map[string]struct{}{},
+		progressB: map[*hcl.Block]map[string]struct{}{},
+
+		doneF: map[string]struct{}{},
+		doneB: map[*hcl.Block]map[string]struct{}{},
+		ectx: &hcl.EvalContext{
+			Variables: map[string]cty.Value{},
+			Functions: stdlibFunctions,
+		},
+	}
+
+	for _, v := range defs.Variables {
+		// TODO: validate name
+		if _, ok := reserved[v.Name]; ok {
+			continue
+		}
+		p.vars[v.Name] = v
+	}
+	for _, v := range defs.Functions {
+		// TODO: validate name
+		if _, ok := reserved[v.Name]; ok {
+			continue
+		}
+		p.funcs[v.Name] = v
+	}
+
+	content, b, diags := b.PartialContent(schema)
+	if diags.HasErrors() {
+		return diags
+	}
+
+	blocks, b, diags := b.PartialContent(defsSchema)
+	if diags.HasErrors() {
+		return diags
+	}
+
+	attrs, diags := b.JustAttributes()
+	if diags.HasErrors() {
+		if d := removeAttributesDiags(diags, reserved, p.vars); len(d) > 0 {
+			return d
+		}
+	}
+
+	for _, v := range attrs {
+		if _, ok := reserved[v.Name]; ok {
+			continue
+		}
+		p.attrs[v.Name] = v
+	}
+	delete(p.attrs, "function")
+
+	for k := range p.opt.Vars {
+		_ = p.resolveValue(k)
+	}
+
+	for _, a := range content.Attributes {
+		return hcl.Diagnostics{
+			&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid attribute",
+				Detail:   "global attributes currently not supported",
+				Subject:  &a.Range,
+				Context:  &a.Range,
+			},
+		}
+	}
+
+	for k := range p.vars {
+		if err := p.resolveValue(k); err != nil {
+			if diags, ok := err.(hcl.Diagnostics); ok {
+				return diags
+			}
+			r := p.vars[k].Body.MissingItemRange()
+			return wrapErrorDiagnostic("Invalid value", err, &r, &r)
+		}
+	}
+
+	for k := range p.funcs {
+		if err := p.resolveFunction(k); err != nil {
+			if diags, ok := err.(hcl.Diagnostics); ok {
+				return diags
+			}
+			var subject *hcl.Range
+			var context *hcl.Range
+			if p.funcs[k].Params != nil {
+				subject = &p.funcs[k].Params.Range
+				context = subject
+			} else {
+				for _, block := range blocks.Blocks {
+					if block.Type == "function" && len(block.Labels) == 1 && block.Labels[0] == k {
+						subject = &block.LabelRanges[0]
+						context = &block.DefRange
+						break
+					}
+				}
+			}
+			return wrapErrorDiagnostic("Invalid function", err, subject, context)
+		}
+	}
+
+	for _, b := range content.Blocks {
+		if len(b.Labels) == 0 || len(b.Labels) > 1 {
+			return hcl.Diagnostics{
+				&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid block",
+					Detail:   fmt.Sprintf("invalid block label: %v", b.Labels),
+					Subject:  &b.LabelRanges[0],
+					Context:  &b.LabelRanges[0],
+				},
+			}
+		}
+		bm, ok := p.blocks[b.Type]
+		if !ok {
+			bm = map[string][]*hcl.Block{}
+			p.blocks[b.Type] = bm
+		}
+
+		lbl := b.Labels[0]
+		bm[lbl] = append(bm[lbl], b)
+	}
+
+	type value struct {
+		reflect.Value
+		idx int
+	}
+	type field struct {
+		idx    int
+		typ    reflect.Type
+		values map[string]value
+	}
+	types := map[string]field{}
+
+	vt := reflect.ValueOf(val).Elem().Type()
+	for i := 0; i < vt.NumField(); i++ {
+		tags := strings.Split(vt.Field(i).Tag.Get("hcl"), ",")
+
+		p.blockTypes[tags[0]] = vt.Field(i).Type.Elem().Elem()
+		types[tags[0]] = field{
+			idx:    i,
+			typ:    vt.Field(i).Type,
+			values: make(map[string]value),
+		}
+	}
+
+	diags = hcl.Diagnostics{}
+	for _, b := range content.Blocks {
+		v := reflect.ValueOf(val)
+
+		err := p.resolveBlock(b, nil)
+		if err != nil {
+			if diag, ok := err.(hcl.Diagnostics); ok {
+				if diag.HasErrors() {
+					diags = append(diags, diag...)
+					continue
+				}
+			} else {
+				return wrapErrorDiagnostic("Invalid block", err, &b.LabelRanges[0], &b.DefRange)
+			}
+		}
+
+		vv := p.blockValues[b]
+
+		t := types[b.Type]
+		lblIndex := setLabel(vv, b.Labels[0])
+
+		oldValue, exists := t.values[b.Labels[0]]
+		if !exists && lblIndex != -1 {
+			if v.Elem().Field(t.idx).Type().Kind() == reflect.Slice {
+				for i := 0; i < v.Elem().Field(t.idx).Len(); i++ {
+					if b.Labels[0] == v.Elem().Field(t.idx).Index(i).Elem().Field(lblIndex).String() {
+						exists = true
+						oldValue = value{Value: v.Elem().Field(t.idx).Index(i), idx: i}
+						break
+					}
+				}
+			}
+		}
+		if exists {
+			if m := oldValue.Value.MethodByName("Merge"); m.IsValid() {
+				m.Call([]reflect.Value{vv})
+			} else {
+				v.Elem().Field(t.idx).Index(oldValue.idx).Set(vv)
+			}
+		} else {
+			slice := v.Elem().Field(t.idx)
+			if slice.IsNil() {
+				slice = reflect.New(t.typ).Elem()
+			}
+			t.values[b.Labels[0]] = value{Value: vv, idx: slice.Len()}
+			v.Elem().Field(t.idx).Set(reflect.Append(slice, vv))
+		}
+	}
+	if diags.HasErrors() {
+		return diags
+	}
+
+	for k := range p.attrs {
+		if err := p.resolveValue(k); err != nil {
+			if diags, ok := err.(hcl.Diagnostics); ok {
+				return diags
+			}
+			return wrapErrorDiagnostic("Invalid attribute", err, &p.attrs[k].Range, &p.attrs[k].Range)
+		}
+	}
+
+	return nil
+}
+
+// wrapErrorDiagnostic wraps an error into a hcl.Diagnostics object.
+// If the error is already an hcl.Diagnostics object, it is returned as is.
+func wrapErrorDiagnostic(message string, err error, subject *hcl.Range, context *hcl.Range) hcl.Diagnostics {
+	switch err := err.(type) {
+	case *hcl.Diagnostic:
+		return hcl.Diagnostics{err}
+	case hcl.Diagnostics:
+		return err
+	default:
+		return hcl.Diagnostics{
+			&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  message,
+				Detail:   err.Error(),
+				Subject:  subject,
+				Context:  context,
+			},
+		}
+	}
+}
+
+func setLabel(v reflect.Value, lbl string) int {
+	// cache field index?
+	numFields := v.Elem().Type().NumField()
+	for i := 0; i < numFields; i++ {
+		for _, t := range strings.Split(v.Elem().Type().Field(i).Tag.Get("hcl"), ",") {
+			if t == "label" {
+				v.Elem().Field(i).Set(reflect.ValueOf(lbl))
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func removeAttributesDiags(diags hcl.Diagnostics, reserved map[string]struct{}, vars map[string]*variable) hcl.Diagnostics {
+	var fdiags hcl.Diagnostics
+	for _, d := range diags {
+		if fout := func(d *hcl.Diagnostic) bool {
+			// https://github.com/docker/buildx/pull/541
+			if d.Detail == "Blocks are not allowed here." {
+				return true
+			}
+			for r := range reserved {
+				// JSON body objects don't handle repeated blocks like HCL but
+				// reserved name attributes should be allowed when multi bodies are merged.
+				// https://github.com/hashicorp/hcl/blob/main/json/spec.md#blocks
+				if strings.HasPrefix(d.Detail, fmt.Sprintf(`Argument "%s" was already set at `, r)) {
+					return true
+				}
+			}
+			for v := range vars {
+				// Do the same for global variables
+				if strings.HasPrefix(d.Detail, fmt.Sprintf(`Argument "%s" was already set at `, v)) {
+					return true
+				}
+			}
+			return false
+		}(d); !fout {
+			fdiags = append(fdiags, d)
+		}
+	}
+	return fdiags
+}

--- a/pkg/buildx/bake/hclparser/stdlib.go
+++ b/pkg/buildx/bake/hclparser/stdlib.go
@@ -1,0 +1,126 @@
+package hclparser
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-cty-funcs/cidr"
+	"github.com/hashicorp/go-cty-funcs/crypto"
+	"github.com/hashicorp/go-cty-funcs/encoding"
+	"github.com/hashicorp/go-cty-funcs/uuid"
+	"github.com/hashicorp/hcl/v2/ext/tryfunc"
+	"github.com/hashicorp/hcl/v2/ext/typeexpr"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+	"github.com/zclconf/go-cty/cty/function/stdlib"
+)
+
+var stdlibFunctions = map[string]function.Function{
+	"absolute":               stdlib.AbsoluteFunc,
+	"add":                    stdlib.AddFunc,
+	"and":                    stdlib.AndFunc,
+	"base64decode":           encoding.Base64DecodeFunc,
+	"base64encode":           encoding.Base64EncodeFunc,
+	"bcrypt":                 crypto.BcryptFunc,
+	"byteslen":               stdlib.BytesLenFunc,
+	"bytesslice":             stdlib.BytesSliceFunc,
+	"can":                    tryfunc.CanFunc,
+	"ceil":                   stdlib.CeilFunc,
+	"chomp":                  stdlib.ChompFunc,
+	"chunklist":              stdlib.ChunklistFunc,
+	"cidrhost":               cidr.HostFunc,
+	"cidrnetmask":            cidr.NetmaskFunc,
+	"cidrsubnet":             cidr.SubnetFunc,
+	"cidrsubnets":            cidr.SubnetsFunc,
+	"csvdecode":              stdlib.CSVDecodeFunc,
+	"coalesce":               stdlib.CoalesceFunc,
+	"coalescelist":           stdlib.CoalesceListFunc,
+	"compact":                stdlib.CompactFunc,
+	"concat":                 stdlib.ConcatFunc,
+	"contains":               stdlib.ContainsFunc,
+	"convert":                typeexpr.ConvertFunc,
+	"distinct":               stdlib.DistinctFunc,
+	"divide":                 stdlib.DivideFunc,
+	"element":                stdlib.ElementFunc,
+	"equal":                  stdlib.EqualFunc,
+	"flatten":                stdlib.FlattenFunc,
+	"floor":                  stdlib.FloorFunc,
+	"formatdate":             stdlib.FormatDateFunc,
+	"format":                 stdlib.FormatFunc,
+	"formatlist":             stdlib.FormatListFunc,
+	"greaterthan":            stdlib.GreaterThanFunc,
+	"greaterthanorequalto":   stdlib.GreaterThanOrEqualToFunc,
+	"hasindex":               stdlib.HasIndexFunc,
+	"indent":                 stdlib.IndentFunc,
+	"index":                  stdlib.IndexFunc,
+	"int":                    stdlib.IntFunc,
+	"jsondecode":             stdlib.JSONDecodeFunc,
+	"jsonencode":             stdlib.JSONEncodeFunc,
+	"keys":                   stdlib.KeysFunc,
+	"join":                   stdlib.JoinFunc,
+	"length":                 stdlib.LengthFunc,
+	"lessthan":               stdlib.LessThanFunc,
+	"lessthanorequalto":      stdlib.LessThanOrEqualToFunc,
+	"log":                    stdlib.LogFunc,
+	"lookup":                 stdlib.LookupFunc,
+	"lower":                  stdlib.LowerFunc,
+	"max":                    stdlib.MaxFunc,
+	"md5":                    crypto.Md5Func,
+	"merge":                  stdlib.MergeFunc,
+	"min":                    stdlib.MinFunc,
+	"modulo":                 stdlib.ModuloFunc,
+	"multiply":               stdlib.MultiplyFunc,
+	"negate":                 stdlib.NegateFunc,
+	"notequal":               stdlib.NotEqualFunc,
+	"not":                    stdlib.NotFunc,
+	"or":                     stdlib.OrFunc,
+	"parseint":               stdlib.ParseIntFunc,
+	"pow":                    stdlib.PowFunc,
+	"range":                  stdlib.RangeFunc,
+	"regexall":               stdlib.RegexAllFunc,
+	"regex":                  stdlib.RegexFunc,
+	"regex_replace":          stdlib.RegexReplaceFunc,
+	"reverse":                stdlib.ReverseFunc,
+	"reverselist":            stdlib.ReverseListFunc,
+	"rsadecrypt":             crypto.RsaDecryptFunc,
+	"sethaselement":          stdlib.SetHasElementFunc,
+	"setintersection":        stdlib.SetIntersectionFunc,
+	"setproduct":             stdlib.SetProductFunc,
+	"setsubtract":            stdlib.SetSubtractFunc,
+	"setsymmetricdifference": stdlib.SetSymmetricDifferenceFunc,
+	"setunion":               stdlib.SetUnionFunc,
+	"sha1":                   crypto.Sha1Func,
+	"sha256":                 crypto.Sha256Func,
+	"sha512":                 crypto.Sha512Func,
+	"signum":                 stdlib.SignumFunc,
+	"slice":                  stdlib.SliceFunc,
+	"sort":                   stdlib.SortFunc,
+	"split":                  stdlib.SplitFunc,
+	"strlen":                 stdlib.StrlenFunc,
+	"substr":                 stdlib.SubstrFunc,
+	"subtract":               stdlib.SubtractFunc,
+	"timeadd":                stdlib.TimeAddFunc,
+	"timestamp":              timestampFunc,
+	"title":                  stdlib.TitleFunc,
+	"trim":                   stdlib.TrimFunc,
+	"trimprefix":             stdlib.TrimPrefixFunc,
+	"trimspace":              stdlib.TrimSpaceFunc,
+	"trimsuffix":             stdlib.TrimSuffixFunc,
+	"try":                    tryfunc.TryFunc,
+	"upper":                  stdlib.UpperFunc,
+	"urlencode":              encoding.URLEncodeFunc,
+	"uuidv4":                 uuid.V4Func,
+	"uuidv5":                 uuid.V5Func,
+	"values":                 stdlib.ValuesFunc,
+	"zipmap":                 stdlib.ZipmapFunc,
+}
+
+// timestampFunc constructs a function that returns a string representation of the current date and time.
+//
+// This function was imported from terraform's datetime utilities.
+var timestampFunc = function.New(&function.Spec{
+	Params: []function.Parameter{},
+	Type:   function.StaticReturnType(cty.String),
+	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+		return cty.StringVal(time.Now().UTC().Format(time.RFC3339)), nil
+	},
+})

--- a/pkg/buildx/bake/hclparser/stdlib.go
+++ b/pkg/buildx/bake/hclparser/stdlib.go
@@ -31,21 +31,21 @@ var stdlibFunctions = map[string]function.Function{
 	"cidrnetmask":            cidr.NetmaskFunc,
 	"cidrsubnet":             cidr.SubnetFunc,
 	"cidrsubnets":            cidr.SubnetsFunc,
-	"csvdecode":              stdlib.CSVDecodeFunc,
 	"coalesce":               stdlib.CoalesceFunc,
 	"coalescelist":           stdlib.CoalesceListFunc,
 	"compact":                stdlib.CompactFunc,
 	"concat":                 stdlib.ConcatFunc,
 	"contains":               stdlib.ContainsFunc,
 	"convert":                typeexpr.ConvertFunc,
+	"csvdecode":              stdlib.CSVDecodeFunc,
 	"distinct":               stdlib.DistinctFunc,
 	"divide":                 stdlib.DivideFunc,
 	"element":                stdlib.ElementFunc,
 	"equal":                  stdlib.EqualFunc,
 	"flatten":                stdlib.FlattenFunc,
 	"floor":                  stdlib.FloorFunc,
-	"formatdate":             stdlib.FormatDateFunc,
 	"format":                 stdlib.FormatFunc,
+	"formatdate":             stdlib.FormatDateFunc,
 	"formatlist":             stdlib.FormatListFunc,
 	"greaterthan":            stdlib.GreaterThanFunc,
 	"greaterthanorequalto":   stdlib.GreaterThanOrEqualToFunc,
@@ -53,10 +53,10 @@ var stdlibFunctions = map[string]function.Function{
 	"indent":                 stdlib.IndentFunc,
 	"index":                  stdlib.IndexFunc,
 	"int":                    stdlib.IntFunc,
+	"join":                   stdlib.JoinFunc,
 	"jsondecode":             stdlib.JSONDecodeFunc,
 	"jsonencode":             stdlib.JSONEncodeFunc,
 	"keys":                   stdlib.KeysFunc,
-	"join":                   stdlib.JoinFunc,
 	"length":                 stdlib.LengthFunc,
 	"lessthan":               stdlib.LessThanFunc,
 	"lessthanorequalto":      stdlib.LessThanOrEqualToFunc,
@@ -70,15 +70,16 @@ var stdlibFunctions = map[string]function.Function{
 	"modulo":                 stdlib.ModuloFunc,
 	"multiply":               stdlib.MultiplyFunc,
 	"negate":                 stdlib.NegateFunc,
-	"notequal":               stdlib.NotEqualFunc,
 	"not":                    stdlib.NotFunc,
+	"notequal":               stdlib.NotEqualFunc,
 	"or":                     stdlib.OrFunc,
 	"parseint":               stdlib.ParseIntFunc,
 	"pow":                    stdlib.PowFunc,
 	"range":                  stdlib.RangeFunc,
-	"regexall":               stdlib.RegexAllFunc,
-	"regex":                  stdlib.RegexFunc,
 	"regex_replace":          stdlib.RegexReplaceFunc,
+	"regex":                  stdlib.RegexFunc,
+	"regexall":               stdlib.RegexAllFunc,
+	"replace":                stdlib.ReplaceFunc,
 	"reverse":                stdlib.ReverseFunc,
 	"reverselist":            stdlib.ReverseListFunc,
 	"rsadecrypt":             crypto.RsaDecryptFunc,
@@ -124,3 +125,11 @@ var timestampFunc = function.New(&function.Spec{
 		return cty.StringVal(time.Now().UTC().Format(time.RFC3339)), nil
 	},
 })
+
+func Stdlib() map[string]function.Function {
+	funcs := make(map[string]function.Function, len(stdlibFunctions))
+	for k, v := range stdlibFunctions {
+		funcs[k] = v
+	}
+	return funcs
+}

--- a/pkg/buildx/bake/remote.go
+++ b/pkg/buildx/bake/remote.go
@@ -1,0 +1,237 @@
+package bake
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"strings"
+
+	"github.com/docker/buildx/builder"
+	"github.com/docker/buildx/driver"
+	"github.com/docker/buildx/util/progress"
+	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/client/llb"
+	gwclient "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/pkg/errors"
+)
+
+type Input struct {
+	State *llb.State
+	URL   string
+}
+
+func ReadRemoteFiles(ctx context.Context, nodes []builder.Node, url string, names []string, pw progress.Writer) ([]File, *Input, error) {
+	var filename string
+	st, ok := detectGitContext(url)
+	if !ok {
+		st, filename, ok = detectHTTPContext(url)
+		if !ok {
+			return nil, nil, errors.Errorf("not url context")
+		}
+	}
+
+	inp := &Input{State: st, URL: url}
+	var files []File
+
+	var node *builder.Node
+	for i, n := range nodes {
+		if n.Err == nil {
+			node = &nodes[i]
+			continue
+		}
+	}
+	if node == nil {
+		return nil, nil, nil
+	}
+
+	c, err := driver.Boot(ctx, ctx, node.Driver, pw)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ch, done := progress.NewChannel(pw)
+	defer func() { <-done }()
+	_, err = c.Build(ctx, client.SolveOpt{}, "buildx", func(ctx context.Context, c gwclient.Client) (*gwclient.Result, error) {
+		def, err := st.Marshal(ctx)
+		if err != nil {
+			return nil, err
+		}
+		res, err := c.Solve(ctx, gwclient.SolveRequest{
+			Definition: def.ToPB(),
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		ref, err := res.SingleRef()
+		if err != nil {
+			return nil, err
+		}
+
+		if filename != "" {
+			files, err = filesFromURLRef(ctx, c, ref, inp, filename, names)
+		} else {
+			files, err = filesFromRef(ctx, ref, names)
+		}
+		return nil, err
+	}, ch)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return files, inp, nil
+}
+
+func IsRemoteURL(url string) bool {
+	if _, _, ok := detectHTTPContext(url); ok {
+		return true
+	}
+	if _, ok := detectGitContext(url); ok {
+		return true
+	}
+	return false
+}
+
+func detectHTTPContext(url string) (*llb.State, string, bool) {
+	if httpPrefix.MatchString(url) {
+		httpContext := llb.HTTP(url, llb.Filename("context"), llb.WithCustomName("[internal] load remote build context"))
+		return &httpContext, "context", true
+	}
+	return nil, "", false
+}
+
+func detectGitContext(ref string) (*llb.State, bool) {
+	found := false
+	if httpPrefix.MatchString(ref) && gitURLPathWithFragmentSuffix.MatchString(ref) {
+		found = true
+	}
+
+	for _, prefix := range []string{"git://", "github.com/", "git@"} {
+		if strings.HasPrefix(ref, prefix) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil, false
+	}
+
+	parts := strings.SplitN(ref, "#", 2)
+	branch := ""
+	if len(parts) > 1 {
+		branch = parts[1]
+	}
+	gitOpts := []llb.GitOption{llb.WithCustomName("[internal] load git source " + ref)}
+
+	st := llb.Git(parts[0], branch, gitOpts...)
+	return &st, true
+}
+
+func isArchive(header []byte) bool {
+	for _, m := range [][]byte{
+		{0x42, 0x5A, 0x68},                   // bzip2
+		{0x1F, 0x8B, 0x08},                   // gzip
+		{0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00}, // xz
+	} {
+		if len(header) < len(m) {
+			continue
+		}
+		if bytes.Equal(m, header[:len(m)]) {
+			return true
+		}
+	}
+
+	r := tar.NewReader(bytes.NewBuffer(header))
+	_, err := r.Next()
+	return err == nil
+}
+
+func filesFromURLRef(ctx context.Context, c gwclient.Client, ref gwclient.Reference, inp *Input, filename string, names []string) ([]File, error) {
+	stat, err := ref.StatFile(ctx, gwclient.StatRequest{Path: filename})
+	if err != nil {
+		return nil, err
+	}
+
+	dt, err := ref.ReadFile(ctx, gwclient.ReadRequest{
+		Filename: filename,
+		Range: &gwclient.FileRange{
+			Length: 1024,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if isArchive(dt) {
+		bc := llb.Scratch().File(llb.Copy(inp.State, filename, "/", &llb.CopyInfo{
+			AttemptUnpack: true,
+		}))
+		inp.State = &bc
+		inp.URL = ""
+		def, err := bc.Marshal(ctx)
+		if err != nil {
+			return nil, err
+		}
+		res, err := c.Solve(ctx, gwclient.SolveRequest{
+			Definition: def.ToPB(),
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		ref, err := res.SingleRef()
+		if err != nil {
+			return nil, err
+		}
+
+		return filesFromRef(ctx, ref, names)
+	}
+
+	inp.State = nil
+	name := inp.URL
+	inp.URL = ""
+
+	if len(dt) > stat.Size() {
+		if stat.Size() > 1024*512 {
+			return nil, errors.Errorf("non-archive definition URL bigger than maximum allowed size")
+		}
+
+		dt, err = ref.ReadFile(ctx, gwclient.ReadRequest{
+			Filename: filename,
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return []File{{Name: name, Data: dt}}, nil
+}
+
+func filesFromRef(ctx context.Context, ref gwclient.Reference, names []string) ([]File, error) {
+	// TODO: auto-remove parent dir in needed
+	var files []File
+
+	isDefault := false
+	if len(names) == 0 {
+		isDefault = true
+		names = defaultFilenames()
+	}
+
+	for _, name := range names {
+		_, err := ref.StatFile(ctx, gwclient.StatRequest{Path: name})
+		if err != nil {
+			if isDefault {
+				continue
+			}
+			return nil, err
+		}
+		dt, err := ref.ReadFile(ctx, gwclient.ReadRequest{Filename: name})
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, File{Name: name, Data: dt})
+	}
+
+	return files, nil
+}

--- a/pkg/buildx/commands/bake.go
+++ b/pkg/buildx/commands/bake.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/containerd/containerd/platforms"
+	"github.com/depot/cli/pkg/buildx/bake"
 	"github.com/depot/cli/pkg/buildx/build"
 	"github.com/depot/cli/pkg/buildx/builder"
 	"github.com/depot/cli/pkg/compose"
@@ -18,7 +19,6 @@ import (
 	depotprogress "github.com/depot/cli/pkg/progress"
 	"github.com/depot/cli/pkg/registry"
 	"github.com/depot/cli/pkg/sbom"
-	"github.com/docker/buildx/bake"
 	buildx "github.com/docker/buildx/build"
 	"github.com/docker/buildx/util/buildflags"
 	"github.com/docker/buildx/util/confutil"

--- a/pkg/buildx/commands/bake.go
+++ b/pkg/buildx/commands/bake.go
@@ -400,7 +400,7 @@ func (t *LocalBakeValidator) Validate(ctx context.Context, _ []builder.Node, _ p
 	// Using a sync.Once because I _think_ the bake file may not always be read
 	// more than one time such as passed over stdin.
 	t.once.Do(func() {
-		files, err := bake.ReadLocalFiles(t.options.files)
+		files, err := bake.ReadLocalFiles(t.options.files, os.Stdin)
 		if err != nil {
 			t.err = err
 			return

--- a/pkg/buildx/commands/print.go
+++ b/pkg/buildx/commands/print.go
@@ -11,7 +11,7 @@ import (
 	"os"
 
 	"github.com/containerd/containerd/platforms"
-	"github.com/docker/buildx/bake"
+	"github.com/depot/cli/pkg/buildx/bake"
 	"github.com/docker/buildx/build"
 	buildxprogress "github.com/docker/buildx/util/progress"
 	"github.com/docker/cli/cli/command"

--- a/pkg/buildx/commands/print.go
+++ b/pkg/buildx/commands/print.go
@@ -28,7 +28,7 @@ func BakePrint(dockerCli command.Cli, targets []string, in BakeOptions) (err err
 		targets = []string{"default"}
 	}
 
-	files, err := bake.ReadLocalFiles(in.files)
+	files, err := bake.ReadLocalFiles(in.files, os.Stdin)
 	if err != nil {
 		return err
 	}

--- a/pkg/compose/compose.go
+++ b/pkg/compose/compose.go
@@ -11,7 +11,7 @@ import (
 	"github.com/compose-spec/compose-go/loader"
 	"github.com/compose-spec/compose-go/types"
 	compose "github.com/compose-spec/compose-go/types"
-	"github.com/docker/buildx/bake"
+	"github.com/depot/cli/pkg/buildx/bake"
 	"gopkg.in/yaml.v2"
 )
 


### PR DESCRIPTION
This PR adds support for `matrix` and HCL `replace` in bake files by importing changes made in buildx 0.11.

For review, it's likely easiest to look at this commit, which is the changes made from buildx 0.10 to 0.11: https://github.com/depot/cli/commit/3f8bba27687332c771cc5769775e4b20f089c87b