### PR TITLE
Allow tag overrides to apply to Compose files

### DIFF
--- a/pkg/buildx/commands/bake.go
+++ b/pkg/buildx/commands/bake.go
@@ -425,7 +425,7 @@ func (t *LocalBakeValidator) Validate(ctx context.Context, _ []builder.Node, _ p
 		}
 
 		for target, opts := range targets {
-			if tag, ok := tags[target]; ok {
+			if tag, ok := tags[target]; ok && len(opts.Tags) == 0 {
 				opts.Tags = tag
 			}
 		}


### PR DESCRIPTION
Overrides like `--set target.tags` apply before `compose.TargetTags(files)` is called, so we need to only set tags with generated tags if no other tags were resolved beforehand.