### PR TITLE
Fix buildkit proxy with buildx 0.13

### DIFF
--- a/pkg/cmd/docker/docker.go
+++ b/pkg/cmd/docker/docker.go
@@ -202,9 +202,6 @@ func runConfigureBuildx(ctx context.Context, dockerCli command.Cli, project, tok
 	}
 
 	version := build.Version
-	if version == "0.0.0-dev" {
-		version = "latest"
-	}
 
 	image := "ghcr.io/depot/cli:" + version
 


### PR DESCRIPTION
Buildx 0.13 no longer issues two `ListWorkers()` calls, so we need to be ready to start the builder after the first `ListWorkers()`