### PR TITLE
Fix the resolution of GitHub Actions cache endpoint

### DIFF
--- a/cmd/depot/main.go
+++ b/cmd/depot/main.go
@@ -29,6 +29,7 @@ func main() {
 	if os.Getenv("DEPOT_DISABLE_OTEL") != "" {
 		helpers.DisableOTEL()
 	}
+	helpers.FixGitHubActionsCacheEnv()
 
 	cpuProfile := os.Getenv("DEPOT_CPU_PROFILE")
 	var cpuProfileFile *os.File

--- a/pkg/helpers/gha.go
+++ b/pkg/helpers/gha.go
@@ -1,0 +1,12 @@
+package helpers
+
+import "os"
+
+// If the CLI is running inside a Depot GitHub Actions runner, restore the original
+// GitHub Actions cache URL so that the remote BuildKit doesn't attempt to use the internal cache.
+func FixGitHubActionsCacheEnv() {
+	original := os.Getenv("GACTIONSCACHE_URL")
+	if original != "" {
+		os.Setenv("ACTIONS_CACHE_URL", original)
+	}
+}


### PR DESCRIPTION
Fixes the resolution of the GitHub Actions cache endpoint when running inside a Depot Actions runner.