### PR TITLE
Fix auth ServerAddress for containerd content store

### DIFF
--- a/pkg/cmd/pull/options.go
+++ b/pkg/cmd/pull/options.go
@@ -44,12 +44,14 @@ func buildPullOpt(msg *cliv1.GetPullInfoResponse, userTags []string, platform, p
 		tags = msg.Options[0].Tags
 	}
 
+	serverAddress := "registry.depot.dev"
 	opts := load.PullOptions{
-		UserTags:  tags,
-		Quiet:     progress == prog.PrinterModeQuiet,
-		KeepImage: true,
-		Username:  &msg.Username,
-		Password:  &msg.Password,
+		UserTags:      tags,
+		Quiet:         progress == prog.PrinterModeQuiet,
+		KeepImage:     true,
+		Username:      &msg.Username,
+		Password:      &msg.Password,
+		ServerAddress: &serverAddress,
 	}
 	if platform != "" {
 		opts.Platform = &platform
@@ -97,12 +99,14 @@ func bakePullOpts(msg *cliv1.GetPullInfoResponse, targets, userTags []string, pl
 			}
 		}
 
+		serverAddress := "registry.depot.dev"
 		opts := load.PullOptions{
-			UserTags:  tags,
-			Quiet:     progress == prog.PrinterModeQuiet,
-			KeepImage: true,
-			Username:  &msg.Username,
-			Password:  &msg.Password,
+			UserTags:      tags,
+			Quiet:         progress == prog.PrinterModeQuiet,
+			KeepImage:     true,
+			Username:      &msg.Username,
+			Password:      &msg.Password,
+			ServerAddress: &serverAddress,
 		}
 		if platform != "" {
 			opts.Platform = &platform

--- a/pkg/load/cli.go
+++ b/pkg/load/cli.go
@@ -20,12 +20,13 @@ type DepotLoadOptions struct {
 
 // Options to download from the Depot hosted registry and tag the image with the user provide tag.
 type PullOptions struct {
-	UserTags  []string // Tags the user wishes the image to have.
-	Quiet     bool     // No logs plz
-	Username  *string  // If set, use this username for the registry.
-	Password  *string  // If set, use this password for the registry.
-	Platform  *string  // If set, only pull the image if it matches the platform.
-	KeepImage bool     // If set, do not remove the image after pulling and tagging with user tags.
+	UserTags      []string // Tags the user wishes the image to have.
+	Quiet         bool     // No logs plz
+	Username      *string  // If set, use this username for the registry.
+	Password      *string  // If set, use this password for the registry.
+	ServerAddress *string  // If set, use this server address for the registry.
+	Platform      *string  // If set, only pull the image if it matches the platform.
+	KeepImage     bool     // If set, do not remove the image after pulling and tagging with user tags.
 }
 
 // WithDepotImagePull updates buildOpts to push to the depot user's personal registry.

--- a/pkg/load/pull.go
+++ b/pkg/load/pull.go
@@ -29,8 +29,9 @@ func ImagePullPrivileged(ctx context.Context, dockerapi docker.APIClient, imageN
 	dockerPullOpts := types.ImagePullOptions{}
 	if opts.Username != nil && opts.Password != nil {
 		authConfig := registry.AuthConfig{
-			Username: *opts.Username,
-			Password: *opts.Password,
+			Username:      *opts.Username,
+			Password:      *opts.Password,
+			ServerAddress: "registry.depot.dev",
 		}
 		buf, err := json.Marshal(authConfig)
 		if err != nil {

--- a/pkg/load/pull.go
+++ b/pkg/load/pull.go
@@ -29,9 +29,11 @@ func ImagePullPrivileged(ctx context.Context, dockerapi docker.APIClient, imageN
 	dockerPullOpts := types.ImagePullOptions{}
 	if opts.Username != nil && opts.Password != nil {
 		authConfig := registry.AuthConfig{
-			Username:      *opts.Username,
-			Password:      *opts.Password,
-			ServerAddress: "registry.depot.dev",
+			Username: *opts.Username,
+			Password: *opts.Password,
+		}
+		if opts.ServerAddress != nil {
+			authConfig.ServerAddress = *opts.ServerAddress
 		}
 		buf, err := json.Marshal(authConfig)
 		if err != nil {


### PR DESCRIPTION
This is needed when pulling into the containerd content store, as containerd will assume Docker Hub as the server unless an address is specified.