### PR TITLE
feat: log when getting git provenance

### DIFF
--- a/pkg/buildx/build/build.go
+++ b/pkg/buildx/build/build.go
@@ -29,6 +29,7 @@ import (
 	depotbuild "github.com/depot/cli/pkg/build"
 	"github.com/depot/cli/pkg/buildx/imagetools"
 	"github.com/depot/cli/pkg/debuglog"
+	depotprogress "github.com/depot/cli/pkg/progress"
 	"github.com/distribution/reference"
 	"github.com/docker/buildx/builder"
 	"github.com/docker/buildx/driver"
@@ -819,7 +820,9 @@ func BuildWithResultHandler(ctx context.Context, nodes []builder.Node, opt map[s
 		multiDriver := len(m[k]) > 1
 		hasMobyDriver := false
 		debuglog.Log("Fetching git attributes")
+		finishLog := depotprogress.StartLog(w, "[internal] fetching git attributes")
 		gitattrs, err := getGitAttributes(ctx, opt.Inputs.ContextPath, opt.Inputs.DockerfilePath)
+		finishLog(err)
 		if err != nil {
 			logrus.Warn(err)
 		}

--- a/pkg/progress/log.go
+++ b/pkg/progress/log.go
@@ -1,0 +1,42 @@
+package progress
+
+import (
+	"time"
+
+	"github.com/docker/buildx/util/progress"
+	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/identity"
+	"github.com/opencontainers/go-digest"
+)
+
+// Log is a helper to log a message with a progress.Writer.
+// progress.Writer is pretty intricate and thus can be a lot of boilerplate.
+
+func StartLog(w progress.Writer, message string) func(err error) {
+	dgst := digest.FromBytes([]byte(identity.NewID()))
+	tm := time.Now()
+	w.Write(&client.SolveStatus{
+		Vertexes: []*client.Vertex{{
+			Digest:  dgst,
+			Name:    message,
+			Started: &tm,
+		}},
+	})
+
+	return func(err error) {
+		tm2 := time.Now()
+		errMsg := ""
+		if err != nil {
+			errMsg = err.Error()
+		}
+		w.Write(&client.SolveStatus{
+			Vertexes: []*client.Vertex{{
+				Digest:    dgst,
+				Name:      message,
+				Started:   &tm,
+				Completed: &tm2,
+				Error:     errMsg,
+			}},
+		})
+	}
+}


### PR DESCRIPTION
Getting ignored git files can take significant amount of time. This now logs the start and end times of git checks.

<img width="854" alt="image" src="https://github.com/depot/cli/assets/1922921/2d3952eb-0aa1-4d98-9ff1-c792526a8dc0">

