### PR TITLE
Remove unused ProxyImage and UseLocalRegistry fields

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -18,10 +18,8 @@ import (
 )
 
 type Build struct {
-	ID               string
-	Token            string
-	UseLocalRegistry bool
-	ProxyImage       string
+	ID    string
+	Token string
 	// BuildURL is the URL to the build on the depot web UI.
 	BuildURL string
 	Finish   func(error)
@@ -104,10 +102,6 @@ func NewBuild(ctx context.Context, req *cliv1.CreateBuildRequest, token string) 
 
 	build.Response = res
 	build.BuildURL = res.Msg.BuildUrl
-	build.UseLocalRegistry = res.Msg.GetRegistry() != nil && res.Msg.GetRegistry().CanUseLocalRegistry
-	if res.Msg.GetRegistry() != nil {
-		build.ProxyImage = res.Msg.GetRegistry().ProxyImage
-	}
 
 	return build, nil
 }

--- a/pkg/buildx/commands/bake.go
+++ b/pkg/buildx/commands/bake.go
@@ -117,11 +117,10 @@ func RunBake(dockerCli command.Cli, in BakeOptions, validator BakeValidator) (er
 		buildOpts, pullOpts = load.WithDepotImagePull(
 			buildOpts,
 			load.DepotLoadOptions{
-				UseLocalRegistry: in.DepotOptions.useLocalRegistry,
-				Project:          in.DepotOptions.project,
-				BuildID:          in.DepotOptions.buildID,
-				IsBake:           true,
-				ProgressMode:     in.progress,
+				Project:      in.DepotOptions.project,
+				BuildID:      in.DepotOptions.buildID,
+				IsBake:       true,
+				ProgressMode: in.progress,
 			},
 		)
 	}
@@ -209,7 +208,7 @@ func RunBake(dockerCli command.Cli, in BakeOptions, validator BakeValidator) (er
 			// For now, we will fallback by rebuilding with load.
 			if in.exportLoad {
 				progress.Write(printer, "[load] fast load failed; retrying", func() error { return err })
-				buildOpts, _ = load.WithDepotImagePull(fallbackOpts, load.DepotLoadOptions{})
+				buildOpts = load.WithDockerLoad(fallbackOpts)
 				_, err = build.DepotBuild(ctx, buildxNodes, buildOpts, dockerClient, dockerConfigDir, printer, nil, in.DepotOptions.build)
 			}
 
@@ -320,8 +319,6 @@ func BakeCmd(dockerCli command.Cli) *cobra.Command {
 			options.buildID = build.ID
 			options.buildURL = build.BuildURL
 			options.token = build.Token
-			options.useLocalRegistry = build.UseLocalRegistry
-			options.proxyImage = build.ProxyImage
 			options.build = &build
 
 			if options.allowNoOutput {

--- a/pkg/buildx/commands/build.go
+++ b/pkg/buildx/commands/build.go
@@ -118,8 +118,6 @@ type DepotOptions struct {
 	buildPlatform string
 	build         *depotbuild.Build
 
-	useLocalRegistry      bool
-	proxyImage            string
 	save                  bool
 	additionalTags        []string
 	additionalCredentials []depotbuild.Credential
@@ -236,11 +234,10 @@ func buildTargets(ctx context.Context, dockerCli command.Cli, nodes []builder.No
 		opts, pullOpts = load.WithDepotImagePull(
 			opts,
 			load.DepotLoadOptions{
-				UseLocalRegistry: depotOpts.useLocalRegistry,
-				Project:          depotOpts.project,
-				BuildID:          depotOpts.buildID,
-				IsBake:           false,
-				ProgressMode:     progressMode,
+				Project:      depotOpts.project,
+				BuildID:      depotOpts.buildID,
+				IsBake:       false,
+				ProgressMode: progressMode,
 			},
 		)
 	}
@@ -347,7 +344,7 @@ func buildTargets(ctx context.Context, dockerCli command.Cli, nodes []builder.No
 
 			if retryable {
 				progress.Write(printer, "[load] fast load failed; retrying", func() error { return err })
-				opts, _ = load.WithDepotImagePull(fallbackOpts, load.DepotLoadOptions{})
+				opts = load.WithDockerLoad(fallbackOpts)
 				_, err = depotbuildxbuild.DepotBuildWithResultHandler(ctx, buildxNodes, opts, dockerClient, dockerConfigDir, printer, nil, nil, allowNoOutput, depotOpts.build)
 			}
 		}
@@ -687,8 +684,6 @@ func BuildCmd(dockerCli command.Cli) *cobra.Command {
 			options.buildID = build.ID
 			options.buildURL = build.BuildURL
 			options.token = build.Token
-			options.useLocalRegistry = build.UseLocalRegistry
-			options.proxyImage = build.ProxyImage
 			options.build = &build
 
 			if options.allowNoOutput {

--- a/pkg/helpers/build.go
+++ b/pkg/helpers/build.go
@@ -41,14 +41,6 @@ func BeginBuild(ctx context.Context, req *cliv1.CreateBuildRequest, token string
 		profilerToken = build.Response.Msg.Profiler.Token
 	}
 
-	if os.Getenv("DEPOT_USE_LOCAL_REGISTRY") != "" {
-		build.UseLocalRegistry = true
-	}
-
-	if proxyImage := os.Getenv("DEPOT_PROXY_IMAGE"); proxyImage != "" {
-		build.ProxyImage = proxyImage
-	}
-
 	profiler.StartProfiler(build.ID, profilerToken)
 
 	return build, err


### PR DESCRIPTION
The UseLocalRegistry feature flag is always true, and we don't do anything with ProxyImage returned from the API