### PR TITLE
feat(bake): allow concurrent projects with x-depot bake extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,12 @@ For all other platforms, you can download the binary directly from [the latest r
 
 Run a Docker build from a HCL, JSON, or Compose file using Depot's remote builder infrastructure. This command accepts all the command line flags as Docker's `docker buildx bake` command, you can run `depot bake --help` for the full list.
 
-The `bake` command needs to know which [project](https://depot.dev/docs/core-concepts#projects) id to route the build to. For passing the project id you have three options available to you:
+The `bake` command needs to know which [project](https://depot.dev/docs/core-concepts#projects) id to route the build to. For passing the project id you have four options available to you:
 
 1. Run `depot init` at the root of your repository and commit the resulting `depot.json` file
 2. Use the `--project` flag in your `depot bake` command
-3. Set the `DEPOT_PROJECT_ID` environment variable which will be automatically detected
+3. Set the `DEPOT_PROJECT_ID` environment variable which will be automatically detected.
+4. Use [`x-depot` ](http://depot.dev/docs/cli/reference#compose-support) extension field in your `docker-compose.yml` file.
 
 By default, `depot bake` will leave the built image in the remote builder cache. If you would like to download the image to your local Docker daemon (for instance, to `docker run` the result), you can use the `--load` flag.
 
@@ -107,6 +108,43 @@ If you want to build a specific target in the bake file, you can specify it in t
 
 ```shell
 depot bake -f docker-bake.hcl original
+```
+
+#### compose support
+
+Depot supports using bake to build [Docker Compose](https://depot.dev/blog/depot-with-docker-compose) files.
+
+To use `depot bake` with a Docker Compose file, you can specify the file with the `-f` flag:
+
+```shell
+depot bake -f docker-compose.yml
+```
+
+Compose files have special extensions prefixed with `x-` to give additional information to the build process.
+
+In this example, the `x-bake` extension is used to specify the tags for each service
+and the `x-depot` extension is used to specify different project IDs for each.
+
+```yaml
+services:
+  mydb:
+    build:
+      dockerfile: ./Dockerfile.db
+      x-bake:
+        tags:
+          - ghcr.io/myorg/mydb:latest
+          - ghcr.io/myorg/mydb:v1.0.0
+      x-depot:
+        project-id: 1234567890
+  myapp:
+    build:
+      dockerfile: ./Dockerfile.app
+      x-bake:
+        tags:
+          - ghcr.io/myorg/myapp:latest
+          - ghcr.io/myorg/myapp:v1.0.0
+      x-depot:
+        project-id: 9876543210
 ```
 
 #### Flags for `bake`

--- a/pkg/buildx/bake/bake.go
+++ b/pkg/buildx/bake/bake.go
@@ -947,6 +947,9 @@ func NewDepotBakeOptions(defaultProjectID string, targets map[string]*Target, in
 		if projectID == "" {
 			projectID = defaultProjectID
 		}
+		if projectID == "" {
+			return nil, errors.Errorf("Project ID is missing for target %s, please specify with --project, DEPOT_PROJECT_ID, or run `depot init`", targetName)
+		}
 		buildOpt, err := toBuildOpt(target, input)
 		if err != nil {
 			return nil, err

--- a/pkg/buildx/bake/bake.go
+++ b/pkg/buildx/bake/bake.go
@@ -628,6 +628,8 @@ type Target struct {
 
 	// linked is a private field to mark a target used as a linked one
 	linked bool
+
+	ProjectID string `json:"project_id,omitempty" hcl:"project_id,optional" cty:"project_id"`
 }
 
 var _ hclparser.WithEvalContexts = &Target{}
@@ -729,6 +731,9 @@ func (t *Target) Merge(t2 *Target) {
 	}
 	if t2.NoCacheFilter != nil { // merge
 		t.NoCacheFilter = append(t.NoCacheFilter, t2.NoCacheFilter...)
+	}
+	if t2.ProjectID != "" {
+		t.ProjectID = t2.ProjectID
 	}
 	t.Inherits = append(t.Inherits, t2.Inherits...)
 }
@@ -927,16 +932,47 @@ func (t *Target) GetName(ectx *hcl.EvalContext, block *hcl.Block, loadDeps func(
 	return value.AsString(), nil
 }
 
-func TargetsToBuildOpt(m map[string]*Target, inp *Input) (map[string]build.Options, error) {
-	m2 := make(map[string]build.Options, len(m))
-	for k, v := range m {
-		bo, err := toBuildOpt(v, inp)
+type DepotBakeOptions struct {
+	ProjectTargetOptions map[string]map[string]build.Options
+}
+
+// input is only used for remote bake.
+func NewDepotBakeOptions(defaultProjectID string, targets map[string]*Target, input *Input) (*DepotBakeOptions, error) {
+	opts := &DepotBakeOptions{
+		ProjectTargetOptions: map[string]map[string]build.Options{},
+	}
+
+	for targetName, target := range targets {
+		projectID := target.ProjectID
+		if projectID == "" {
+			projectID = defaultProjectID
+		}
+		buildOpt, err := toBuildOpt(target, input)
 		if err != nil {
 			return nil, err
 		}
-		m2[k] = *bo
+
+		if _, ok := opts.ProjectTargetOptions[projectID]; !ok {
+			opts.ProjectTargetOptions[projectID] = map[string]build.Options{}
+		}
+		opts.ProjectTargetOptions[projectID][targetName] = *buildOpt
 	}
-	return m2, nil
+
+	return opts, nil
+}
+
+// ProjectOpts returns the targeted build options for a specific project ID.
+func (o *DepotBakeOptions) ProjectOpts(id string) map[string]build.Options {
+	return o.ProjectTargetOptions[id]
+}
+
+// ProjectIDs returns the x-depot project IDs.
+func (o *DepotBakeOptions) ProjectIDs() []string {
+	projectIDs := make([]string, 0, len(o.ProjectTargetOptions))
+	for projectID := range o.ProjectTargetOptions {
+		projectIDs = append(projectIDs, projectID)
+	}
+	return projectIDs
 }
 
 func updateContext(t *build.Inputs, inp *Input) {

--- a/pkg/buildx/bake/compose.go
+++ b/pkg/buildx/bake/compose.go
@@ -232,6 +232,10 @@ type xbake struct {
 	// docs/manuals/bake/compose-file.md#extension-field-with-x-bake
 }
 
+type XDepot struct {
+	ProjectID string `yaml:"project-id,omitempty"`
+}
+
 type stringMap map[string]string
 type stringArray []string
 
@@ -253,6 +257,18 @@ func (sa *stringArray) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // composeExtTarget converts Compose build extension x-bake to bake Target
 // https://github.com/compose-spec/compose-spec/blob/master/spec.md#extension
 func (t *Target) composeExtTarget(exts map[string]interface{}) error {
+	var xdepot XDepot
+	buf, ok := exts["x-depot"]
+	if ok && buf != nil {
+		yb, _ := yaml.Marshal(buf)
+		if err := yaml.Unmarshal(yb, &xdepot); err != nil {
+			return err
+		}
+		if xdepot.ProjectID != "" {
+			t.ProjectID = xdepot.ProjectID
+		}
+	}
+
 	var xb xbake
 
 	ext, ok := exts["x-bake"]

--- a/pkg/buildx/commands/bake.go
+++ b/pkg/buildx/commands/bake.go
@@ -82,7 +82,7 @@ func RunBake(dockerCli command.Cli, in BakeOptions, validator BakeValidator, pri
 		return err
 	}
 
-	validatedOpts, requestedTargets, err := validator.Validate(ctx, nodes, printer)
+	validatedOpts, _, err := validator.Validate(ctx, nodes, printer)
 	if err != nil {
 		return err
 	}
@@ -90,6 +90,11 @@ func RunBake(dockerCli command.Cli, in BakeOptions, validator BakeValidator, pri
 	buildOpts := validatedOpts.ProjectOpts(in.project)
 	if buildOpts == nil {
 		return fmt.Errorf("project %s build options not found", in.project)
+	}
+
+	requestedTargets := make([]string, 0, len(buildOpts))
+	for target := range buildOpts {
+		requestedTargets = append(requestedTargets, target)
 	}
 
 	var (

--- a/pkg/buildx/commands/build.go
+++ b/pkg/buildx/commands/build.go
@@ -350,7 +350,7 @@ func buildTargets(ctx context.Context, dockerCli command.Cli, nodes []builder.No
 
 	printWarnings(os.Stderr, printer.Warnings(), progressMode)
 	if depotOpts.save {
-		printSaveUsage(depotOpts.project, depotOpts.buildID, progressMode, nil)
+		printSaveHelp(depotOpts.project, depotOpts.buildID, progressMode, nil)
 	}
 	linter.Print(os.Stderr, progressMode)
 

--- a/pkg/buildx/commands/lint.go
+++ b/pkg/buildx/commands/lint.go
@@ -84,13 +84,13 @@ type Linter struct {
 	FailureMode LintFailure
 	Clients     []*client.Client
 	BuildxNodes []builder.Node
-	printer     *progress.Printer
+	printer     progress.Writer
 
 	mu     sync.Mutex
 	issues map[string][]client.VertexWarning
 }
 
-func NewLinter(printer *progress.Printer, failureMode LintFailure, clients []*client.Client, nodes []builder.Node) *Linter {
+func NewLinter(printer progress.Writer, failureMode LintFailure, clients []*client.Client, nodes []builder.Node) *Linter {
 	return &Linter{
 		FailureMode: failureMode,
 		Clients:     clients,

--- a/pkg/progresshelper/shared.go
+++ b/pkg/progresshelper/shared.go
@@ -1,0 +1,75 @@
+package progresshelper
+
+import (
+	"context"
+	"os"
+	"sync"
+	"sync/atomic"
+
+	"github.com/docker/buildx/util/progress"
+	"github.com/moby/buildkit/client"
+	"github.com/opencontainers/go-digest"
+)
+
+var _ progress.Writer = (*SharedPrinter)(nil)
+
+// SharedPrinter is a reference counted progress.Writer that can be used
+// to share progress updates between several concurrent builds.
+// Originally used for bake files with multiple projects.
+//
+// the `Wait()` method will wait until all writers have
+// run Wait().
+type SharedPrinter struct {
+	wg      sync.WaitGroup
+	printer *progress.Printer
+	cancel  context.CancelFunc
+
+	numPrinters atomic.Int32
+}
+
+func NewSharedPrinter(mode string) (*SharedPrinter, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	printer, err := progress.NewPrinter(ctx, os.Stderr, os.Stderr, mode)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	return &SharedPrinter{
+		printer: printer,
+		cancel:  cancel,
+	}, nil
+}
+
+// Add increments the reference count of the writer.
+// Each call to Add() should be matched with a call to Wait().
+func (w *SharedPrinter) Add() {
+	w.wg.Add(1)
+	w.numPrinters.Add(1)
+}
+
+func (w *SharedPrinter) Wait() error {
+	w.wg.Done()
+	w.wg.Wait()
+
+	w.cancel()
+
+	lastPrinter := w.numPrinters.Add(-1) == 0
+
+	// The docker progress writer will only return an
+	// error if it is a context cancellation error.
+	//
+	// Only the last printer will be the one to stop the docker printer as
+	// the docker printer closes channels.
+	if lastPrinter {
+		_ = w.printer.Wait()
+	}
+
+	return nil
+}
+
+func (w *SharedPrinter) Write(status *client.SolveStatus) { w.printer.Write(status) }
+func (w *SharedPrinter) ClearLogSource(v interface{})     { w.printer.ClearLogSource(v) }
+func (w *SharedPrinter) ValidateLogSource(d digest.Digest, v interface{}) bool {
+	return w.printer.ValidateLogSource(d, v)
+}


### PR DESCRIPTION
Adding x-depot to compose files allows different services to be built on different projects.  This allows faster concurrent builds.