### PR TITLE
Cleanup temporary certificate files after build

### DIFF
--- a/cmd/buildctl/main.go
+++ b/cmd/buildctl/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/depot/cli/internal/build"
+	"github.com/depot/cli/pkg/cleanup"
 	"github.com/depot/cli/pkg/cmd/buildctl"
 	"github.com/getsentry/sentry-go"
 )
@@ -25,6 +26,8 @@ func runMain() int {
 			log.Fatalf("sentry.Init: %s", err)
 		}
 	}
+
+	defer cleanup.CleanupTmpfiles()
 
 	err := buildctl.NewBuildctl().Execute()
 	if err != nil {

--- a/cmd/depot/main.go
+++ b/cmd/depot/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/depot/cli/internal/build"
 	"github.com/depot/cli/internal/update"
 	"github.com/depot/cli/pkg/api"
+	"github.com/depot/cli/pkg/cleanup"
 	"github.com/depot/cli/pkg/cmd/root"
 	"github.com/depot/cli/pkg/config"
 	"github.com/depot/cli/pkg/helpers"
@@ -81,6 +82,8 @@ func runMain() int {
 			log.Fatalf("sentry.Init: %s", err)
 		}
 	}
+
+	defer cleanup.CleanupTmpfiles()
 
 	buildVersion := build.Version
 	buildDate := build.Date

--- a/pkg/cleanup/tmpfiles.go
+++ b/pkg/cleanup/tmpfiles.go
@@ -1,0 +1,15 @@
+package cleanup
+
+import "os"
+
+var tmpfiles = []string{}
+
+func RegisterTmpfile(filename string) {
+	tmpfiles = append(tmpfiles, filename)
+}
+
+func CleanupTmpfiles() {
+	for _, filename := range tmpfiles {
+		_ = os.Remove(filename)
+	}
+}

--- a/pkg/machine/machine.go
+++ b/pkg/machine/machine.go
@@ -11,6 +11,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/depot/cli/pkg/api"
+	"github.com/depot/cli/pkg/cleanup"
 	cliv1 "github.com/depot/cli/pkg/proto/depot/cli/v1"
 	"github.com/depot/cli/pkg/proto/depot/cli/v1/cliv1connect"
 	"github.com/moby/buildkit/client"
@@ -180,6 +181,7 @@ func (m *Machine) Client(ctx context.Context) (*client.Client, error) {
 			return nil, errors.Wrap(err, "failed to write cert to temp file")
 		}
 		cert := file.Name()
+		cleanup.RegisterTmpfile(cert)
 
 		file, err = os.CreateTemp("", "depot-key")
 		if err != nil {
@@ -191,6 +193,7 @@ func (m *Machine) Client(ctx context.Context) (*client.Client, error) {
 			return nil, errors.Wrap(err, "failed to write key to temp file")
 		}
 		key := file.Name()
+		cleanup.RegisterTmpfile(key)
 
 		file, err = os.CreateTemp("", "depot-ca-cert")
 		if err != nil {
@@ -202,6 +205,7 @@ func (m *Machine) Client(ctx context.Context) (*client.Client, error) {
 			return nil, errors.Wrap(err, "failed to write CA cert to temp file")
 		}
 		caCert := file.Name()
+		cleanup.RegisterTmpfile(caCert)
 
 		opts = append(opts, client.WithCredentials(m.ServerName, caCert, cert, key))
 	}


### PR DESCRIPTION
The OS normally cleans these up regularly, but this PR makes the CLI attempt cleanup first.