### PR TITLE
Fix GHA cache URL in Depot runners

### DIFF
--- a/pkg/helpers/gha.go
+++ b/pkg/helpers/gha.go
@@ -5,7 +5,12 @@ import "os"
 // If the CLI is running inside a Depot GitHub Actions runner, restore the original
 // GitHub Actions cache URL so that the remote BuildKit doesn't attempt to use the internal cache.
 func FixGitHubActionsCacheEnv() {
-	original := os.Getenv("GACTIONSCACHE_URL")
+	original := os.Getenv("UPSTREAM_ACTIONS_CACHE_URL")
+
+	if original == "" {
+		original = os.Getenv("GACTIONSCACHE_URL")
+	}
+
 	if original != "" {
 		os.Setenv("ACTIONS_CACHE_URL", original)
 	}


### PR DESCRIPTION
Restores the upstream Actions cache URL if present.