### PR TITLE
Allow specifying `DOCKER_CONFIG` via `--config`

### DIFF
--- a/pkg/buildx/commands/bake.go
+++ b/pkg/buildx/commands/bake.go
@@ -14,6 +14,7 @@ import (
 	"github.com/depot/cli/pkg/buildx/build"
 	"github.com/depot/cli/pkg/buildx/builder"
 	"github.com/depot/cli/pkg/compose"
+	"github.com/depot/cli/pkg/dockerclient"
 	"github.com/depot/cli/pkg/helpers"
 	"github.com/depot/cli/pkg/load"
 	"github.com/depot/cli/pkg/progresshelper"
@@ -208,7 +209,7 @@ func RunBake(dockerCli command.Cli, in BakeOptions, validator BakeValidator, pri
 	return nil
 }
 
-func BakeCmd(dockerCli command.Cli) *cobra.Command {
+func BakeCmd() *cobra.Command {
 	var options BakeOptions
 
 	cmd := &cobra.Command{
@@ -216,6 +217,11 @@ func BakeCmd(dockerCli command.Cli) *cobra.Command {
 		Aliases: []string{"f"},
 		Short:   "Build from a file",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			dockerCli, err := dockerclient.NewDockerCLI()
+			if err != nil {
+				return err
+			}
+
 			// TODO: remove when upgrading to buildx 0.12
 			for idx, file := range options.files {
 				if strings.HasPrefix(file, "cwd://") {

--- a/pkg/buildx/commands/build.go
+++ b/pkg/buildx/commands/build.go
@@ -25,6 +25,7 @@ import (
 	"github.com/depot/cli/pkg/ci"
 	"github.com/depot/cli/pkg/cmd/docker"
 	"github.com/depot/cli/pkg/debuglog"
+	"github.com/depot/cli/pkg/dockerclient"
 	"github.com/depot/cli/pkg/helpers"
 	"github.com/depot/cli/pkg/load"
 	"github.com/depot/cli/pkg/progresshelper"
@@ -604,7 +605,7 @@ func validateBuildOptions(in *buildOptions) (map[string]build.Options, error) {
 	return map[string]build.Options{defaultTargetName: opts}, nil
 }
 
-func BuildCmd(dockerCli command.Cli) *cobra.Command {
+func BuildCmd() *cobra.Command {
 	options := newBuildOptions()
 
 	cmd := &cobra.Command{
@@ -613,6 +614,11 @@ func BuildCmd(dockerCli command.Cli) *cobra.Command {
 		Short:   "Start a build",
 		Args:    cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			dockerCli, err := dockerclient.NewDockerCLI()
+			if err != nil {
+				return err
+			}
+
 			options.contextPath = args[0]
 			cmd.Flags().VisitAll(checkWarnedFlags)
 

--- a/pkg/cmd/bake/bake.go
+++ b/pkg/cmd/bake/bake.go
@@ -2,10 +2,9 @@ package init
 
 import (
 	"github.com/depot/cli/pkg/buildx/commands"
-	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
 )
 
-func NewCmdBake(dockerCli command.Cli) *cobra.Command {
-	return commands.BakeCmd(dockerCli)
+func NewCmdBake() *cobra.Command {
+	return commands.BakeCmd()
 }

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -3,10 +3,9 @@ package build
 import (
 	"github.com/depot/cli/pkg/buildx/commands"
 	_ "github.com/depot/cli/pkg/buildxdriver"
-	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
 )
 
-func NewCmdBuild(dockerCli command.Cli) *cobra.Command {
-	return commands.BuildCmd(dockerCli)
+func NewCmdBuild() *cobra.Command {
+	return commands.BuildCmd()
 }

--- a/pkg/cmd/docker/docker.go
+++ b/pkg/cmd/docker/docker.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/depot/cli/internal/build"
 	"github.com/depot/cli/pkg/buildx/imagetools"
+	depotdockerclient "github.com/depot/cli/pkg/dockerclient"
 	"github.com/depot/cli/pkg/helpers"
 	"github.com/docker/buildx/store"
 	"github.com/docker/buildx/store/storeutil"
@@ -31,7 +32,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewCmdConfigureDocker(dockerCli command.Cli) *cobra.Command {
+func NewCmdConfigureDocker() *cobra.Command {
 	uninstall := false
 	var (
 		project string
@@ -42,6 +43,11 @@ func NewCmdConfigureDocker(dockerCli command.Cli) *cobra.Command {
 		Use:   "configure-docker",
 		Short: "Configure Docker to use Depot for builds",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			dockerCli, err := depotdockerclient.NewDockerCLI()
+			if err != nil {
+				return err
+			}
+
 			dir := config.Dir()
 			if err := os.MkdirAll(dir, 0755); err != nil {
 				return errors.Wrap(err, "could not create docker config")

--- a/pkg/cmd/exec/exec.go
+++ b/pkg/cmd/exec/exec.go
@@ -18,11 +18,10 @@ import (
 	cliv1 "github.com/depot/cli/pkg/proto/depot/cli/v1"
 	"github.com/docker/buildx/util/progress"
 	"github.com/docker/cli/cli"
-	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
 )
 
-func NewCmdExec(dockerCli command.Cli) *cobra.Command {
+func NewCmdExec() *cobra.Command {
 	var (
 		envVar       string
 		token        string

--- a/pkg/cmd/pull/pull.go
+++ b/pkg/cmd/pull/pull.go
@@ -7,6 +7,7 @@ import (
 	"connectrpc.com/connect"
 	depotapi "github.com/depot/cli/pkg/api"
 	"github.com/depot/cli/pkg/ci"
+	"github.com/depot/cli/pkg/dockerclient"
 	"github.com/depot/cli/pkg/helpers"
 	"github.com/depot/cli/pkg/load"
 	cliv1 "github.com/depot/cli/pkg/proto/depot/cli/v1"
@@ -17,7 +18,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-func NewCmdPull(dockerCli command.Cli) *cobra.Command {
+func NewCmdPull() *cobra.Command {
 	var (
 		token     string
 		projectID string
@@ -33,6 +34,11 @@ func NewCmdPull(dockerCli command.Cli) *cobra.Command {
 		Short: "Pull a project's build from the Depot ephemeral registry",
 		Args:  cli.RequiresMaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			dockerCli, err := dockerclient.NewDockerCLI()
+			if err != nil {
+				return err
+			}
+
 			if len(args) > 0 {
 				buildID = args[0]
 			}

--- a/pkg/cmd/pulltoken/pulltoken.go
+++ b/pkg/cmd/pulltoken/pulltoken.go
@@ -8,11 +8,10 @@ import (
 	"github.com/depot/cli/pkg/helpers"
 	cliv1 "github.com/depot/cli/pkg/proto/depot/cli/v1"
 	"github.com/docker/cli/cli"
-	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
 )
 
-func NewCmdPullToken(dockerCli command.Cli) *cobra.Command {
+func NewCmdPullToken() *cobra.Command {
 	var (
 		token     string
 		projectID string

--- a/pkg/cmd/push/push.go
+++ b/pkg/cmd/push/push.go
@@ -8,6 +8,7 @@ import (
 	"github.com/depot/cli/pkg/api"
 	depotapi "github.com/depot/cli/pkg/api"
 	"github.com/depot/cli/pkg/ci"
+	"github.com/depot/cli/pkg/dockerclient"
 	"github.com/depot/cli/pkg/helpers"
 	cliv1 "github.com/depot/cli/pkg/proto/depot/cli/v1"
 	prog "github.com/docker/buildx/util/progress"
@@ -19,7 +20,7 @@ import (
 )
 
 // NewCmdPush pushes a previously saved build to a registry from the Depot ephemeral registry.
-func NewCmdPush(dockerCli command.Cli) *cobra.Command {
+func NewCmdPush() *cobra.Command {
 	var (
 		token       string
 		projectID   string
@@ -34,6 +35,11 @@ func NewCmdPush(dockerCli command.Cli) *cobra.Command {
 		Short: "Push a project's build from the Depot ephemeral registry to a destination registry",
 		Args:  cli.RequiresMaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			dockerCli, err := dockerclient.NewDockerCLI()
+			if err != nil {
+				return err
+			}
+
 			if len(args) > 0 {
 				buildID = args[0]
 			}

--- a/pkg/dockerclient/client.go
+++ b/pkg/dockerclient/client.go
@@ -1,0 +1,23 @@
+package dockerclient
+
+import (
+	"github.com/depot/cli/pkg/docker"
+	"github.com/docker/cli/cli/command"
+)
+
+var dockerCli *command.DockerCli
+
+func NewDockerCLI() (*command.DockerCli, error) {
+	if dockerCli != nil {
+		return dockerCli, nil
+	}
+
+	var err error
+	cli, err := docker.NewDockerCLI()
+	if err != nil {
+		return nil, err
+	}
+
+	dockerCli = cli
+	return dockerCli, nil
+}


### PR DESCRIPTION
Some tools like AWS CDK call the Depot build command like `depot --config /tmp/configXXXXX build ...` intending to set the path to Docker config. This PR adds a hidden CLI flag to accept this input and set the `DOCKER_CONFIG` environment variable to the provided value.