### PR TITLE
Pull CLI helper image from ECR Public

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ bin/depot:
 
 .PHONY: image
 image:
-	docker --context=default buildx build --builder default -t ghcr.io/depot/cli:0.0.0-dev --load .
+	docker --context=default buildx build --builder default -t public.ecr.aws/depot/cli:0.0.0-dev --load .
 
 .PHONY: npm
 npm:

--- a/pkg/cmd/docker/docker.go
+++ b/pkg/cmd/docker/docker.go
@@ -209,7 +209,7 @@ func runConfigureBuildx(ctx context.Context, dockerCli command.Cli, project, tok
 
 	version := build.Version
 
-	image := "ghcr.io/depot/cli:" + version
+	image := "public.ecr.aws/depot/cli:" + version
 
 	nodeName := "depot_" + projectName
 	ng := &store.NodeGroup{
@@ -372,14 +372,14 @@ func UpdateDrivers(ctx context.Context, dockerCli command.Cli) error {
 		var save bool
 		for i, node := range nodeGroup.Nodes {
 			image := node.DriverOpts["image"]
-			if strings.HasPrefix(image, "ghcr.io/depot/cli") {
-				nodeGroup.Nodes[i].DriverOpts["image"] = "ghcr.io/depot/cli:" + version
+			if strings.HasPrefix(image, "ghcr.io/depot/cli") || strings.HasPrefix(image, "public.ecr.aws/depot/cli") {
+				nodeGroup.Nodes[i].DriverOpts["image"] = "public.ecr.aws/depot/cli:" + version
 				save = true
 
 				projectName := node.DriverOpts["env.DEPOT_PROJECT_ID"]
 				token := node.DriverOpts["env.DEPOT_TOKEN"]
 				platform := node.DriverOpts["env.DEPOT_PLATFORM"]
-				_ = Bootstrap(ctx, dockerCli, "ghcr.io/depot/cli:"+version, projectName, token, platform)
+				_ = Bootstrap(ctx, dockerCli, "public.ecr.aws/depot/cli:"+version, projectName, token, platform)
 			}
 
 		}

--- a/pkg/load/proxy.go
+++ b/pkg/load/proxy.go
@@ -16,7 +16,7 @@ import (
 	"github.com/docker/go-connections/nat"
 )
 
-var proxyImage = "ghcr.io/depot/cli:" + build.Version //
+var proxyImage = "public.ecr.aws/depot/cli:" + build.Version //
 
 type ProxyContainer struct {
 	ID   string


### PR DESCRIPTION
We have seen some GHCR outages that cause the CLI to be unable to pull its helper container. This PR switches from GHCR to ECR Public for improved stability.