### PR TITLE
Retry bootstrapping failures

### DIFF
--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -1,0 +1,15 @@
+package retry
+
+import "time"
+
+func Retry(fn func() error, attempts int) error {
+	var err error
+	for i := 0; i < attempts; i++ {
+		err = fn()
+		if err == nil {
+			return nil
+		}
+		time.Sleep(1 * time.Second)
+	}
+	return err
+}


### PR DESCRIPTION
This should try to bootstrap the buildx driver container up to three times before erroring