### PR TITLE
feat: support remote cache for Go compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Official CLI for [Depot](https://depot.dev) - you can use the CLI to build Docke
       - [Flags for `build`](#flags-for-build)
     - [`depot cache`](#depot-cache)
       - [`depot cache reset`](#depot-cache-reset)
+    - [`depot gocache`](#depot-gocache)
     - [`depot configure-docker`](#depot-configure-docker)
     - [`depot list`](#depot-list)
       - [`depot list projects`](#depot-list-projects)
@@ -263,6 +264,31 @@ Reset the cache of a specific project ID
 
 ```shell
 depot cache reset --project 12345678910
+```
+
+### `depot gocache`
+
+Configure Go tools to use Depot remote cache.
+The Go tools will store build artifacts in the Depot cache, and retrieve them from the cache when building again.
+
+This requires Go 1.24 or later.
+
+Export the environment variable `GOCACHEPROG` to use the Depot cache.
+
+```shell
+export GOCACHEPROG='depot gocache'
+```
+
+Next, run your Go build commands as usual.
+
+```shell
+go build ./...
+```
+
+To set verbose output, add the --verbose option:
+
+```shell
+export GOCACHEPROG='depot gocache --verbose'
 ```
 
 ### `depot configure-docker`

--- a/pkg/cmd/gocache/gocache.go
+++ b/pkg/cmd/gocache/gocache.go
@@ -56,7 +56,6 @@ func NewCmdGoCache() *cobra.Command {
 			p := NewCache(CacheServer, orgID, token, dir, verbose)
 			return p.Run(ctx)
 		},
-		Hidden: true,
 	}
 
 	flags := cmd.Flags()

--- a/pkg/cmd/gocache/gocache.go
+++ b/pkg/cmd/gocache/gocache.go
@@ -1,0 +1,556 @@
+package gocache
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/depot/cli/pkg/cmd/gocache/wire"
+	"github.com/depot/cli/pkg/helpers"
+	"github.com/spf13/cobra"
+)
+
+const CacheServer = "https://cache.depot.dev"
+
+func NewCmdGoCache() *cobra.Command {
+	var (
+		verbose bool
+		token   string
+		orgID   string
+		dir     string
+	)
+	cmd := &cobra.Command{
+		Use:   "gocache",
+		Short: `Go compiler remote cache using Depot. To use set GOCACHEPROG="depot gocache"`,
+		Long:  "depot gocache implements the Go compiler external cache protocol. It communicates over stdin/stdout with the Go tool cache.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			token, err := helpers.ResolveToken(ctx, token)
+			if err != nil {
+				return err
+			}
+
+			if token == "" {
+				return fmt.Errorf("missing API token, please run `depot login`")
+			}
+
+			p := NewCache(CacheServer, orgID, token, dir, verbose)
+			return p.Run(ctx)
+		},
+		Hidden: true,
+	}
+
+	flags := cmd.Flags()
+	flags.SortFlags = false
+	flags.BoolVarP(&verbose, "verbose", "v", false, "Print verbose output")
+	flags.StringVar(&token, "token", "", "Depot token")
+	flags.StringVarP(&orgID, "organization", "o", "", "Depot organization ID")
+	flags.StringVar(&dir, "dir", defaultCacheDir(), "Directory to store cache files")
+
+	return cmd
+}
+
+func defaultCacheDir() string {
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		return ""
+	}
+	dir = filepath.Join(dir, "depot-go-cache")
+	return dir
+}
+
+// Cache implements the cmd/go JSON protocol over stdin & stdout via three
+// funcs that callers can optionally implement.
+type Cache struct {
+	RemoteCache *RemoteCache
+	Verbose     bool
+
+	Gets      atomic.Int64
+	GetHits   atomic.Int64
+	GetMisses atomic.Int64
+	GetErrors atomic.Int64
+	Puts      atomic.Int64
+	PutErrors atomic.Int64
+}
+
+func NewCache(baseURL, orgID, token, dir string, verbose bool) *Cache {
+	disk := &DiskCache{Dir: dir, Verbose: verbose}
+	hc := &RemoteCache{
+		BaseURL: baseURL,
+		Token:   token,
+		OrgID:   orgID,
+		Disk:    disk,
+		Verbose: verbose,
+	}
+	// Background because we use .Close() to handle shutdown of the of the background PUT operations.
+	hc.Ctx, hc.CtxCancel = context.WithCancel(context.Background())
+
+	p := &Cache{
+		RemoteCache: hc,
+		Verbose:     verbose,
+	}
+	return p
+}
+
+func (p *Cache) Run(ctx context.Context) error {
+	defer p.RemoteCache.Close()
+
+	br := bufio.NewReader(os.Stdin)
+	dec := json.NewDecoder(br)
+
+	bw := bufio.NewWriter(os.Stdout)
+	enc := json.NewEncoder(bw)
+
+	caps := []wire.ProgCmd{"get", "put", "close"}
+	_ = enc.Encode(&wire.ProgResponse{KnownCommands: caps})
+	err := bw.Flush()
+	if err != nil {
+		return err
+	}
+
+	var wmu sync.Mutex // guards writing responses
+	for {
+		var req wire.ProgRequest
+		if err := dec.Decode(&req); err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+
+		// The content of a PUT immediately follows the command.
+		// The content is encoded as a JSON base64 encoded string.
+		if req.Command == wire.CmdPut && req.BodySize > 0 {
+			var bodyb []byte
+			if err := dec.Decode(&bodyb); err != nil {
+				log.Fatal(err)
+			}
+			if int64(len(bodyb)) != req.BodySize {
+				log.Fatalf("only got %d bytes of declared %d", len(bodyb), req.BodySize)
+			}
+			req.Body = bytes.NewReader(bodyb)
+		}
+
+		// Handle the request in a goroutine so we can handle multiple requests concurrently.
+		// The request ID is used to match responses to requests within the compiler.
+		go func(ctx context.Context) {
+			res := &wire.ProgResponse{ID: req.ID}
+			if err := p.handleRequest(ctx, &req, res); err != nil {
+				res.Err = err.Error()
+			}
+			wmu.Lock()
+			defer wmu.Unlock()
+			_ = enc.Encode(res)
+			_ = bw.Flush()
+		}(ctx)
+	}
+}
+
+func (p *Cache) handleRequest(ctx context.Context, req *wire.ProgRequest, res *wire.ProgResponse) error {
+	switch req.Command {
+	default:
+		return errors.New("unknown command")
+	case "close":
+		// Close will wait up to 10 seconds for all operations to finish.
+		_ = p.RemoteCache.Close()
+		if p.Verbose {
+			log.Printf("cacher: closing; %d gets (%d hits, %d misses, %d errors); %d puts (%d errors)",
+				p.Gets.Load(), p.GetHits.Load(), p.GetMisses.Load(), p.GetErrors.Load(), p.Puts.Load(), p.PutErrors.Load())
+		}
+		return nil
+	case "get":
+		return p.handleGet(ctx, req, res)
+	case "put":
+		return p.handlePut(ctx, req, res)
+	}
+}
+
+func (p *Cache) handleGet(ctx context.Context, req *wire.ProgRequest, res *wire.ProgResponse) (retErr error) {
+	p.Gets.Add(1)
+	defer func() {
+		if retErr != nil {
+			log.Printf("get(action %x): %v", req.ActionID, retErr)
+			p.GetErrors.Add(1)
+		} else if res.Miss {
+			p.GetMisses.Add(1)
+		} else {
+			p.GetHits.Add(1)
+		}
+	}()
+	outputID, diskPath, err := p.RemoteCache.Get(ctx, fmt.Sprintf("%x", req.ActionID))
+	if err != nil {
+		return err
+	}
+	if outputID == "" && diskPath == "" {
+		res.Miss = true
+		return nil
+	}
+	if outputID == "" {
+		return errors.New("no outputID")
+	}
+	res.OutputID, err = hex.DecodeString(outputID)
+	if err != nil {
+		return fmt.Errorf("invalid OutputID: %v", err)
+	}
+	fi, err := os.Stat(diskPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			res.Miss = true
+			return nil
+		}
+		return err
+	}
+	if !fi.Mode().IsRegular() {
+		return fmt.Errorf("not a regular file")
+	}
+	res.Size = fi.Size()
+	time := fi.ModTime()
+	res.Time = &time
+	res.DiskPath = diskPath
+	return nil
+}
+
+func (p *Cache) handlePut(ctx context.Context, req *wire.ProgRequest, res *wire.ProgResponse) (retErr error) {
+	actionID, objectID := fmt.Sprintf("%x", req.ActionID), fmt.Sprintf("%x", req.OutputID)
+	p.Puts.Add(1)
+	defer func() {
+		if retErr != nil {
+			p.PutErrors.Add(1)
+			log.Printf("put(action %s, obj %s, %v bytes): %v", actionID, objectID, req.BodySize, retErr)
+		}
+	}()
+
+	if req.OutputID == nil && req.ObjectID != nil {
+		req.OutputID = req.ObjectID
+	}
+	if req.OutputID == nil && req.ObjectID == nil {
+		return fmt.Errorf("missing OutputID")
+	}
+
+	var body io.Reader = req.Body
+	if body == nil {
+		body = bytes.NewReader(nil)
+	}
+	diskPath, err := p.RemoteCache.Put(ctx, actionID, objectID, req.BodySize, body)
+	if err != nil {
+		return err
+	}
+	fi, err := os.Stat(diskPath)
+	if err != nil {
+		return fmt.Errorf("stat after successful Put: %w", err)
+	}
+	if fi.Size() != req.BodySize {
+		return fmt.Errorf("failed to write file to disk with right size: disk=%v; wanted=%v", fi.Size(), req.BodySize)
+	}
+	res.DiskPath = diskPath
+	return nil
+}
+
+type RemoteCache struct {
+	// BaseURL is the base URL of the cacher server, like "http://localhost:31364".
+	BaseURL string
+
+	// OrgID is the optional Depot org id used for user tokens.
+	OrgID string
+	// Token is the optional Depot token used for user tokens.
+	Token string
+
+	// Disk is where to write the output files to local disk, as required by the
+	// cache protocol.
+	Disk *DiskCache
+
+	// HTTPClient optionally specifies the http.Client to use.
+	// If nil, http.DefaultClient is used.
+	HTTPClient *http.Client
+
+	Verbose bool
+
+	// Ctx is the context for all background PUT operations.
+	// Valid until Close.
+	Ctx context.Context
+	// CtxCancel cancels the context for all background PUT operations.
+	CtxCancel context.CancelFunc
+
+	wg sync.WaitGroup
+}
+
+// Close cancels all background PUT operations.
+// It waits up to 10 seconds for all operations to finish.
+func (c *RemoteCache) Close() error {
+	go func() {
+		time.Sleep(10 * time.Second)
+		c.CtxCancel()
+	}()
+	c.wg.Wait()
+	return nil
+}
+
+func (c *RemoteCache) httpClient() *http.Client {
+	if c.HTTPClient != nil {
+		return c.HTTPClient
+	}
+	return http.DefaultClient
+}
+
+func (c *RemoteCache) Get(ctx context.Context, actionID string) (outputID, diskPath string, err error) {
+	outputID, diskPath, err = c.Disk.Get(ctx, actionID)
+	if err == nil && outputID != "" {
+		return outputID, diskPath, nil
+	}
+
+	now := time.Now()
+	req, _ := http.NewRequestWithContext(ctx, "GET", c.BaseURL+"/gocache/v1/"+actionID, nil)
+	req.Header.Set("User-Agent", "gocacheprog")
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+	if c.OrgID != "" {
+		req.Header.Set("X-Depot-Org", c.OrgID)
+	}
+
+	res, err := c.httpClient().Do(req)
+	if err != nil {
+		return "", "", err
+	}
+	defer res.Body.Close()
+	if res.StatusCode == http.StatusNotFound {
+		return "", "", nil
+	}
+	if res.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("unexpected GET /gocache/v1/%s status %v", outputID, res.Status)
+	}
+
+	var size uint32
+	if res.Header.Get("Content-Length") == "0" {
+		outputID = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" // sha256 of empty string
+	} else {
+		// Read the length of the outputID and then the outputID itself.
+		b := make([]byte, 1)
+		_, err = io.ReadAtLeast(io.LimitReader(res.Body, 1), b, 1)
+		if err != nil {
+			return "", "", fmt.Errorf("unable to read outputID length: %v", err)
+		}
+		outputIDLen := int64(b[0])
+
+		outputIDBuf := make([]byte, outputIDLen)
+		_, err = io.ReadAtLeast(io.LimitReader(res.Body, outputIDLen), outputIDBuf, int(outputIDLen))
+		if err != nil {
+			return "", "", fmt.Errorf("unable to read outputID: %v", err)
+		}
+		outputID = string(outputIDBuf)
+
+		err = binary.Read(res.Body, binary.LittleEndian, &size)
+		if err != nil {
+			return "", "", fmt.Errorf("unable to read size: %v", err)
+		}
+	}
+
+	if c.Verbose {
+		dur := time.Since(now)
+		log.Printf("GET /gocache/v1/%s/%s: %d bytes in %v", actionID, outputID, size, dur)
+	}
+
+	// The rest of the body is the actual output.
+	now = time.Now()
+	diskPath, err = c.Disk.Put(ctx, actionID, outputID, int64(size), res.Body)
+	if err != nil {
+		return "", "", err
+	}
+	if c.Verbose {
+		dur := time.Since(now)
+		log.Printf("CACHED %s: %d bytes in %v", actionID, size, dur)
+	}
+	return outputID, diskPath, err
+}
+
+func (c *RemoteCache) Put(ctx context.Context, actionID, outputID string, size int64, body io.Reader) (diskPath string, _ error) {
+	if size < 0 {
+		return "", fmt.Errorf("negative size %d", size)
+	}
+	if size >= 4<<30 { // 4GB
+		return "", fmt.Errorf("size %d too large", size)
+	}
+	if len(outputID) > 255 {
+		return "", fmt.Errorf("outputID too long: %d", len(outputID))
+	}
+
+	// Header is 1 byte for the length of the outputID, the outputID itself, and 4 bytes for the size.
+	headerSize := 1 + len(outputID) + 4
+	b := bytes.NewBuffer(make([]byte, 0, headerSize+int(size)))
+	b.WriteByte(byte(len(outputID)))
+	b.WriteString(outputID)
+	_ = binary.Write(b, binary.LittleEndian, uint32(size))
+	_, err := io.Copy(b, body)
+	if err != nil {
+		return "", err
+	}
+	buf := b.Bytes()
+
+	diskPath, err = c.Disk.Put(ctx, actionID, outputID, size, bytes.NewReader(buf[headerSize:]))
+	if err != nil {
+		return "", err
+	}
+
+	if len(outputID) == 0 {
+		return diskPath, nil
+	}
+
+	// Send the output to the cache server in the background.
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		putBody := bytes.NewReader(buf)
+		if size == 0 {
+			putBody = bytes.NewReader(nil)
+		}
+		req, _ := http.NewRequestWithContext(c.Ctx, "PUT", c.BaseURL+"/gocache/v1/"+actionID, putBody)
+		req.GetBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(buf)), nil
+		}
+
+		req.Header.Set("User-Agent", "gocacheprog")
+		req.Header.Set("Authorization", "Bearer "+c.Token)
+		if c.OrgID != "" {
+			req.Header.Set("X-Depot-Org", c.OrgID)
+		}
+
+		req.ContentLength = int64(len(buf))
+		res, err := c.httpClient().Do(req)
+		if err != nil {
+			if !errors.Is(err, context.Canceled) {
+				log.Printf("error PUT /%s/%s: %v", actionID, outputID, err)
+			}
+			return
+		}
+
+		defer res.Body.Close()
+		if res.StatusCode != http.StatusCreated {
+			all, _ := io.ReadAll(io.LimitReader(res.Body, 4<<10))
+			log.Printf("unexpected PUT /gocache/v1/%s/%s status %v: %s", actionID, outputID, res.Status, all)
+			return
+		}
+	}()
+
+	return diskPath, nil
+}
+
+// indexEntry is the metadata that DiskCache stores on disk for an ActionID.
+type indexEntry struct {
+	Version   int    `json:"v"`
+	OutputID  string `json:"o"`
+	Size      int64  `json:"n"`
+	TimeNanos int64  `json:"t"`
+}
+
+type DiskCache struct {
+	Dir     string
+	Verbose bool
+}
+
+func (dc *DiskCache) Get(ctx context.Context, actionID string) (outputID, diskPath string, err error) {
+	actionFile := filepath.Join(dc.Dir, fmt.Sprintf("a-%s", actionID))
+	ij, err := os.ReadFile(actionFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			err = nil
+			if dc.Verbose {
+				log.Printf("disk miss: %v", actionID)
+			}
+		}
+		return "", "", err
+	}
+	var ie indexEntry
+	if err := json.Unmarshal(ij, &ie); err != nil {
+		log.Printf("Warning: JSON error for action %q: %v", actionID, err)
+		return "", "", nil
+	}
+	if _, err := hex.DecodeString(ie.OutputID); err != nil {
+		// Protect against malicious non-hex OutputID on disk
+		return "", "", nil
+	}
+	return ie.OutputID, filepath.Join(dc.Dir, fmt.Sprintf("o-%v", ie.OutputID)), nil
+}
+
+func (dc *DiskCache) OutputFilename(objectID string) string {
+	if len(objectID) < 4 || len(objectID) > 1000 {
+		return ""
+	}
+	for i := range objectID {
+		b := objectID[i]
+		if b >= '0' && b <= '9' || b >= 'a' && b <= 'f' {
+			continue
+		}
+		return ""
+	}
+	return filepath.Join(dc.Dir, fmt.Sprintf("o-%s", objectID))
+}
+
+func (dc *DiskCache) Put(ctx context.Context, actionID, objectID string, size int64, body io.Reader) (diskPath string, _ error) {
+	file := filepath.Join(dc.Dir, fmt.Sprintf("o-%s", objectID))
+
+	// Special case empty files; they're both common and easier to do race-free.
+	if size == 0 {
+		zf, err := os.OpenFile(file, os.O_CREATE|os.O_RDWR, 0644)
+		if err != nil {
+			return "", err
+		}
+		zf.Close()
+	} else {
+		wrote, err := writeAtomic(file, body)
+		if err != nil {
+			return "", err
+		}
+		if wrote != size {
+			return "", fmt.Errorf("wrote %d bytes, expected %d", wrote, size)
+		}
+	}
+
+	ij, err := json.Marshal(indexEntry{
+		Version:   1,
+		OutputID:  objectID,
+		Size:      size,
+		TimeNanos: time.Now().UnixNano(),
+	})
+	if err != nil {
+		return "", err
+	}
+	actionFile := filepath.Join(dc.Dir, fmt.Sprintf("a-%s", actionID))
+	if _, err := writeAtomic(actionFile, bytes.NewReader(ij)); err != nil {
+		return "", err
+	}
+	return file, nil
+}
+
+func writeAtomic(dest string, r io.Reader) (int64, error) {
+	tf, err := os.CreateTemp(filepath.Dir(dest), filepath.Base(dest)+".*")
+	if err != nil {
+		return 0, err
+	}
+	size, err := io.Copy(tf, r)
+	if err != nil {
+		tf.Close()
+		os.Remove(tf.Name())
+		return 0, err
+	}
+	if err := tf.Close(); err != nil {
+		os.Remove(tf.Name())
+		return 0, err
+	}
+	if err := os.Rename(tf.Name(), dest); err != nil {
+		os.Remove(tf.Name())
+		return 0, err
+	}
+	return size, nil
+}

--- a/pkg/cmd/gocache/gocache.go
+++ b/pkg/cmd/gocache/gocache.go
@@ -39,6 +39,11 @@ func NewCmdGoCache() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
+			err := os.MkdirAll(dir, 0755)
+			if err != nil {
+				return err
+			}
+
 			token, err := helpers.ResolveToken(ctx, token)
 			if err != nil {
 				return err

--- a/pkg/cmd/gocache/wire/wire.go
+++ b/pkg/cmd/gocache/wire/wire.go
@@ -1,0 +1,104 @@
+// From https://github.com/golang/go/blob/master/src/cmd/go/internal/cache/prog.go
+//
+// Copyright 2023 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package wire contains the JSON types that cmd/go uses
+// to communicate with child processes implementing
+// the cache interface.
+package wire
+
+import (
+	"io"
+	"time"
+)
+
+// ProgCmd is a command that can be issued to a child process.
+//
+// If the interface needs to grow, we can add new commands or new versioned
+// commands like "get2".
+type ProgCmd string
+
+const (
+	CmdGet   = ProgCmd("get")
+	CmdPut   = ProgCmd("put")
+	CmdClose = ProgCmd("close")
+)
+
+// ProgRequest is the JSON-encoded message that's sent from cmd/go to
+// the GOCACHEPROG child process over stdin. Each JSON object is on its
+// own line. A ProgRequest of Type "put" with BodySize > 0 will be followed
+// by a line containing a base64-encoded JSON string literal of the body.
+type ProgRequest struct {
+	// ID is a unique number per process across all requests.
+	// It must be echoed in the ProgResponse from the child.
+	ID int64
+
+	// Command is the type of request.
+	// The cmd/go tool will only send commands that were declared
+	// as supported by the child.
+	Command ProgCmd
+
+	// ActionID is non-nil for get and puts.
+	ActionID []byte `json:",omitempty"` // or nil if not used
+
+	// OutputID is set for Type "put".
+	//
+	// Prior to Go 1.24, when GOCACHEPROG was still an experiment, this was
+	// accidentally named ObjectID. It was renamed to OutputID in Go 1.24.
+	OutputID []byte `json:",omitempty"` // or nil if not used
+
+	// Body is the body for "put" requests. It's sent after the JSON object
+	// as a base64-encoded JSON string when BodySize is non-zero.
+	// It's sent as a separate JSON value instead of being a struct field
+	// send in this JSON object so large values can be streamed in both directions.
+	// The base64 string body of a ProgRequest will always be written
+	// immediately after the JSON object and a newline.
+	Body io.Reader `json:"-"`
+
+	// BodySize is the number of bytes of Body. If zero, the body isn't written.
+	BodySize int64 `json:",omitempty"`
+
+	// ObjectID is the accidental spelling of OutputID that was used prior to Go
+	// 1.24.
+	//
+	// Deprecated: use OutputID. This field is only populated temporarily for
+	// backwards compatibility with Go 1.23 and earlier when
+	// GOEXPERIMENT=gocacheprog is set. It will be removed in Go 1.25.
+	ObjectID []byte `json:",omitempty"`
+}
+
+// ProgResponse is the JSON response from the child process to cmd/go.
+//
+// With the exception of the first protocol message that the child writes to its
+// stdout with ID==0 and KnownCommands populated, these are only sent in
+// response to a ProgRequest from cmd/go.
+//
+// ProgResponses can be sent in any order. The ID must match the request they're
+// replying to.
+type ProgResponse struct {
+	ID  int64  // that corresponds to ProgRequest; they can be answered out of order
+	Err string `json:",omitempty"` // if non-empty, the error
+
+	// KnownCommands is included in the first message that cache helper program
+	// writes to stdout on startup (with ID==0). It includes the
+	// ProgRequest.Command types that are supported by the program.
+	//
+	// This lets us extend the protocol gracefully over time (adding "get2",
+	// etc), or fail gracefully when needed. It also lets us verify the program
+	// wants to be a cache helper.
+	KnownCommands []ProgCmd `json:",omitempty"`
+
+	// For Get requests.
+
+	Miss     bool       `json:",omitempty"` // cache miss
+	OutputID []byte     `json:",omitempty"`
+	Size     int64      `json:",omitempty"` // in bytes
+	Time     *time.Time `json:",omitempty"` // an Entry.Time; when the object was added to the docs
+
+	// DiskPath is the absolute path on disk of the ObjectID corresponding
+	// a "get" request's ActionID (on cache hit) or a "put" request's
+	// provided ObjectID.
+	DiskPath string `json:",omitempty"`
+}

--- a/pkg/cmd/gocache/wire/wire.go
+++ b/pkg/cmd/gocache/wire/wire.go
@@ -60,12 +60,7 @@ type ProgRequest struct {
 	// BodySize is the number of bytes of Body. If zero, the body isn't written.
 	BodySize int64 `json:",omitempty"`
 
-	// ObjectID is the accidental spelling of OutputID that was used prior to Go
-	// 1.24.
-	//
-	// Deprecated: use OutputID. This field is only populated temporarily for
-	// backwards compatibility with Go 1.23 and earlier when
-	// GOEXPERIMENT=gocacheprog is set. It will be removed in Go 1.25.
+	// ObjectID is the accidental spelling of OutputID that was used prior to Go 1.24.
 	ObjectID []byte `json:",omitempty"`
 }
 

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -10,6 +10,7 @@ import (
 	cacheCmd "github.com/depot/cli/pkg/cmd/cache"
 	dockerCmd "github.com/depot/cli/pkg/cmd/docker"
 	"github.com/depot/cli/pkg/cmd/exec"
+	"github.com/depot/cli/pkg/cmd/gocache"
 	initCmd "github.com/depot/cli/pkg/cmd/init"
 	"github.com/depot/cli/pkg/cmd/list"
 	loginCmd "github.com/depot/cli/pkg/cmd/login"
@@ -68,6 +69,7 @@ func NewCmdRoot(version, buildDate string) *cobra.Command {
 	cmd.AddCommand(dockerCmd.NewCmdConfigureDocker())
 	cmd.AddCommand(registry.NewCmdRegistry())
 	cmd.AddCommand(projects.NewCmdProjects())
+	cmd.AddCommand(gocache.NewCmdGoCache())
 	cmd.AddCommand(exec.NewCmdExec())
 
 	return cmd


### PR DESCRIPTION
Set `GOCACHEPROG="depot gocache"` to cache Go tool cache remotely in depot.
This supports Go version 1.24 or greater.