### PR TITLE
fix: add SBOM and S3 caching secrets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	buf.build/gen/go/depot/api/protocolbuffers/go v1.32.0-20240221184445-e8316610338f.1
 	connectrpc.com/connect v1.15.0
 	github.com/adrg/xdg v0.4.0
+	github.com/aws/aws-sdk-go-v2/config v1.15.5
 	github.com/briandowns/spinner v1.18.1
 	github.com/charmbracelet/bubbles v0.16.1
 	github.com/charmbracelet/bubbletea v0.24.2
@@ -64,7 +65,6 @@ require (
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.16.3 // indirect
-	github.com/aws/aws-sdk-go-v2/config v1.15.5 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.12.0 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.4 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.10 // indirect

--- a/pkg/buildx/bake/buildflags/cache.go
+++ b/pkg/buildx/bake/buildflags/cache.go
@@ -1,11 +1,15 @@
 package buildflags
 
 import (
+	"context"
 	"encoding/csv"
 	"encoding/json"
 	"maps"
+	"os"
+	"strconv"
 	"strings"
 
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/moby/buildkit/client"
 	"github.com/pkg/errors"
 	"github.com/zclconf/go-cty/cty"
@@ -183,6 +187,9 @@ func CreateCaches(entries []*CacheOptionsEntry) []client.CacheOptionsEntry {
 		return nil
 	}
 	for _, entry := range entries {
+		addGithubToken(entry)
+		addAwsCredentials(entry)
+
 		out := client.CacheOptionsEntry{
 			Type:  entry.Type,
 			Attrs: map[string]string{},
@@ -193,4 +200,68 @@ func CreateCaches(entries []*CacheOptionsEntry) []client.CacheOptionsEntry {
 		outs = append(outs, out)
 	}
 	return outs
+}
+
+func addGithubToken(ci *CacheOptionsEntry) {
+	if ci.Type != "gha" {
+		return
+	}
+	version, ok := ci.Attrs["version"]
+	if !ok {
+		// https://github.com/actions/toolkit/blob/2b08dc18f261b9fdd978b70279b85cbef81af8bc/packages/cache/src/internal/config.ts#L19
+		if v, ok := os.LookupEnv("ACTIONS_CACHE_SERVICE_V2"); ok {
+			if b, err := strconv.ParseBool(v); err == nil && b {
+				version = "2"
+			}
+		}
+	}
+	if _, ok := ci.Attrs["token"]; !ok {
+		if v, ok := os.LookupEnv("ACTIONS_RUNTIME_TOKEN"); ok {
+			ci.Attrs["token"] = v
+		}
+	}
+	if _, ok := ci.Attrs["url_v2"]; !ok && version == "2" {
+		// https://github.com/actions/toolkit/blob/2b08dc18f261b9fdd978b70279b85cbef81af8bc/packages/cache/src/internal/config.ts#L34-L35
+		if v, ok := os.LookupEnv("ACTIONS_RESULTS_URL"); ok {
+			ci.Attrs["url_v2"] = v
+		}
+	}
+	if _, ok := ci.Attrs["url"]; !ok {
+		// https://github.com/actions/toolkit/blob/2b08dc18f261b9fdd978b70279b85cbef81af8bc/packages/cache/src/internal/config.ts#L28-L33
+		if v, ok := os.LookupEnv("ACTIONS_CACHE_URL"); ok {
+			ci.Attrs["url"] = v
+		} else if v, ok := os.LookupEnv("ACTIONS_RESULTS_URL"); ok {
+			ci.Attrs["url"] = v
+		}
+	}
+}
+
+func addAwsCredentials(ci *CacheOptionsEntry) {
+	if ci.Type != "s3" {
+		return
+	}
+	_, okAccessKeyID := ci.Attrs["access_key_id"]
+	_, okSecretAccessKey := ci.Attrs["secret_access_key"]
+	// If the user provides access_key_id, secret_access_key, do not override the session token.
+	if okAccessKeyID && okSecretAccessKey {
+		return
+	}
+	ctx := context.TODO()
+	awsConfig, err := awsconfig.LoadDefaultConfig(ctx)
+	if err != nil {
+		return
+	}
+	credentials, err := awsConfig.Credentials.Retrieve(ctx)
+	if err != nil {
+		return
+	}
+	if !okAccessKeyID && credentials.AccessKeyID != "" {
+		ci.Attrs["access_key_id"] = credentials.AccessKeyID
+	}
+	if !okSecretAccessKey && credentials.SecretAccessKey != "" {
+		ci.Attrs["secret_access_key"] = credentials.SecretAccessKey
+	}
+	if _, ok := ci.Attrs["session_token"]; !ok && credentials.SessionToken != "" {
+		ci.Attrs["session_token"] = credentials.SessionToken
+	}
 }

--- a/pkg/buildx/build/build.go
+++ b/pkg/buildx/build/build.go
@@ -401,6 +401,10 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Op
 	supportsAttestations := true
 	if len(attests) > 0 {
 		for k, v := range attests {
+			// DEPOT: Bake does not have `attest:` and build does.
+			if !strings.HasPrefix(k, "attest:") {
+				k = "attest:" + k
+			}
 			so.FrontendAttrs[k] = v
 		}
 	}

--- a/pkg/helpers/gha.go
+++ b/pkg/helpers/gha.go
@@ -7,11 +7,13 @@ import "os"
 func FixGitHubActionsCacheEnv() {
 	original := os.Getenv("UPSTREAM_ACTIONS_CACHE_URL")
 
-	if original == "" {
-		original = os.Getenv("GACTIONSCACHE_URL")
-	}
-
 	if original != "" {
 		os.Setenv("ACTIONS_CACHE_URL", original)
+	}
+
+	original = os.Getenv("UPSTREAM_ACTIONS_RESULTS_URL")
+
+	if original != "" {
+		os.Setenv("ACTIONS_RESULTS_URL", original)
 	}
 }


### PR DESCRIPTION
Upstream has moved various type to string conversions
to a variety of different places in the code.