### PR TITLE
docs: remove references to 'ephemeral' registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ services:
 | `provenance`     | Shorthand for "--set=\*.attest=type=provenance"                                                           |
 | `pull`           | Always attempt to pull all referenced images                                                              |
 | `push`           | Shorthand for "--set=\*.output=type=registry"                                                             |
-| `save`           | Saves bake targets to the Depot ephemeral registry                                                        |
+| `save`           | Saves bake targets to the Depot registry                                                        |
 | `sbom`           | Shorthand for "--set=\*.attest=type=sbom"                                                                 |
 | `set`            | Override target value (e.g., "targetpattern.key=value")                                                   |
 | `token`          | Depot API token                                                                                           |
@@ -234,7 +234,7 @@ depot build -t repo/image:tag . --push
 | `pull`            | Always attempt to pull all referenced images                                                              |
 | `push`            | Shorthand for "--output=type=registry"                                                                    |
 | `quiet`           | Suppress the build output and print image ID on success                                                   |
-| `save`           | Saves build to the Depot ephemeral registry                                                                |
+| `save`           | Saves build to the Depot registry                                                                |
 | `sbom`            | Shorthand for "--attest=type=sbom"                                                                        |
 | `secret`          | Secret to expose to the build (format: "id=mysecret[,src=/local/secret]")                                 |
 | `shm-size`        | Size of "/dev/shm"                                                                                        |
@@ -398,13 +398,13 @@ depot logout
 
 ### `depot pull`
 
-Pull an image from the Depot ephemeral registry to your local Docker daemon.
+Pull an image from the Depot registry to your local Docker daemon.
 
 ```shell
 depot pull --tag repo:tag <BUILD_ID>
 ```
 
-Pull all bake images from the Depot ephemeral registry to your local Docker daemon.
+Pull all bake images from the Depot registry to your local Docker daemon.
 By default images will be tagged with the bake target names.
 
 ```shell
@@ -413,7 +413,7 @@ depot pull <BUILD_ID>
 
 ### `depot push`
 
-Push an image from the Depot ephemeral registry to a destination registry.
+Push an image from the Depot registry to a destination registry.
 
 ```shell
 depot push --tag repo:tag <BUILD_ID>

--- a/pkg/cmd/pull/pull.go
+++ b/pkg/cmd/pull/pull.go
@@ -31,7 +31,7 @@ func NewCmdPull() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "pull [flags] [buildID]",
-		Short: "Pull a project's build from the Depot ephemeral registry",
+		Short: "Pull a project's build from the Depot registry",
 		Args:  cli.RequiresMaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			dockerCli, err := dockerclient.NewDockerCLI()
@@ -104,7 +104,7 @@ func NewCmdPull() *cobra.Command {
 
 			buildOptions := res.Msg.Options
 			if len(buildOptions) > 0 && !isSavedBuild(buildOptions) {
-				return fmt.Errorf("build %s is not a saved build. To use the ephemeral registry use --save when building", buildID)
+				return fmt.Errorf("build %s is not a saved build. To use the registry use --save when building", buildID)
 			}
 
 			if isBake(buildOptions) {

--- a/pkg/cmd/pulltoken/pulltoken.go
+++ b/pkg/cmd/pulltoken/pulltoken.go
@@ -20,7 +20,7 @@ func NewCmdPullToken() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "pull-token [flags] ([buildID])",
-		Short: "Create a new pull token for the ephemeral registry",
+		Short: "Create a new pull token for the registry",
 		Args:  cli.RequiresMaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {

--- a/pkg/cmd/push/manifests.go
+++ b/pkg/cmd/push/manifests.go
@@ -70,7 +70,7 @@ type ImageDescriptors struct {
 
 // GetImageDescriptors returns back all the descriptors for an image.
 func GetImageDescriptors(ctx context.Context, token, buildID, target string, logger StartLogDetailFunc) (*ImageDescriptors, error) {
-	// Download location and credentials of ephemeral image save.
+	// Download location and credentials of image save.
 	client := depotapi.NewBuildClient()
 	req := &cliv1.GetPullInfoRequest{BuildId: buildID}
 	res, err := client.GetPullInfo(ctx, depotapi.WithAuthentication(connect.NewRequest(req), token))
@@ -192,7 +192,7 @@ func fetch(ctx context.Context, fetcher remotes.Fetcher, desc ocispecs.Descripto
 	return io.ReadAll(r)
 }
 
-// Authorizer is a static authorizer used to authenticate with the Depot ephemeral registry.
+// Authorizer is a static authorizer used to authenticate with the Depot registry.
 type Authorizer struct {
 	Username string
 	Password string

--- a/pkg/cmd/push/push.go
+++ b/pkg/cmd/push/push.go
@@ -19,7 +19,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// NewCmdPush pushes a previously saved build to a registry from the Depot ephemeral registry.
+// NewCmdPush pushes a previously saved build to a registry from the Depot registry.
 func NewCmdPush() *cobra.Command {
 	var (
 		token       string
@@ -32,7 +32,7 @@ func NewCmdPush() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "push [flags] [buildID]",
-		Short: "Push a project's build from the Depot ephemeral registry to a destination registry",
+		Short: "Push a project's build from the Depot registry to a destination registry",
 		Args:  cli.RequiresMaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			dockerCli, err := dockerclient.NewDockerCLI()


### PR DESCRIPTION
the registry is no longer ephemeral, as you can store images for any
length of time. removing references to the registry being 'ephemeral'
makes sense.