### PR TITLE
fix(gocacheprog): support go 1.23

### DIFF
--- a/pkg/cmd/gocache/gocache.go
+++ b/pkg/cmd/gocache/gocache.go
@@ -249,6 +249,17 @@ func (p *Cache) handleGet(ctx context.Context, req *wire.ProgRequest, res *wire.
 }
 
 func (p *Cache) handlePut(ctx context.Context, req *wire.ProgRequest, res *wire.ProgResponse) (retErr error) {
+	if req.OutputID == nil && req.ObjectID != nil {
+		req.OutputID = req.ObjectID
+	}
+	if req.OutputID == nil && req.ObjectID == nil {
+		return fmt.Errorf("missing OutputID")
+	}
+
+	if len(req.OutputID) < 2 {
+		return fmt.Errorf("invalid OutputID length: %d", len(req.OutputID))
+	}
+
 	actionID, objectID := fmt.Sprintf("%x", req.ActionID), fmt.Sprintf("%x", req.OutputID)
 	p.Puts.Add(1)
 	defer func() {
@@ -257,13 +268,6 @@ func (p *Cache) handlePut(ctx context.Context, req *wire.ProgRequest, res *wire.
 			log.Printf("put(action %s, obj %s, %v bytes): %v", actionID, objectID, req.BodySize, retErr)
 		}
 	}()
-
-	if req.OutputID == nil && req.ObjectID != nil {
-		req.OutputID = req.ObjectID
-	}
-	if req.OutputID == nil && req.ObjectID == nil {
-		return fmt.Errorf("missing OutputID")
-	}
 
 	var body io.Reader = req.Body
 	if body == nil {


### PR DESCRIPTION
Go 1.23 would send `ObjectID`.

Previously, the code would panic because it sliced into an empty Go 1.24 `OutputID` field. Now, we correctly guard and set the outputID.