### PR TITLE
Fix pulumi / buildx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN \
   go build -ldflags="${LDFLAGS}" \
   -o /out/ ./cmd/...
 
-FROM --platform=$TARGETPLATFORM ubuntu:20.04
+FROM ubuntu:24.04
 
 RUN apt-get update && apt-get install -y ca-certificates curl && rm -rf /var/lib/apt/lists/*
 COPY entrypoint.sh /usr/bin/entrypoint.sh


### PR DESCRIPTION
Pulumi / modern buildx is calling the Info method, which currently shuts down the buildx proxy. This PR removes that shutdown, plus leaves a disabled debugging logger in place for next time we need to debug this.