### PR TITLE
fix(bake): ensure output push defaults to false

### DIFF
--- a/pkg/buildx/bake/bake.go
+++ b/pkg/buildx/bake/bake.go
@@ -1286,6 +1286,8 @@ func setPushOverride(outputs []*buildflags.ExportEntry, push bool) []*buildflags
 				outputs[i] = output
 			}
 		}
+
+		return outputs
 	}
 
 	for i, output := range outputs {


### PR DESCRIPTION
We iterate over the outputs and set `push` to `"false"`, but this is overwritten by the following for loop.

Should fix an issue where an image built using `bake` is pushed to an external registry when the push flag is not applied.