### PR TITLE
fix: specify platform for registry pull when load using registry

### DIFF
--- a/pkg/load/cli.go
+++ b/pkg/load/cli.go
@@ -6,6 +6,7 @@ import (
 
 	depotbuild "github.com/depot/cli/pkg/build"
 	"github.com/docker/buildx/build"
+	"github.com/docker/buildx/util/platformutil"
 	"github.com/docker/buildx/util/progress"
 	"github.com/moby/buildkit/client"
 )
@@ -79,6 +80,13 @@ func WithDepotImagePull(buildOpts map[string]build.Options, loadOpts DepotLoadOp
 				pullOpt.Username = &loadOpts.PullInfo.Username
 				pullOpt.Password = &loadOpts.PullInfo.Password
 				pullOpt.ServerAddress = &serverAddress
+
+				platforms := platformutil.Format(buildOpt.Platforms)
+				// only specify a platform to pull when a single platform is used
+				if len(platforms) == 1 {
+					platform := platforms[0]
+					pullOpt.Platform = &platform
+				}
 			}
 
 			toPull[target] = pullOpt


### PR DESCRIPTION
When specifying registry pull options for loading from the registry, if platform is specified for the target, specify platform in pull options to be used when pulling from the registry. If there are multiple platforms configured for the target, we don't specify a platform. Alternatively this can be updated to use the first platform if that makes more sense than not specifying one.

