### PR TITLE
feat: support depot push w/o docker .config credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,12 @@ depot pull <BUILD_ID>
 ### `depot push`
 
 Push an image from the Depot registry to a destination registry.
+By default, it uses registry credentials stored in Docker when pushing to registries.
+If you have not already authenticated with your registry, you can do so with `docker login`
+before running `depot push`.
+
+Alternatively, you can specify the environment variables `DEPOT_PUSH_REGISTRY_USERNAME` and `DEPOT_PUSH_REGISTRY_PASSWORD`
+for the registry credentials. This allows you to skip the `docker login` step.
 
 ```shell
 depot push --tag repo:tag <BUILD_ID>


### PR DESCRIPTION
Pushing to registries previously depended on the default docker method of reading the docker config file for auth tokens.

This was inconvenient because the format is complicated and is shared among all concurrent depot pushes.

To support more concurrency with ephemeral tokens, we've introduced the environment variables
`DEPOT_PUSH_REGISTRY_USERNAME` and `DEPOT_PUSH_REGISTRY_PASSWORD`.

To use with depot push:

```
DEPOT_PUSH_REGISTRY_USERNAME=AWS DEPOT_PUSH_REGISTRY_PASSWORD=hunter2 depot push ...
```