### PR TITLE
Add `depot cargo` command

### DIFF
--- a/pkg/cmd/cargo/cargo.go
+++ b/pkg/cmd/cargo/cargo.go
@@ -107,12 +107,8 @@ func NewCmdCargo() *cobra.Command {
 		},
 	}
 
-	return cmd
-}
+	cmd.Flags().StringVar(&orgID, "org", "", "Organization ID")
+	cmd.Flags().Lookup("org").Hidden = true
 
-func init() {
-	cargoCmd := NewCmdCargo()
-	// Add a hidden --org flag for command completion, but we parse it manually
-	cargoCmd.Flags().StringVar(&orgID, "org", "", "Organization ID")
-	cargoCmd.Flags().Lookup("org").Hidden = true
+	return cmd
 }

--- a/pkg/cmd/cargo/cargo.go
+++ b/pkg/cmd/cargo/cargo.go
@@ -1,0 +1,118 @@
+package cargo
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/depot/cli/pkg/helpers"
+	"github.com/spf13/cobra"
+)
+
+var orgID string
+
+func NewCmdCargo() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                "cargo [cargo-flags]...",
+		Short:              "Run cargo with Depot caching",
+		DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			// Manual flag parsing to handle --org
+			var cargoArgs []string
+			i := 0
+			for i < len(args) {
+				arg := args[i]
+				if arg == "--org" && i+1 < len(args) {
+					orgID = args[i+1]
+					i += 2
+				} else if after, ok := strings.CutPrefix(arg, "--org="); ok {
+					orgID = after
+					i++
+				} else {
+					cargoArgs = append(cargoArgs, arg)
+					i++
+				}
+			}
+
+			// If no org ID specified via flag, check environment variable
+			if orgID == "" {
+				orgID = os.Getenv("DEPOT_ORG_ID")
+			}
+
+			// Check for sccache
+			sccachePath, err := exec.LookPath("sccache")
+			if err != nil {
+				return fmt.Errorf("sccache not found in PATH: %w\n\nPlease install sccache: cargo install sccache", err)
+			}
+
+			// Get authentication token
+			token, err := helpers.ResolveToken(ctx, "")
+			if err != nil {
+				return fmt.Errorf("failed to resolve token: %w", err)
+			}
+
+			// Create cargo command
+			cargoCmd := exec.CommandContext(ctx, "cargo", cargoArgs...)
+			cargoCmd.Stdin = os.Stdin
+			cargoCmd.Stdout = os.Stdout
+			cargoCmd.Stderr = os.Stderr
+
+			// Inherit environment and filter out existing sccache vars
+			cargoCmd.Env = []string{}
+			for _, env := range os.Environ() {
+				// Skip any existing SCCACHE environment variables
+				if !strings.HasPrefix(env, "SCCACHE_") {
+					cargoCmd.Env = append(cargoCmd.Env, env)
+				}
+			}
+
+			// Now add our sccache vars
+			cargoCmd.Env = append(cargoCmd.Env, fmt.Sprintf("RUSTC_WRAPPER=%s", sccachePath))
+			cargoCmd.Env = append(cargoCmd.Env, "SCCACHE_WEBDAV_ENDPOINT=https://cache.depot.dev")
+
+			if orgID != "" {
+				// Use org-specific authentication
+				cargoCmd.Env = append(cargoCmd.Env, fmt.Sprintf("SCCACHE_WEBDAV_USERNAME=%s", orgID))
+				cargoCmd.Env = append(cargoCmd.Env, fmt.Sprintf("SCCACHE_WEBDAV_PASSWORD=%s", token))
+			} else {
+				// Use token-only authentication
+				cargoCmd.Env = append(cargoCmd.Env, fmt.Sprintf("SCCACHE_WEBDAV_TOKEN=%s", token))
+			}
+
+			// Set up signal handling
+			signalCh := make(chan os.Signal, 1)
+			signal.Notify(signalCh, syscall.SIGINT, syscall.SIGTERM)
+			go func() {
+				sig := <-signalCh
+				if cargoCmd.Process != nil {
+					cargoCmd.Process.Signal(sig)
+				}
+			}()
+
+			// Run cargo
+			err = cargoCmd.Run()
+			if err != nil {
+				if exitErr, ok := err.(*exec.ExitError); ok {
+					os.Exit(exitErr.ExitCode())
+				}
+				return err
+			}
+
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func init() {
+	cargoCmd := NewCmdCargo()
+	// Add a hidden --org flag for command completion, but we parse it manually
+	cargoCmd.Flags().StringVar(&orgID, "org", "", "Organization ID")
+	cargoCmd.Flags().Lookup("org").Hidden = true
+}

--- a/pkg/cmd/cargo/cargo.go
+++ b/pkg/cmd/cargo/cargo.go
@@ -90,7 +90,7 @@ func NewCmdCargo() *cobra.Command {
 			go func() {
 				sig := <-signalCh
 				if cargoCmd.Process != nil {
-					cargoCmd.Process.Signal(sig)
+					_ = cargoCmd.Process.Signal(sig)
 				}
 			}()
 

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -8,6 +8,7 @@ import (
 	bakeCmd "github.com/depot/cli/pkg/cmd/bake"
 	buildCmd "github.com/depot/cli/pkg/cmd/build"
 	cacheCmd "github.com/depot/cli/pkg/cmd/cache"
+	cargoCmd "github.com/depot/cli/pkg/cmd/cargo"
 	claudeCmd "github.com/depot/cli/pkg/cmd/claude"
 	dockerCmd "github.com/depot/cli/pkg/cmd/docker"
 	"github.com/depot/cli/pkg/cmd/exec"
@@ -59,6 +60,7 @@ func NewCmdRoot(version, buildDate string) *cobra.Command {
 	cmd.AddCommand(bakeCmd.NewCmdBake())
 	cmd.AddCommand(buildCmd.NewCmdBuild())
 	cmd.AddCommand(cacheCmd.NewCmdCache())
+	cmd.AddCommand(cargoCmd.NewCmdCargo())
 	cmd.AddCommand(claudeCmd.NewCmdClaude())
 	cmd.AddCommand(initCmd.NewCmdInit())
 	cmd.AddCommand(list.NewCmdList())


### PR DESCRIPTION
Adds a wrapper around `cargo` that configures Depot Cache.