### PR TITLE
feat: support JIT tokens from Depot environments

### DIFF
--- a/pkg/cmd/cargo/cargo.go
+++ b/pkg/cmd/cargo/cargo.go
@@ -53,8 +53,7 @@ func NewCmdCargo() *cobra.Command {
 			}
 
 			// Get authentication token
-			token := os.Getenv("DEPOT_CACHE_TOKEN")
-			token, err = helpers.ResolveToken(ctx, token)
+			token, err := helpers.ResolveToken(ctx, "")
 			if err != nil {
 				return fmt.Errorf("failed to resolve token: %w", err)
 			}

--- a/pkg/cmd/gocache/gocache.go
+++ b/pkg/cmd/gocache/gocache.go
@@ -49,7 +49,6 @@ func NewCmdGoCache() *cobra.Command {
 				return err
 			}
 
-			token := os.Getenv("DEPOT_CACHE_TOKEN")
 			token, err = helpers.ResolveToken(ctx, token)
 			if err != nil {
 				return err

--- a/pkg/helpers/token.go
+++ b/pkg/helpers/token.go
@@ -40,6 +40,10 @@ func ResolveToken(ctx context.Context, token string) (string, error) {
 		}
 	}
 
+	if token == "" {
+		token = ResolveJITToken()
+	}
+
 	if token == "" && IsTerminal() {
 		return AuthorizeDevice(ctx)
 	}
@@ -60,4 +64,16 @@ func AuthorizeDevice(ctx context.Context) (string, error) {
 		return "", err
 	}
 	return tokenResponse.Token, nil
+}
+
+func ResolveJITToken() string {
+	if token := os.Getenv("DEPOT_JIT_TOKEN"); token != "" {
+		return token
+	}
+
+	if token := os.Getenv("DEPOT_CACHE_TOKEN"); token != "" {
+		return token
+	}
+
+	return ""
 }

--- a/pkg/helpers/token.go
+++ b/pkg/helpers/token.go
@@ -41,7 +41,7 @@ func ResolveToken(ctx context.Context, token string) (string, error) {
 	}
 
 	if token == "" {
-		token = ResolveJITToken()
+		token = resolveJITToken()
 	}
 
 	if token == "" && IsTerminal() {
@@ -66,7 +66,7 @@ func AuthorizeDevice(ctx context.Context) (string, error) {
 	return tokenResponse.Token, nil
 }
 
-func ResolveJITToken() string {
+func resolveJITToken() string {
 	if token := os.Getenv("DEPOT_JIT_TOKEN"); token != "" {
 		return token
 	}


### PR DESCRIPTION
Various depot commands (e.g. `depot claude`, `depot cargo`) would benefit from default auth mechanisms within Depot execution environments. This PR adds support for a `DEPOT_JIT_TOKEN` and a legacy `DEPOT_CACHE_TOKEN` present in such environments.