### PR TITLE
feat: support JIT tokens from Depot environments

### DIFF
--- a/pkg/buildx/commands/bake.go
+++ b/pkg/buildx/commands/bake.go
@@ -275,7 +275,7 @@ func BakeCmd() *cobra.Command {
 				options.pull = nil
 			}
 
-			token, err := helpers.ResolveToken(context.Background(), options.token)
+			token, err := helpers.ResolveProjectAuth(context.Background(), options.token)
 			if err != nil {
 				return err
 			}

--- a/pkg/buildx/commands/build.go
+++ b/pkg/buildx/commands/build.go
@@ -630,7 +630,7 @@ func BuildCmd() *cobra.Command {
 			options.contextPath = args[0]
 			cmd.Flags().VisitAll(checkWarnedFlags)
 
-			token, err := helpers.ResolveToken(context.Background(), options.token)
+			token, err := helpers.ResolveProjectAuth(context.Background(), options.token)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/cache/reset.go
+++ b/pkg/cmd/cache/reset.go
@@ -33,7 +33,7 @@ func NewCmdResetCache() *cobra.Command {
 			}
 
 			var err error
-			token, err = helpers.ResolveToken(context.Background(), token)
+			token, err = helpers.ResolveProjectAuth(context.Background(), token)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/cargo/cargo.go
+++ b/pkg/cmd/cargo/cargo.go
@@ -54,7 +54,7 @@ func NewCmdCargo() *cobra.Command {
 
 			// Get authentication token
 			token := os.Getenv("DEPOT_CACHE_TOKEN")
-			token, err = helpers.ResolveToken(ctx, token)
+			token, err = helpers.ResolveProjectAuth(ctx, token)
 			if err != nil {
 				return fmt.Errorf("failed to resolve token: %w", err)
 			}

--- a/pkg/cmd/cargo/cargo.go
+++ b/pkg/cmd/cargo/cargo.go
@@ -53,7 +53,8 @@ func NewCmdCargo() *cobra.Command {
 			}
 
 			// Get authentication token
-			token, err := helpers.ResolveToken(ctx, "")
+			token := os.Getenv("DEPOT_CACHE_TOKEN")
+			token, err = helpers.ResolveToken(ctx, token)
 			if err != nil {
 				return fmt.Errorf("failed to resolve token: %w", err)
 			}

--- a/pkg/cmd/cargo/cargo.go
+++ b/pkg/cmd/cargo/cargo.go
@@ -52,9 +52,7 @@ func NewCmdCargo() *cobra.Command {
 				return fmt.Errorf("sccache not found in PATH: %w\n\nPlease install sccache: cargo install sccache", err)
 			}
 
-			// Get authentication token
-			token := os.Getenv("DEPOT_CACHE_TOKEN")
-			token, err = helpers.ResolveProjectAuth(ctx, token)
+			token, err := helpers.ResolveOrgAuth(ctx, "")
 			if err != nil {
 				return fmt.Errorf("failed to resolve token: %w", err)
 			}

--- a/pkg/cmd/claude/claude.go
+++ b/pkg/cmd/claude/claude.go
@@ -418,7 +418,7 @@ func RunClaudeSession(ctx context.Context, opts *ClaudeSessionOptions) error {
 		opts.Stderr = os.Stderr
 	}
 
-	token, err := helpers.ResolveToken(ctx, opts.Token)
+	token, err := helpers.ResolveProjectAuth(ctx, opts.Token)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/claude/claude.go
+++ b/pkg/cmd/claude/claude.go
@@ -418,7 +418,7 @@ func RunClaudeSession(ctx context.Context, opts *ClaudeSessionOptions) error {
 		opts.Stderr = os.Stderr
 	}
 
-	token, err := helpers.ResolveProjectAuth(ctx, opts.Token)
+	token, err := helpers.ResolveOrgAuth(ctx, opts.Token)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/claude/listsessions.go
+++ b/pkg/cmd/claude/listsessions.go
@@ -48,7 +48,7 @@ In interactive mode, pressing Enter on a session will start Claude with that ses
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
-			token, err := helpers.ResolveToken(ctx, token)
+			token, err := helpers.ResolveProjectAuth(ctx, token)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/docker/docker.go
+++ b/pkg/cmd/docker/docker.go
@@ -177,7 +177,7 @@ func uninstallDepotPlugin(dir string) error {
 
 func runConfigureBuildx(ctx context.Context, dockerCli command.Cli, project, token string) error {
 	var err error
-	token, err = helpers.ResolveToken(ctx, token)
+	token, err = helpers.ResolveProjectAuth(ctx, token)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/exec/exec.go
+++ b/pkg/cmd/exec/exec.go
@@ -33,7 +33,7 @@ func NewCmdExec() *cobra.Command {
 	run := func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 
-		token, err := helpers.ResolveToken(ctx, token)
+		token, err := helpers.ResolveProjectAuth(ctx, token)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/gocache/gocache.go
+++ b/pkg/cmd/gocache/gocache.go
@@ -49,6 +49,7 @@ func NewCmdGoCache() *cobra.Command {
 				return err
 			}
 
+			token := os.Getenv("DEPOT_CACHE_TOKEN")
 			token, err = helpers.ResolveToken(ctx, token)
 			if err != nil {
 				return err

--- a/pkg/cmd/gocache/gocache.go
+++ b/pkg/cmd/gocache/gocache.go
@@ -50,7 +50,7 @@ func NewCmdGoCache() *cobra.Command {
 			}
 
 			token := os.Getenv("DEPOT_CACHE_TOKEN")
-			token, err = helpers.ResolveToken(ctx, token)
+			token, err = helpers.ResolveProjectAuth(ctx, token)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/gocache/gocache.go
+++ b/pkg/cmd/gocache/gocache.go
@@ -49,8 +49,7 @@ func NewCmdGoCache() *cobra.Command {
 				return err
 			}
 
-			token := os.Getenv("DEPOT_CACHE_TOKEN")
-			token, err = helpers.ResolveProjectAuth(ctx, token)
+			token, err = helpers.ResolveOrgAuth(ctx, token)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/init/init.go
+++ b/pkg/cmd/init/init.go
@@ -38,7 +38,7 @@ func NewCmdInit() *cobra.Command {
 				return fmt.Errorf("Project configuration %s already exists at path \"%s\", re-run with `--force` to overwrite", filepath.Base(existingFile), filepath.Dir(existingFile))
 			}
 
-			token, err = helpers.ResolveToken(context.Background(), token)
+			token, err = helpers.ResolveProjectAuth(context.Background(), token)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/list/builds.go
+++ b/pkg/cmd/list/builds.go
@@ -30,7 +30,7 @@ func NewCmdBuilds() *cobra.Command {
 				return errors.Errorf("unknown project ID (run `depot init` or use --project or $DEPOT_PROJECT_ID)")
 			}
 
-			token, err := helpers.ResolveToken(context.Background(), token)
+			token, err := helpers.ResolveProjectAuth(context.Background(), token)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/list/projects.go
+++ b/pkg/cmd/list/projects.go
@@ -32,7 +32,7 @@ func NewCmdProjects(commandName, commandAlias string) *cobra.Command {
 		Aliases: []string{commandAlias},
 		Short:   "List depot projects",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			token, err := helpers.ResolveToken(context.Background(), token)
+			token, err := helpers.ResolveProjectAuth(context.Background(), token)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/projects/create.go
+++ b/pkg/cmd/projects/create.go
@@ -33,7 +33,7 @@ func NewCmdCreate() *cobra.Command {
 			ctx := cmd.Context()
 			projectName := args[0]
 
-			token, err := helpers.ResolveToken(ctx, token)
+			token, err := helpers.ResolveProjectAuth(ctx, token)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/projects/delete.go
+++ b/pkg/cmd/projects/delete.go
@@ -27,7 +27,7 @@ func NewCmdDelete() *cobra.Command {
 			ctx := cmd.Context()
 
 			// Resolve token first
-			token, err := helpers.ResolveToken(cmd.Context(), token)
+			token, err := helpers.ResolveProjectAuth(cmd.Context(), token)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pull/pull.go
+++ b/pkg/cmd/pull/pull.go
@@ -49,7 +49,7 @@ func NewCmdPull() *cobra.Command {
 
 			ctx := cmd.Context()
 
-			token, err := helpers.ResolveToken(ctx, token)
+			token, err := helpers.ResolveProjectAuth(ctx, token)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulltoken/pulltoken.go
+++ b/pkg/cmd/pulltoken/pulltoken.go
@@ -29,7 +29,7 @@ func NewCmdPullToken() *cobra.Command {
 
 			ctx := cmd.Context()
 
-			token, err := helpers.ResolveToken(ctx, token)
+			token, err := helpers.ResolveProjectAuth(ctx, token)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/push/push.go
+++ b/pkg/cmd/push/push.go
@@ -51,7 +51,7 @@ func NewCmdPush() *cobra.Command {
 
 			ctx := cmd.Context()
 
-			token, err := helpers.ResolveToken(ctx, token)
+			token, err := helpers.ResolveProjectAuth(ctx, token)
 			if err != nil {
 				return err
 			}

--- a/pkg/helpers/token.go
+++ b/pkg/helpers/token.go
@@ -40,10 +40,6 @@ func ResolveToken(ctx context.Context, token string) (string, error) {
 		}
 	}
 
-	if token == "" {
-		token = resolveJITToken()
-	}
-
 	if token == "" && IsTerminal() {
 		return AuthorizeDevice(ctx)
 	}
@@ -64,16 +60,4 @@ func AuthorizeDevice(ctx context.Context) (string, error) {
 		return "", err
 	}
 	return tokenResponse.Token, nil
-}
-
-func resolveJITToken() string {
-	if token := os.Getenv("DEPOT_JIT_TOKEN"); token != "" {
-		return token
-	}
-
-	if token := os.Getenv("DEPOT_CACHE_TOKEN"); token != "" {
-		return token
-	}
-
-	return ""
 }

--- a/pkg/helpers/token.go
+++ b/pkg/helpers/token.go
@@ -42,7 +42,7 @@ func ResolveProjectAuth(ctx context.Context, tok string) (string, error) {
 		}
 	}
 
-	if token == "" && IsTerminal() {
+	if IsTerminal() {
 		return AuthorizeDevice(ctx)
 	}
 

--- a/pkg/helpers/token.go
+++ b/pkg/helpers/token.go
@@ -11,8 +11,6 @@ import (
 )
 
 func ResolveProjectAuth(ctx context.Context, tok string) (string, error) {
-	var token string
-
 	if tok != "" {
 		return tok, nil
 	}

--- a/pkg/helpers/token.go
+++ b/pkg/helpers/token.go
@@ -10,7 +10,7 @@ import (
 	"github.com/depot/cli/pkg/oidc"
 )
 
-func ResolveToken(ctx context.Context, token string) (string, error) {
+func ResolveProjectAuth(ctx context.Context, token string) (string, error) {
 	if token == "" {
 		token = os.Getenv("DEPOT_TOKEN")
 	}

--- a/pkg/helpers/token.go
+++ b/pkg/helpers/token.go
@@ -21,8 +21,8 @@ func ResolveProjectAuth(ctx context.Context, tok string) (string, error) {
 		return token, nil
 	}
 
-	if token == "" {
-		token = config.GetApiToken()
+	if token := config.GetApiToken(); token != "" {
+		return token, nil
 	}
 
 	if token == "" {

--- a/pkg/helpers/token.go
+++ b/pkg/helpers/token.go
@@ -25,15 +25,13 @@ func ResolveProjectAuth(ctx context.Context, tok string) (string, error) {
 		return token, nil
 	}
 
-	var err error
 	debug := os.Getenv("DEPOT_DEBUG_OIDC") != ""
-
 	for _, provider := range oidc.Providers {
 		if debug {
 			fmt.Printf("Trying OIDC provider %s\n", provider.Name())
 		}
 
-		token, err = provider.RetrieveToken(ctx)
+		token, err := provider.RetrieveToken(ctx)
 
 		if err != nil && debug {
 			fmt.Printf("OIDC provider %s failed: %v\n", provider.Name(), err)

--- a/pkg/helpers/token.go
+++ b/pkg/helpers/token.go
@@ -10,9 +10,11 @@ import (
 	"github.com/depot/cli/pkg/oidc"
 )
 
-func ResolveProjectAuth(ctx context.Context, token string) (string, error) {
-	if token != "" {
-		return token, nil
+func ResolveProjectAuth(ctx context.Context, tok string) (string, error) {
+	var token string
+
+	if tok != "" {
+		return tok, nil
 	}
 
 	if token == "" {

--- a/pkg/helpers/token.go
+++ b/pkg/helpers/token.go
@@ -45,13 +45,13 @@ func ResolveProjectAuth(ctx context.Context, tok string) (string, error) {
 	}
 
 	if IsTerminal() {
-		return AuthorizeDevice(ctx)
+		return authorizeDevice(ctx)
 	}
 
 	return "", nil
 }
 
-func AuthorizeDevice(ctx context.Context) (string, error) {
+func authorizeDevice(ctx context.Context) (string, error) {
 	tokenResponse, err := api.AuthorizeDevice(ctx)
 	if err != nil {
 		return "", err

--- a/pkg/helpers/token.go
+++ b/pkg/helpers/token.go
@@ -10,6 +10,30 @@ import (
 	"github.com/depot/cli/pkg/oidc"
 )
 
+func ResolveOrgAuth(ctx context.Context, tok string) (string, error) {
+	if tok != "" {
+		return tok, nil
+	}
+
+	if token := os.Getenv("DEPOT_TOKEN"); token != "" {
+		return token, nil
+	}
+
+	if token := config.GetApiToken(); token != "" {
+		return token, nil
+	}
+
+	if token := resolveJITToken(); token != "" {
+		return token, nil
+	}
+
+	if IsTerminal() {
+		return authorizeDevice(ctx)
+	}
+
+	return "", nil
+}
+
 func ResolveProjectAuth(ctx context.Context, tok string) (string, error) {
 	if tok != "" {
 		return tok, nil

--- a/pkg/helpers/token.go
+++ b/pkg/helpers/token.go
@@ -40,6 +40,10 @@ func ResolveProjectAuth(ctx context.Context, tok string) (string, error) {
 		}
 	}
 
+	if token := resolveJITToken(); token != "" {
+		return token, nil
+	}
+
 	if IsTerminal() {
 		return AuthorizeDevice(ctx)
 	}
@@ -60,4 +64,16 @@ func AuthorizeDevice(ctx context.Context) (string, error) {
 		return "", err
 	}
 	return tokenResponse.Token, nil
+}
+
+func resolveJITToken() string {
+	if token := os.Getenv("DEPOT_JIT_TOKEN"); token != "" {
+		return token
+	}
+
+	if token := os.Getenv("DEPOT_CACHE_TOKEN"); token != "" {
+		return token
+	}
+
+	return ""
 }

--- a/pkg/helpers/token.go
+++ b/pkg/helpers/token.go
@@ -25,24 +25,22 @@ func ResolveProjectAuth(ctx context.Context, tok string) (string, error) {
 		return token, nil
 	}
 
-	if token == "" {
-		var err error
-		debug := os.Getenv("DEPOT_DEBUG_OIDC") != ""
+	var err error
+	debug := os.Getenv("DEPOT_DEBUG_OIDC") != ""
 
-		for _, provider := range oidc.Providers {
-			if debug {
-				fmt.Printf("Trying OIDC provider %s\n", provider.Name())
-			}
+	for _, provider := range oidc.Providers {
+		if debug {
+			fmt.Printf("Trying OIDC provider %s\n", provider.Name())
+		}
 
-			token, err = provider.RetrieveToken(ctx)
+		token, err = provider.RetrieveToken(ctx)
 
-			if err != nil && debug {
-				fmt.Printf("OIDC provider %s failed: %v\n", provider.Name(), err)
-			}
+		if err != nil && debug {
+			fmt.Printf("OIDC provider %s failed: %v\n", provider.Name(), err)
+		}
 
-			if token != "" {
-				return token, nil
-			}
+		if token != "" {
+			return token, nil
 		}
 	}
 

--- a/pkg/helpers/token.go
+++ b/pkg/helpers/token.go
@@ -46,7 +46,7 @@ func ResolveProjectAuth(ctx context.Context, tok string) (string, error) {
 		return AuthorizeDevice(ctx)
 	}
 
-	return token, nil
+	return "", nil
 }
 
 func AuthorizeDevice(ctx context.Context) (string, error) {

--- a/pkg/helpers/token.go
+++ b/pkg/helpers/token.go
@@ -17,8 +17,8 @@ func ResolveProjectAuth(ctx context.Context, tok string) (string, error) {
 		return tok, nil
 	}
 
-	if token == "" {
-		token = os.Getenv("DEPOT_TOKEN")
+	if token := os.Getenv("DEPOT_TOKEN"); token != "" {
+		return token, nil
 	}
 
 	if token == "" {

--- a/pkg/helpers/token.go
+++ b/pkg/helpers/token.go
@@ -11,6 +11,10 @@ import (
 )
 
 func ResolveProjectAuth(ctx context.Context, token string) (string, error) {
+	if token != "" {
+		return token, nil
+	}
+
 	if token == "" {
 		token = os.Getenv("DEPOT_TOKEN")
 	}


### PR DESCRIPTION
This is a reimplementation of https://github.com/depot/cli/pull/376.

Many depot commands interact with docker builds and thus operate in the context of a Project. When resolving auth for a project, we try fetching an OIDC token from the current environment, which may later be tied to [trust relationship](https://depot.dev/docs/cli/authentication#oidc-trust-relationships). Other depot commands operate on the parent organization and thus can't use an OIDC token as a valid form of auth.

In this PR we separate resolution logic for org- and project-level auth, and introduce support for JIT tokens as a final fallback to both pathways.