### PR TITLE
Finish multi-project bake builds when complete

### DIFF
--- a/pkg/buildx/commands/bake.go
+++ b/pkg/buildx/commands/bake.go
@@ -368,18 +368,15 @@ func BakeCmd() *cobra.Command {
 
 				func(c command.Cli, o BakeOptions, v BakeValidator, p *progresshelper.SharedPrinter) {
 					eg.Go(func() error {
-						var buildErr error
-						defer func() {
-							o.build.Finish(buildErr)
-							PrintBuildURL(o.buildURL, o.progress)
-						}()
-
-						buildErr = retryRetryableErrors(ctx, func() error {
+						buildErr := retryRetryableErrors(ctx, func() error {
 							return RunBake(c, o, v, p)
 						})
 						if buildErr != nil {
 							_ = p.Wait()
 						}
+
+						o.build.Finish(buildErr)
+						PrintBuildURL(o.buildURL, o.progress)
 
 						return rewriteFriendlyErrors(buildErr)
 					})

--- a/pkg/buildx/commands/bake.go
+++ b/pkg/buildx/commands/bake.go
@@ -337,12 +337,6 @@ func BakeCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				var buildErr error
-				defer func() {
-					build.Finish(buildErr)
-					PrintBuildURL(build.BuildURL, options.progress)
-				}()
-
 				options.builderOptions = []builder.Option{builder.WithDepotOptions(buildPlatform, build)}
 
 				buildProject := build.BuildProject()
@@ -374,6 +368,12 @@ func BakeCmd() *cobra.Command {
 
 				func(c command.Cli, o BakeOptions, v BakeValidator, p *progresshelper.SharedPrinter) {
 					eg.Go(func() error {
+						var buildErr error
+						defer func() {
+							o.build.Finish(buildErr)
+							PrintBuildURL(o.buildURL, o.progress)
+						}()
+
 						buildErr = retryRetryableErrors(ctx, func() error {
 							return RunBake(c, o, v, p)
 						})


### PR DESCRIPTION
Currently when using `depot bake` with multiple project IDs, we are calling `build.Finish()` when the entire `BakeCmd()` function returns, which means that all sub-builds for each of the participating projects wait to be marked as done until every build is done.

This PR moves the `build.Finish()` into the sub-build goroutine, so that builds are able to complete as soon as they are actually done, without waiting on each other.