### PR TITLE
`claude` command generates invalid urls if org id not set

### DIFF
--- a/pkg/cmd/claude/remote.go
+++ b/pkg/cmd/claude/remote.go
@@ -51,6 +51,9 @@ func RunAgentRemote(ctx context.Context, opts *AgentRemoteOptions) error {
 	}
 
 	if opts.OrgID == "" {
+		if os.Getenv("DEPOT_ORG_ID") == "" {
+			return fmt.Errorf("organization ID is required. Set it via --org flag, DEPOT_ORG_ID environment variable, or run 'depot org switch <org-id>'")
+		}
 		opts.OrgID = os.Getenv("DEPOT_ORG_ID")
 	}
 


### PR DESCRIPTION
Unsure how/when this is supposed to be setup. 

After running:

```bash
depot claude \                                                                 INT ✘ 
  --session-id feature-auth \
  --repository https://github.com/howdy/doody \
  --branch main \
  "Give me a general summary of this repository"
```

I get

```bash
✓ Claude sandbox started!
  Session ID: feature-auth
  Link: https://depot.dev/orgs//claude/feature-auth
```

When I run `depot org list` I see a bunch, but when I run `depot org show` it's empty.

So feel like this should probably failfast? Or the default org should be inferred? Unsure how y'all want to handle