### PR TITLE
Hide save summary and upgrade message with env var

### DIFF
--- a/cmd/depot/main.go
+++ b/cmd/depot/main.go
@@ -134,7 +134,7 @@ func runMain() int {
 	}
 
 	newRelease := <-updateMessageChan
-	if newRelease != nil {
+	if newRelease != nil && os.Getenv("DEPOT_NO_SUMMARY_LINK") == "" {
 		isHomebrew := update.IsUnderHomebrew()
 		fmt.Fprintf(os.Stderr, "\n\n%s%s%s %s → %s\n",
 			ansi.Color("A new release of depot is available, released on ", "yellow"),

--- a/pkg/buildx/commands/bake.go
+++ b/pkg/buildx/commands/bake.go
@@ -597,7 +597,7 @@ func parseBakeTargets(targets []string) (bkt bakeTargets) {
 
 // printSaveHelp prints instructions to pull or push the saved targets.
 func printSaveHelp(project, buildID, progressMode string, requestedTargets, additionalTags []string) {
-	if progressMode != progress.PrinterModeQuiet {
+	if progressMode != progress.PrinterModeQuiet && os.Getenv("DEPOT_NO_SUMMARY_LINK") == "" {
 		fmt.Fprintln(os.Stderr)
 		saved := "target"
 		if len(requestedTargets) > 1 {


### PR DESCRIPTION
This updates `DEPOT_NO_SUMMARY_LINK` to also hide upgrade notices and `--save` help text.