### PR TITLE
Fix `--load` attempting to pull extra targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ bin/depot:
 
 .PHONY: image
 image:
-	docker --context=default buildx build --builder default -t public.ecr.aws/depot/cli:0.0.0-dev --load .
+	docker --context=desktop-linux buildx build --builder desktop-linux -t public.ecr.aws/depot/cli:0.0.0-dev --load .
 
 .PHONY: npm
 npm:

--- a/pkg/buildx/commands/build.go
+++ b/pkg/buildx/commands/build.go
@@ -330,7 +330,13 @@ func buildTargets(ctx context.Context, dockerCli command.Cli, nodes []builder.No
 	reportingPrinter := progresshelper.NewReporter(ctx, printer, depotOpts.buildID, depotOpts.token)
 
 	if depotOpts.loadUsingRegistry && depotOpts.pullInfo != nil {
-		err = load.DepotLoadFromRegistry(ctx, dockerCli.Client(), depotOpts.pullInfo.Reference, false, pullOpts, reportingPrinter)
+		for target, pullOpt := range pullOpts {
+			pw := progress.WithPrefix(reportingPrinter, target, len(pullOpts) > 1)
+			err = load.PullImages(ctx, dockerCli.Client(), depotOpts.pullInfo.Reference, pullOpt, pw)
+			if err != nil {
+				break
+			}
+		}
 	} else {
 		err = load.DepotFastLoad(ctx, dockerCli.Client(), resp, pullOpts, reportingPrinter)
 	}

--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -75,29 +75,6 @@ func DepotFastLoad(ctx context.Context, dockerapi docker.APIClient, resp []depot
 	return nil
 }
 
-func DepotLoadFromRegistry(ctx context.Context, dockerapi docker.APIClient, reference string, isBake bool, pullOpts map[string]PullOptions, printer progress.Writer) error {
-	if len(pullOpts) == 0 {
-		return nil
-	}
-
-	for target, pullOpt := range pullOpts {
-		pw := progress.WithPrefix(printer, target, len(pullOpts) > 1)
-
-		imageName := reference
-
-		if isBake {
-			imageName = fmt.Sprintf("%s-%s", reference, target)
-		}
-
-		err := PullImages(ctx, dockerapi, imageName, pullOpt, pw)
-		if err != nil {
-			return fmt.Errorf("failed to pull image: %w", err)
-		}
-	}
-
-	return nil
-}
-
 // For now if there is a multi-platform build we try to only download the
 // architecture of the depot CLI host.  If there is not a node with the same
 // architecture as the  depot CLI host, we take the first node in the list.


### PR DESCRIPTION
We recently fixed an issue where intermediate non-requested targets in a bake file were pushed to our registry. They no longer are, but now `--load` was still attempting to pull these non-requested targets when using our registry.

This PR updates `--load` so that it also only tries to load the requested targets as well.