### PR TITLE
chore: migrate cmd - reverse order of next steps when secrets detected

### DIFF
--- a/pkg/cmd/ci/migrate.go
+++ b/pkg/cmd/ci/migrate.go
@@ -640,16 +640,22 @@ func workflows(opts migrateOptions) error {
 
 	fmt.Fprintln(out, "")
 	fmt.Fprintf(out, "%s\n\n", bold.Render("Next steps:"))
-	if defaultBranch != "" {
-		fmt.Fprintf(out, "  1. Activate these workflows by pushing and merging them into %s\n", bold.Render(defaultBranch))
-	} else {
-		fmt.Fprintln(out, "  1. Activate these workflows by pushing and merging them into your default branch")
-	}
 
 	if len(detectedSecrets) > 0 || len(detectedVariables) > 0 {
-		fmt.Fprintf(out, "  2. Your workflows depend on %d secret(s) and %d variable(s) which need to be imported from GitHub:\n", len(detectedSecrets), len(detectedVariables))
+		fmt.Fprintf(out, "  1. Your workflows depend on %d secret(s) and %d variable(s) which need to be imported from GitHub:\n", len(detectedSecrets), len(detectedVariables))
 		fmt.Fprintln(out, "     - Import them automatically with `depot ci migrate secrets-and-vars`")
 		fmt.Fprintln(out, "     - Or import them manually with `depot ci secrets add` and `depot ci vars add`")
+		if defaultBranch != "" {
+			fmt.Fprintf(out, "  2. Activate these workflows by pushing and merging them into %s\n", bold.Render(defaultBranch))
+		} else {
+			fmt.Fprintln(out, "  2. Activate these workflows by pushing and merging them into your default branch")
+		}
+	} else {
+		if defaultBranch != "" {
+			fmt.Fprintf(out, "  Activate these workflows by pushing and merging them into %s\n", bold.Render(defaultBranch))
+		} else {
+			fmt.Fprintln(out, "  Activate these workflows by pushing and merging them into your default branch")
+		}
 	}
 
 	fmt.Fprintln(out, "")


### PR DESCRIPTION
This PR changes the output of the `depot ci migrate` command:
- when secrets or variables are detected, the Next steps are reversed to suggest 1)importing secrets and vars 2) push and merge to default branch
- this means the first workflow run has a better chance of passing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts `depot ci migrate` console messaging/step numbering, with no changes to migration logic or API calls.
> 
> **Overview**
> Updates `depot ci migrate` "Next steps" output so that when secrets/variables are detected it now instructs users to **import secrets/vars first** (step 1) and **activate workflows by merging to the default branch second** (step 2). When no secrets/vars are found, it prints only the activation instruction (without numbered steps).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8963b45bf1b398d77a39b41ce22cdaf562bb6024. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->