### PR TITLE
fix: include untracked .depot/ files in workspace patches

### DIFF
--- a/pkg/cmd/ci/run.go
+++ b/pkg/cmd/ci/run.go
@@ -396,7 +396,37 @@ func detectPatch(workflowDir string) *patchInfo {
 		return nil
 	}
 
+	repoRoot := resolveRepoRoot(workflowDir)
+	if repoRoot == "" {
+		repoRoot = workflowDir
+	}
+
+	// Temporarily track untracked .depot/ files so they appear in the diff.
+	// git diff only sees tracked files; without this, new local actions that
+	// haven't been staged/committed are invisible to the workspace patch.
+	untrackedFiles := findUntrackedDepotFiles(repoRoot)
+	addedToIndex := false
+	if len(untrackedFiles) > 0 {
+		addArgs := append([]string{"-C", repoRoot, "add", "-N", "--"}, untrackedFiles...)
+		if err := exec.Command("git", addArgs...).Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to stage .depot/ files for patch: %v\n", err)
+		} else {
+			addedToIndex = true
+			defer func() {
+				if addedToIndex {
+					resetIntentToAdd(repoRoot, untrackedFiles)
+				}
+			}()
+		}
+	}
+
 	diffOut, err := exec.Command("git", "-C", workflowDir, "diff", "--binary", mergeBase).Output()
+
+	if addedToIndex {
+		resetIntentToAdd(repoRoot, untrackedFiles)
+		addedToIndex = false
+	}
+
 	if err != nil {
 		return nil
 	}
@@ -411,6 +441,37 @@ func detectPatch(workflowDir string) *patchInfo {
 		mergeBase:  mergeBase,
 		content:    content,
 	}
+}
+
+func resetIntentToAdd(repoRoot string, files []string) {
+	args := append([]string{"-C", repoRoot, "reset", "--"}, files...)
+	if err := exec.Command("git", args...).Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to reset intent-to-add .depot/ files: %v\n", err)
+	}
+}
+
+func resolveRepoRoot(dir string) string {
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// findUntrackedDepotFiles returns untracked files under .depot/ so the
+// workspace patch can include new local actions and workflows.
+func findUntrackedDepotFiles(repoRoot string) []string {
+	out, err := exec.Command("git", "-C", repoRoot, "ls-files", "--others", "--exclude-standard", "--", ".depot/").Output()
+	if err != nil {
+		return nil
+	}
+	var files []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line != "" {
+			files = append(files, line)
+		}
+	}
+	return files
 }
 
 // resolveJobDeps returns the set of job names that must be included to satisfy

--- a/pkg/cmd/ci/run_test.go
+++ b/pkg/cmd/ci/run_test.go
@@ -277,3 +277,93 @@ func TestSetRunRequestGitContext_noPatch_headUnresolved(t *testing.T) {
 		t.Fatalf("WorkspacePatchCacheKey should be unset, got %q", req.GetWorkspacePatchCacheKey())
 	}
 }
+
+func TestFindUntrackedDepotFiles_includesNewActions(t *testing.T) {
+	bare := initBareRemote(t)
+	clone := cloneRepo(t, bare)
+
+	// Create untracked .depot/ files
+	depotDir := filepath.Join(clone, ".depot", "actions", "my-action")
+	if err := os.MkdirAll(depotDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(depotDir, "action.yml"), "name: test")
+
+	files := findUntrackedDepotFiles(clone)
+	if len(files) != 1 {
+		t.Fatalf("expected 1 untracked file, got %d: %v", len(files), files)
+	}
+	if files[0] != ".depot/actions/my-action/action.yml" {
+		t.Errorf("expected .depot/actions/my-action/action.yml, got %q", files[0])
+	}
+}
+
+func TestFindUntrackedDepotFiles_emptyWhenAllTracked(t *testing.T) {
+	bare := initBareRemote(t)
+	clone := cloneRepo(t, bare)
+
+	files := findUntrackedDepotFiles(clone)
+	if len(files) != 0 {
+		t.Fatalf("expected no untracked files, got %d: %v", len(files), files)
+	}
+}
+
+func TestFindUntrackedDepotFiles_excludesNonDepotFiles(t *testing.T) {
+	bare := initBareRemote(t)
+	clone := cloneRepo(t, bare)
+
+	// Create untracked files both inside and outside .depot/
+	depotDir := filepath.Join(clone, ".depot", "actions", "test")
+	if err := os.MkdirAll(depotDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(depotDir, "action.yml"), "name: test")
+	writeFile(t, filepath.Join(clone, "unrelated.txt"), "not depot")
+
+	files := findUntrackedDepotFiles(clone)
+	if len(files) != 1 {
+		t.Fatalf("expected 1 untracked file, got %d: %v", len(files), files)
+	}
+}
+
+func TestDetectPatch_includesUntrackedDepotFiles(t *testing.T) {
+	bare := initBareRemote(t)
+	clone := cloneRepo(t, bare)
+
+	// Create an untracked .depot/ action
+	actionDir := filepath.Join(clone, ".depot", "actions", "local-action")
+	if err := os.MkdirAll(actionDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(actionDir, "action.yml"), "name: local\nruns:\n  using: composite\n  steps:\n    - run: echo hi\n      shell: bash")
+
+	patch := detectPatch(clone)
+	if patch == nil {
+		t.Fatal("expected patch to be generated for untracked .depot/ files")
+	}
+	if !strings.Contains(patch.content, ".depot/actions/local-action/action.yml") {
+		t.Error("patch should contain the new action file")
+	}
+
+	// Verify git state is clean after detectPatch
+	status := run(t, clone, "git", "status", "--short")
+	for _, line := range strings.Split(status, "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		// All .depot/ files should be back to untracked (??)
+		if strings.Contains(line, ".depot/") && !strings.HasPrefix(line, "??") {
+			t.Errorf("expected .depot/ files to be untracked after detectPatch, got: %s", line)
+		}
+	}
+}
+
+func TestDetectPatch_noChanges(t *testing.T) {
+	bare := initBareRemote(t)
+	clone := cloneRepo(t, bare)
+
+	patch := detectPatch(clone)
+	if patch != nil {
+		t.Fatalf("expected nil patch when no changes, got %+v", patch)
+	}
+}


### PR DESCRIPTION
## Summary

`depot ci run` was ghosting your local composite actions — if they weren't `git add`'d yet, they simply didn't exist as far as the workspace patch was concerned.

## What was happening

The CLI generates a workspace patch via `git diff` to ship local changes to the sandbox. But `git diff` only sees **tracked** files. If you create a new `.depot/actions/my-action/` directory and run `depot ci run` before staging it, the action files are invisible to the diff — the patch gets uploaded without them, and the runner fails with `action manifest not found`.

## What happens now

Before generating the diff, the CLI temporarily marks untracked `.depot/` files with `git add -N` (intent-to-add), making them visible to `git diff`. The index is reset immediately after the diff is captured. From the user's perspective, nothing changes — `git status` looks identical before and after `depot ci run`.

| | Stock CLI (v2.101.41) | Patched CLI (dev) |
|---|---|---|
| **Patch generated** | No patch (untracked files invisible) | 3349 bytes (includes `.depot/` files) |
| **Job result** | **FAILED** | **PASSED** |
| **Error** | `action manifest not found in .depot/actions/dep-4165-test` | — |
| **Output** | — | `PASS: Local composite action resolved and ran correctly` |

## Anything else?

- Only `.depot/` files are affected — untracked files outside that directory are never touched
- If `git add -N` or `git reset` fails, a warning is printed to stderr (no silent swallowing)
- The eager reset + deferred safety net pattern minimizes the window where the index has intent-to-add entries

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches patch generation by temporarily modifying the git index (`add -N`/`reset`) to capture untracked `.depot/` files; failures could leave unexpected index state or alter diff output in edge cases.
> 
> **Overview**
> `depot ci run` now includes **untracked files under `.depot/`** (e.g., new local composite actions/workflows) in the workspace patch by temporarily marking them as intent-to-add before running `git diff`.
> 
> Adds helpers to resolve the repo root, list untracked `.depot/` files, and reliably reset the index afterward (with stderr warnings on failure), plus tests covering inclusion/exclusion behavior and ensuring `detectPatch` leaves `git status` unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03452679810ff1cd0a35fb608cb90f37ce69ddca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->