### PR TITLE
feat: add --org flag to sandbox exec/pty/exec-pipe (DEP-4184)

### DIFF
--- a/pkg/cmd/sandbox/exec-pipe.go
+++ b/pkg/cmd/sandbox/exec-pipe.go
@@ -37,6 +37,9 @@ func newSandboxExecPipe() *cobra.Command {
 				return fmt.Errorf("failed to resolve token: %w", err)
 			}
 
+			orgID, err := cmd.Flags().GetString("org")
+			cobra.CheckErr(err)
+
 			sandboxID, err := cmd.Flags().GetString("sandbox-id")
 			cobra.CheckErr(err)
 
@@ -60,6 +63,9 @@ func newSandboxExecPipe() *cobra.Command {
 			client := api.NewComputeClient()
 			stream := client.ExecPipe(ctx)
 			stream.RequestHeader().Set("Authorization", "Bearer "+token)
+			if orgID != "" {
+				stream.RequestHeader().Set("x-depot-org", orgID)
+			}
 
 			// Send init message with the command.
 			if err := stream.Send(&civ1.ExecuteCommandPipeRequest{

--- a/pkg/cmd/sandbox/exec-pipe.go
+++ b/pkg/cmd/sandbox/exec-pipe.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/depot/cli/pkg/api"
+	"github.com/depot/cli/pkg/config"
 	"github.com/depot/cli/pkg/helpers"
 	civ1 "github.com/depot/cli/pkg/proto/depot/ci/v1"
 	"github.com/spf13/cobra"
@@ -39,6 +40,10 @@ func newSandboxExecPipe() *cobra.Command {
 
 			orgID, err := cmd.Flags().GetString("org")
 			cobra.CheckErr(err)
+
+			if orgID == "" {
+				orgID = config.GetCurrentOrganization()
+			}
 
 			sandboxID, err := cmd.Flags().GetString("sandbox-id")
 			cobra.CheckErr(err)

--- a/pkg/cmd/sandbox/exec.go
+++ b/pkg/cmd/sandbox/exec.go
@@ -6,6 +6,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/depot/cli/pkg/api"
+	"github.com/depot/cli/pkg/config"
 	"github.com/depot/cli/pkg/helpers"
 	civ1 "github.com/depot/cli/pkg/proto/depot/ci/v1"
 	"github.com/spf13/cobra"
@@ -40,6 +41,10 @@ func newSandboxExec() *cobra.Command {
 
 			orgID, err := cmd.Flags().GetString("org")
 			cobra.CheckErr(err)
+
+			if orgID == "" {
+				orgID = config.GetCurrentOrganization()
+			}
 
 			sandboxID, err := cmd.Flags().GetString("sandbox-id")
 			cobra.CheckErr(err)

--- a/pkg/cmd/sandbox/exec.go
+++ b/pkg/cmd/sandbox/exec.go
@@ -38,6 +38,9 @@ func newSandboxExec() *cobra.Command {
 				return fmt.Errorf("failed to resolve token: %w", err)
 			}
 
+			orgID, err := cmd.Flags().GetString("org")
+			cobra.CheckErr(err)
+
 			sandboxID, err := cmd.Flags().GetString("sandbox-id")
 			cobra.CheckErr(err)
 
@@ -57,14 +60,14 @@ func newSandboxExec() *cobra.Command {
 
 			client := api.NewComputeClient()
 
-			stream, err := client.RemoteExec(ctx, api.WithAuthentication(connect.NewRequest(&civ1.ExecuteCommandRequest{
+			stream, err := client.RemoteExec(ctx, api.WithAuthenticationAndOrg(connect.NewRequest(&civ1.ExecuteCommandRequest{
 				SandboxId: sandboxID,
 				SessionId: sessionID,
 				Command: &civ1.Command{
 					CommandArray: args,
 					TimeoutMs:    int32(timeout),
 				},
-			}), token))
+			}), token, orgID))
 			if err != nil {
 				// nolint:wrapcheck
 				return err

--- a/pkg/cmd/sandbox/pty.go
+++ b/pkg/cmd/sandbox/pty.go
@@ -35,6 +35,9 @@ func newSandboxPty() *cobra.Command {
 				return fmt.Errorf("failed to resolve token: %w", err)
 			}
 
+			orgID, err := cmd.Flags().GetString("org")
+			cobra.CheckErr(err)
+
 			sandboxID, err := cmd.Flags().GetString("sandbox-id")
 			cobra.CheckErr(err)
 
@@ -66,6 +69,7 @@ func newSandboxPty() *cobra.Command {
 
 			return pty.Run(ctx, pty.SessionOptions{
 				Token:     token,
+				OrgID:     orgID,
 				SandboxID: sandboxID,
 				SessionID: sessionID,
 				Cwd:       cwd,

--- a/pkg/cmd/sandbox/pty.go
+++ b/pkg/cmd/sandbox/pty.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/depot/cli/pkg/config"
 	"github.com/depot/cli/pkg/helpers"
 	"github.com/depot/cli/pkg/pty"
 	"github.com/spf13/cobra"
@@ -37,6 +38,10 @@ func newSandboxPty() *cobra.Command {
 
 			orgID, err := cmd.Flags().GetString("org")
 			cobra.CheckErr(err)
+
+			if orgID == "" {
+				orgID = config.GetCurrentOrganization()
+			}
 
 			sandboxID, err := cmd.Flags().GetString("sandbox-id")
 			cobra.CheckErr(err)

--- a/pkg/cmd/sandbox/sandbox.go
+++ b/pkg/cmd/sandbox/sandbox.go
@@ -19,6 +19,7 @@ Subcommands:
 	}
 
 	cmd.PersistentFlags().String("token", "", "Depot API token")
+	cmd.PersistentFlags().String("org", "", "Organization ID (required when user is a member of multiple organizations)")
 
 	cmd.AddCommand(newSandboxExec())
 	cmd.AddCommand(newSandboxPty())


### PR DESCRIPTION
## Summary
- Adds `--org` persistent flag to `depot sandbox` parent command
- Threads org ID through to `x-depot-org` header in exec, pty, and exec-pipe subcommands
- Fixes `Unauthorized` error for multi-org users calling `depot sandbox exec/pty/exec-pipe`

The Go API's `RemoteExec` and `OpenPtySession` RPCs require `x-depot-org` to disambiguate when the bearer token resolves to a user in multiple orgs. `depot ci ssh` already handles this via its parent command's `--org` flag — this brings parity to the sandbox commands.

## Test plan
- [x] `depot sandbox exec --org <org> --sandbox-id <id> --session-id <sid> -- whoami` — auth passes (previously returned `Unauthorized`)
- [ ] Verify exec output streams correctly (blocked on host proxy networking — DEP-4130)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds organization scoping to sandbox RPC requests, which affects authentication/authorization behavior for multi-org users. Low code complexity, but incorrect org selection could still cause unexpected access errors or target the wrong org.
> 
> **Overview**
> Adds a persistent `--org` flag to `depot sandbox` and defaults it from `config.GetCurrentOrganization()` when not provided.
> 
> Threads the resolved org ID through sandbox subcommands: `exec` now uses `api.WithAuthenticationAndOrg`, `exec-pipe` sets `x-depot-org` on the streaming request headers, and `pty` passes `OrgID` into `pty.SessionOptions`, fixing `Unauthorized` for users in multiple orgs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04c850fedd7839408a851fb8807a3bf861f4f199. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->