### PR TITLE
fix: disable external diff drivers in workspace patch generation

### DIFF
--- a/pkg/cmd/ci/run.go
+++ b/pkg/cmd/ci/run.go
@@ -420,7 +420,7 @@ func detectPatch(workflowDir string) *patchInfo {
 		}
 	}
 
-	diffOut, err := exec.Command("git", "-C", workflowDir, "diff", "--binary", mergeBase).Output()
+	diffOut, err := exec.Command("git", "-C", workflowDir, "diff", "--binary", "--no-ext-diff", mergeBase).Output()
 
 	if addedToIndex {
 		resetIntentToAdd(repoRoot, untrackedFiles)


### PR DESCRIPTION
## Summary

Workspace patches generated by `depot ci run` could silently contain non-diff content when a user has an external diff driver configured, causing all local actions to be invisible at compile and runtime.

## What was happening

`git diff --binary` does **not** disable external diff drivers (`GIT_EXTERNAL_DIFF` env var or `diff.external` in gitconfig). If a user has one configured (e.g. `difft`, `delta`, or a custom viewer), the diff output is in whatever format that tool produces instead of unified diff. This non-diff content gets uploaded to the cache, and then `git apply --allow-empty` silently succeeds with zero hunks applied — so `.depot/` files are never materialized on disk.

## What happens now

Added `--no-ext-diff` to the `git diff` command in `detectPatch()`, which forces git's internal diff engine regardless of user configuration.

| | Released CLI | Patched CLI |
|---|---|---|
| `GIT_EXTERNAL_DIFF` set | 549 bytes (rendered, not a diff) | 820 bytes (valid unified diff) |
| Job result | **FAILED** — `action manifest not found` | **PASSED** |


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single flag change to patch generation; low blast radius and primarily improves determinism of `git diff` output.
> 
> **Overview**
> Fixes workspace patch generation for `depot ci run` by forcing Git’s built-in diff output: `detectPatch()` now runs `git diff --binary --no-ext-diff` so user-configured external diff drivers can’t replace the unified diff content that gets uploaded/applied.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a55ff39f0c8d78f7b3c49d8d0ae38c99b31298a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->