### PR TITLE
Fix bake project ID sync after onboarding resolution

### DIFF
--- a/pkg/buildx/bake/bake.go
+++ b/pkg/buildx/bake/bake.go
@@ -1046,6 +1046,35 @@ func (o *DepotBakeOptions) ProjectIDs() []string {
 	return projectIDs
 }
 
+// WithResolvedProjectID returns a copy of the bake options keyed by the
+// resolved project ID returned from the API. This keeps the original options
+// stable for other in-flight project builds while fixing lookups for the
+// current build after onboarding rewrites the project ID.
+func (o *DepotBakeOptions) WithResolvedProjectID(requestedID, resolvedID string) *DepotBakeOptions {
+	if o == nil || resolvedID == "" || requestedID == "" || requestedID == resolvedID {
+		return o
+	}
+
+	projectOpts, ok := o.ProjectTargetOptions[requestedID]
+	if !ok {
+		return o
+	}
+	if _, ok := o.ProjectTargetOptions[resolvedID]; ok {
+		return o
+	}
+
+	projectTargetOptions := make(map[string]map[string]build.Options, len(o.ProjectTargetOptions))
+	for projectID, targetOpts := range o.ProjectTargetOptions {
+		projectTargetOptions[projectID] = targetOpts
+	}
+	projectTargetOptions[resolvedID] = projectOpts
+	delete(projectTargetOptions, requestedID)
+
+	return &DepotBakeOptions{
+		ProjectTargetOptions: projectTargetOptions,
+	}
+}
+
 func updateContext(t *build.Inputs, inp *Input) {
 	if inp == nil || inp.State == nil {
 		return

--- a/pkg/buildx/bake/bake_test.go
+++ b/pkg/buildx/bake/bake_test.go
@@ -5,8 +5,33 @@ import (
 	"testing"
 
 	"github.com/depot/cli/pkg/buildx/bake"
+	build "github.com/docker/buildx/build"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDepotBakeOptionsWithResolvedProjectID(t *testing.T) {
+	opts := &bake.DepotBakeOptions{
+		ProjectTargetOptions: map[string]map[string]build.Options{
+			"default": {
+				"web-prod": {},
+			},
+			"other-project": {
+				"worker": {},
+			},
+		},
+	}
+
+	resolved := opts.WithResolvedProjectID("default", "2g91tjw9dr")
+	require.NotNil(t, resolved)
+
+	require.Nil(t, resolved.ProjectOpts("default"))
+	require.Contains(t, resolved.ProjectOpts("2g91tjw9dr"), "web-prod")
+	require.Contains(t, resolved.ProjectOpts("other-project"), "worker")
+
+	// Ensure the original options remain untouched for any parallel builds.
+	require.Contains(t, opts.ProjectOpts("default"), "web-prod")
+	require.Nil(t, opts.ProjectOpts("2g91tjw9dr"))
+}
 
 func TestReadTargets(t *testing.T) {
 	fp := bake.File{

--- a/pkg/buildx/commands/bake.go
+++ b/pkg/buildx/commands/bake.go
@@ -37,9 +37,10 @@ import (
 )
 
 type BakeOptions struct {
-	files     []string
-	overrides []string
-	printOnly bool
+	files            []string
+	overrides        []string
+	printOnly        bool
+	requestedProject string
 	commonOptions
 	DepotOptions
 }
@@ -80,6 +81,10 @@ func RunBake(dockerCli command.Cli, in BakeOptions, validator BakeValidator, pri
 	}
 
 	buildOpts := validatedOpts.ProjectOpts(in.project)
+	if buildOpts == nil && in.requestedProject != "" {
+		validatedOpts = validatedOpts.WithResolvedProjectID(in.requestedProject, in.project)
+		buildOpts = validatedOpts.ProjectOpts(in.project)
+	}
 	if buildOpts == nil {
 		return nil, nil, fmt.Errorf("project %s build options not found", in.project)
 	}
@@ -288,6 +293,7 @@ func BakeCmd() *cobra.Command {
 			}
 
 			options.project = helpers.ResolveProjectID(options.project, options.files...)
+			options.requestedProject = options.project
 
 			buildPlatform, err := helpers.ResolveBuildPlatform(options.buildPlatform)
 			if err != nil {

--- a/pkg/buildx/commands/bake.go
+++ b/pkg/buildx/commands/bake.go
@@ -342,6 +342,7 @@ func BakeCmd() *cobra.Command {
 			eg, ctx := errgroup.WithContext(context.Background())
 			for _, projectID := range projectIDs {
 				options.project = projectID
+				options.requestedProject = projectID
 				bakeOpts := validatedOpts.ProjectOpts(projectID)
 
 				req := helpers.NewBakeRequest(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- preserve the original `--project` input separately from the canonical project ID returned by build creation
- re-key validated bake options to the resolved project ID when `RunBake` would otherwise miss after onboarding rewrites the project
- add regression coverage for the bake-options re-key helper to ensure the original map stays unchanged for parallel builds

## Testing
- `go test ./pkg/buildx/bake ./pkg/buildx/commands`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DEP-4071](https://linear.app/depot/issue/DEP-4071/cli-bake-confusing-build-options-not-found-error-when-project-receives)

<div><a href="https://cursor.com/agents/bc-42b57d20-7324-46da-8f10-e8247cba6335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42b57d20-7324-46da-8f10-e8247cba6335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

