### PR TITLE
Use unique names for local context in bake

### DIFF
--- a/pkg/buildx/build/build.go
+++ b/pkg/buildx/build/build.go
@@ -324,7 +324,7 @@ func toRepoOnly(in string) (string, error) {
 	return strings.Join(out, ","), nil
 }
 
-func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Options, configDir string, pw progress.Writer, dl dockerLoadCallback) (solveOpt *client.SolveOpt, dockerfile *DockerfileInputs, release func(), err error) {
+func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, name string, opt Options, configDir string, pw progress.Writer, dl dockerLoadCallback) (solveOpt *client.SolveOpt, dockerfile *DockerfileInputs, release func(), err error) {
 	nodeDriver := node.Driver
 	defers := make([]func(), 0, 2)
 	releaseF := func() {
@@ -536,7 +536,7 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Op
 		if p, err := filepath.Abs(sharedKey); err == nil {
 			sharedKey = filepath.Base(p)
 		}
-		so.SharedKey = sharedKey + ":" + tryNodeIdentifier(configDir)
+		so.SharedKey = sharedKey + ":" + name + ":" + tryNodeIdentifier(configDir)
 	}
 
 	if opt.Pull {
@@ -851,7 +851,7 @@ func BuildWithResultHandler(ctx context.Context, nodes []builder.Node, opt map[s
 				hasMobyDriver = true
 			}
 			opt.Platforms = np.platforms
-			so, dockerfile, release, err := toSolveOpt(ctx, node, multiDriver, opt, configDir, w, func(name string) (io.WriteCloser, func(), error) {
+			so, dockerfile, release, err := toSolveOpt(ctx, node, multiDriver, k, opt, configDir, w, func(name string) (io.WriteCloser, func(), error) {
 				return docker.LoadImage(ctx, name, w)
 			})
 			if err != nil {
@@ -980,6 +980,7 @@ func BuildWithResultHandler(ctx context.Context, nodes []builder.Node, opt map[s
 				pw := progress.WithPrefix(w, k, multiTarget)
 
 				c := clients[dp.driverIndex]
+
 				eg2.Go(func() error {
 					debuglog.Log("Preparing to call client Build()")
 					pw = progress.ResetTime(pw)


### PR DESCRIPTION
Bake targets that look at the local context + filter that local context can potentially overwrite each other, leading to sometimes files being missing. This PR adds the name to the cache key to make the local contexts unique

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how BuildKit `SharedKey` is computed for local contexts, which can affect cache sharing and concurrency behavior across bake targets.
> 
> **Overview**
> Prevents bake targets that use filtered local contexts from overwriting each other by making the BuildKit local-context `SharedKey` **target-specific**.
> 
> `toSolveOpt` now takes the bake target name and includes it in `so.SharedKey` (alongside the context basename and node identifier), ensuring parallel targets don’t collide when sharing the same local context path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f557b10d8bd0c581b7fffdf6374829bda8667a8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->