### PR TITLE
Implement `depot api-token` command for envfiles, etc

### DIFF
--- a/pkg/cmd/apitoken/apitoken.go
+++ b/pkg/cmd/apitoken/apitoken.go
@@ -1,0 +1,25 @@
+package apitoken
+
+import (
+	"fmt"
+
+	"github.com/depot/cli/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdApiToken() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "api-token",
+		Short: "Get the API token for a Depot login",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			token := config.GetApiToken()
+			if token == "" {
+				return fmt.Errorf("missing API token, please run `depot login`")
+			}
+
+			fmt.Println(token)
+			return nil
+		},
+	}
+	return cmd
+}

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	apiTokenCmd "github.com/depot/cli/pkg/cmd/apitoken"
 	bakeCmd "github.com/depot/cli/pkg/cmd/bake"
 	"github.com/depot/cli/pkg/cmd/blog"
 	buildCmd "github.com/depot/cli/pkg/cmd/build"
@@ -62,6 +63,7 @@ func NewCmdRoot(version, buildDate string) *cobra.Command {
 	_ = cmd.PersistentFlags().MarkHidden("config")
 
 	// Child commands
+	cmd.AddCommand(apiTokenCmd.NewCmdApiToken())
 	cmd.AddCommand(bakeCmd.NewCmdBake())
 	cmd.AddCommand(blog.NewCmdBlog())
 	cmd.AddCommand(buildCmd.NewCmdBuild())


### PR DESCRIPTION
My org is in the process of adopting Moonrepo with Depot Cache, and the need for each user to manually sign into the Depot user settings page and mint an API token to set up their [config](https://depot.dev/docs/cache/integrations/moonrepo) is a point of friction. This PR adds a new subcommand `depot api-token` which simply prints the Depot CLI's user token to stdout or errors; if this ships, I can then put `DEPOT_CACHE_TOKEN=$(depot api-token || echo '')` in a shared envfile configuration and solve this problem for everyone at once.

Tested: I built the CLI locally and ran `depot api-token` in both logged-in and logged-out states and it worked as expected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a read-only CLI subcommand that prints the locally stored API token; no changes to token storage, auth flows, or network behavior.
> 
> **Overview**
> Adds a new `depot api-token` subcommand that prints the configured API token to stdout and errors with an actionable message if no token is present.
> 
> Registers the new command in `pkg/cmd/root/root.go` so it is available alongside existing CLI subcommands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a092458270b2d518498888c708d465ce1b3a07ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->