### PR TITLE
Add JSON output for depot ci status

### DIFF
--- a/pkg/cmd/ci/status.go
+++ b/pkg/cmd/ci/status.go
@@ -5,13 +5,15 @@ import (
 
 	"github.com/depot/cli/pkg/config"
 	"github.com/depot/cli/pkg/helpers"
+	civ1 "github.com/depot/cli/pkg/proto/depot/ci/v1"
 	"github.com/spf13/cobra"
 )
 
 func NewCmdStatus() *cobra.Command {
 	var (
-		orgID string
-		token string
+		orgID  string
+		token  string
+		output string
 	)
 
 	cmd := &cobra.Command{
@@ -25,6 +27,12 @@ func NewCmdStatus() *cobra.Command {
 
 			ctx := cmd.Context()
 			runID := args[0]
+
+			switch output {
+			case "", "json":
+			default:
+				return fmt.Errorf("unsupported output %q (valid: json)", output)
+			}
 
 			if orgID == "" {
 				orgID = config.GetCurrentOrganization()
@@ -47,6 +55,9 @@ func NewCmdStatus() *cobra.Command {
 			if cmd.Flags().Changed("org") {
 				orgFlag = " --org " + orgID
 			}
+			if output == "json" {
+				return writeJSON(statusToJSON(resp, orgFlag))
+			}
 
 			fmt.Printf("Org: %s\n", resp.OrgId)
 			fmt.Printf("Run: %s (%s)\n", resp.RunId, resp.Status)
@@ -65,15 +76,13 @@ func NewCmdStatus() *cobra.Command {
 					fmt.Printf("    Job: %s [%s] (%s)\n", job.JobId, job.JobKey, job.Status)
 
 					for _, attempt := range job.Attempts {
-						isRunning := attempt.Status != "finished" && attempt.Status != "failed" && attempt.Status != "cancelled"
-
 						fmt.Printf("      Attempt #%d (%s)\n", attempt.Attempt, attempt.Status)
 						fmt.Printf("        Logs: depot ci logs %s%s\n", attempt.AttemptId, orgFlag)
 						if canDownloadLogExport(attempt.Status) {
 							fmt.Printf("        Download: depot ci logs %s --output-file %s%s\n", attempt.AttemptId, logDownloadFilename, orgFlag)
 						}
 						fmt.Printf("        View: https://depot.dev/orgs/%s/workflows/%s\n", resp.OrgId, attempt.AttemptId)
-						if attempt.GetSandboxId() != "" && isRunning {
+						if attempt.GetSandboxId() != "" && statusIsRunning(attempt.GetStatus()) {
 							fmt.Printf("        SSH:  depot ci ssh %s --job %s%s\n", resp.RunId, job.JobKey, orgFlag)
 						}
 					}
@@ -86,6 +95,102 @@ func NewCmdStatus() *cobra.Command {
 
 	cmd.Flags().StringVar(&orgID, "org", "", "Organization ID (required when user is a member of multiple organizations)")
 	cmd.Flags().StringVar(&token, "token", "", "Depot API token")
+	cmd.Flags().StringVarP(&output, "output", "o", "", "Output format (json)")
 
 	return cmd
+}
+
+type statusJSON struct {
+	OrgID     string               `json:"org_id"`
+	RunID     string               `json:"run_id"`
+	Status    string               `json:"status"`
+	Workflows []statusWorkflowJSON `json:"workflows"`
+}
+
+type statusWorkflowJSON struct {
+	WorkflowID   string          `json:"workflow_id"`
+	Status       string          `json:"status"`
+	WorkflowPath string          `json:"workflow_path,omitempty"`
+	Name         string          `json:"name,omitempty"`
+	ErrorMessage string          `json:"error_message,omitempty"`
+	Jobs         []statusJobJSON `json:"jobs"`
+}
+
+type statusJobJSON struct {
+	JobID    string              `json:"job_id"`
+	JobKey   string              `json:"job_key"`
+	Status   string              `json:"status"`
+	Attempts []statusAttemptJSON `json:"attempts"`
+}
+
+type statusAttemptJSON struct {
+	AttemptID         string `json:"attempt_id"`
+	Attempt           int32  `json:"attempt"`
+	Status            string `json:"status"`
+	SandboxID         string `json:"sandbox_id,omitempty"`
+	SessionID         string `json:"session_id,omitempty"`
+	LogsCommand       string `json:"logs_command"`
+	DownloadAvailable bool   `json:"download_available"`
+	DownloadCommand   string `json:"download_command,omitempty"`
+	ViewURL           string `json:"view_url"`
+	SSHAvailable      bool   `json:"ssh_available"`
+	SSHCommand        string `json:"ssh_command,omitempty"`
+}
+
+func statusToJSON(resp *civ1.GetRunStatusResponse, orgFlag string) statusJSON {
+	out := statusJSON{
+		OrgID:     resp.GetOrgId(),
+		RunID:     resp.GetRunId(),
+		Status:    resp.GetStatus(),
+		Workflows: make([]statusWorkflowJSON, 0, len(resp.GetWorkflows())),
+	}
+
+	for _, workflow := range resp.GetWorkflows() {
+		wf := statusWorkflowJSON{
+			WorkflowID:   workflow.GetWorkflowId(),
+			Status:       workflow.GetStatus(),
+			WorkflowPath: workflow.GetWorkflowPath(),
+			Name:         workflow.GetName(),
+			ErrorMessage: workflow.GetErrorMessage(),
+			Jobs:         make([]statusJobJSON, 0, len(workflow.GetJobs())),
+		}
+
+		for _, job := range workflow.GetJobs() {
+			j := statusJobJSON{
+				JobID:    job.GetJobId(),
+				JobKey:   job.GetJobKey(),
+				Status:   job.GetStatus(),
+				Attempts: make([]statusAttemptJSON, 0, len(job.GetAttempts())),
+			}
+
+			for _, attempt := range job.GetAttempts() {
+				a := statusAttemptJSON{
+					AttemptID:         attempt.GetAttemptId(),
+					Attempt:           attempt.GetAttempt(),
+					Status:            attempt.GetStatus(),
+					SandboxID:         attempt.GetSandboxId(),
+					SessionID:         attempt.GetSessionId(),
+					LogsCommand:       fmt.Sprintf("depot ci logs %s%s", attempt.GetAttemptId(), orgFlag),
+					DownloadAvailable: canDownloadLogExport(attempt.GetStatus()),
+					ViewURL:           fmt.Sprintf("https://depot.dev/orgs/%s/workflows/%s", resp.GetOrgId(), attempt.GetAttemptId()),
+					SSHAvailable:      attempt.GetSandboxId() != "" && statusIsRunning(attempt.GetStatus()),
+				}
+				if a.DownloadAvailable {
+					a.DownloadCommand = fmt.Sprintf("depot ci logs %s --output-file %s%s", attempt.GetAttemptId(), logDownloadFilename, orgFlag)
+				}
+				if a.SSHAvailable {
+					a.SSHCommand = fmt.Sprintf("depot ci ssh %s --job %s%s", resp.GetRunId(), job.GetJobKey(), orgFlag)
+				}
+				j.Attempts = append(j.Attempts, a)
+			}
+			wf.Jobs = append(wf.Jobs, j)
+		}
+		out.Workflows = append(out.Workflows, wf)
+	}
+
+	return out
+}
+
+func statusIsRunning(status string) bool {
+	return status != "finished" && status != "failed" && status != "cancelled"
 }

--- a/pkg/cmd/ci/status_test.go
+++ b/pkg/cmd/ci/status_test.go
@@ -2,12 +2,40 @@ package ci
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"strings"
 	"testing"
 
 	civ1 "github.com/depot/cli/pkg/proto/depot/ci/v1"
 )
+
+func testStatusResponse() *civ1.GetRunStatusResponse {
+	return &civ1.GetRunStatusResponse{
+		OrgId:  "org-123",
+		RunId:  "run-1",
+		Status: "running",
+		Workflows: []*civ1.WorkflowStatus{
+			{
+				WorkflowId:   "workflow-1",
+				Status:       "running",
+				WorkflowPath: ".depot/workflows/ci.yml",
+				Jobs: []*civ1.JobStatus{
+					{
+						JobId:  "job-1",
+						JobKey: "ci.yml:build",
+						Status: "running",
+						Attempts: []*civ1.AttemptStatus{
+							{AttemptId: "att-finished", Attempt: 1, Status: "finished"},
+							{AttemptId: "att-running", Attempt: 2, Status: "running", SandboxId: "sandbox-1", SessionId: "session-1"},
+							{AttemptId: "att-failed", Attempt: 3, Status: "failed"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
 
 func TestStatusHumanOutputShowsDownloadForFinishedAttemptsOnly(t *testing.T) {
 	originalGetRunStatus := ciGetRunStatus
@@ -20,30 +48,7 @@ func TestStatusHumanOutputShowsDownloadForFinishedAttemptsOnly(t *testing.T) {
 		capturedToken = token
 		capturedOrgID = orgID
 		capturedRunID = runID
-		return &civ1.GetRunStatusResponse{
-			OrgId:  "org-123",
-			RunId:  "run-1",
-			Status: "running",
-			Workflows: []*civ1.WorkflowStatus{
-				{
-					WorkflowId:   "workflow-1",
-					Status:       "running",
-					WorkflowPath: ".depot/workflows/ci.yml",
-					Jobs: []*civ1.JobStatus{
-						{
-							JobId:  "job-1",
-							JobKey: "ci.yml:build",
-							Status: "running",
-							Attempts: []*civ1.AttemptStatus{
-								{AttemptId: "att-finished", Attempt: 1, Status: "finished"},
-								{AttemptId: "att-running", Attempt: 2, Status: "running", SandboxId: "sandbox-1"},
-								{AttemptId: "att-failed", Attempt: 3, Status: "failed"},
-							},
-						},
-					},
-				},
-			},
-		}, nil
+		return testStatusResponse(), nil
 	}
 
 	cmd := NewCmdStatus()
@@ -83,5 +88,107 @@ func TestStatusHumanOutputShowsDownloadForFinishedAttemptsOnly(t *testing.T) {
 		if strings.Contains(stdout, notWant) {
 			t.Fatalf("status output advertised download for non-finished attempt %q:\n%s", notWant, stdout)
 		}
+	}
+}
+
+func TestStatusJSONOutput(t *testing.T) {
+	originalGetRunStatus := ciGetRunStatus
+	t.Cleanup(func() { ciGetRunStatus = originalGetRunStatus })
+
+	ciGetRunStatus = func(ctx context.Context, token, orgID, runID string) (*civ1.GetRunStatusResponse, error) {
+		return testStatusResponse(), nil
+	}
+
+	cmd := NewCmdStatus()
+	cmd.SetArgs([]string{"--org", "org-123", "--token", "token-123", "--output", "json", "run-1"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	stdout, err := captureStdout(t, cmd.Execute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(stdout, "Logs: depot ci logs") {
+		t.Fatalf("json output included human log hints:\n%s", stdout)
+	}
+
+	var got struct {
+		OrgID     string `json:"org_id"`
+		RunID     string `json:"run_id"`
+		Status    string `json:"status"`
+		Workflows []struct {
+			WorkflowID   string `json:"workflow_id"`
+			WorkflowPath string `json:"workflow_path"`
+			Jobs         []struct {
+				JobID    string `json:"job_id"`
+				JobKey   string `json:"job_key"`
+				Attempts []struct {
+					AttemptID         string `json:"attempt_id"`
+					Status            string `json:"status"`
+					SandboxID         string `json:"sandbox_id"`
+					SessionID         string `json:"session_id"`
+					LogsCommand       string `json:"logs_command"`
+					DownloadAvailable bool   `json:"download_available"`
+					DownloadCommand   string `json:"download_command"`
+					ViewURL           string `json:"view_url"`
+					SSHAvailable      bool   `json:"ssh_available"`
+					SSHCommand        string `json:"ssh_command"`
+				} `json:"attempts"`
+			} `json:"jobs"`
+		} `json:"workflows"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("invalid JSON output: %v\n%s", err, stdout)
+	}
+	if got.OrgID != "org-123" || got.RunID != "run-1" || got.Status != "running" {
+		t.Fatalf("unexpected run JSON: %+v", got)
+	}
+	if len(got.Workflows) != 1 || got.Workflows[0].WorkflowID != "workflow-1" || got.Workflows[0].WorkflowPath != ".depot/workflows/ci.yml" {
+		t.Fatalf("unexpected workflow JSON: %+v", got.Workflows)
+	}
+	if len(got.Workflows[0].Jobs) != 1 || got.Workflows[0].Jobs[0].JobID != "job-1" || got.Workflows[0].Jobs[0].JobKey != "ci.yml:build" {
+		t.Fatalf("unexpected job JSON: %+v", got.Workflows[0].Jobs)
+	}
+	attempts := got.Workflows[0].Jobs[0].Attempts
+	if len(attempts) != 3 || attempts[1].AttemptID != "att-running" || attempts[1].SandboxID != "sandbox-1" || attempts[1].SessionID != "session-1" {
+		t.Fatalf("unexpected attempts JSON: %+v", attempts)
+	}
+	if attempts[0].LogsCommand != "depot ci logs att-finished --org org-123" {
+		t.Fatalf("finished logs command = %q", attempts[0].LogsCommand)
+	}
+	if !attempts[0].DownloadAvailable || attempts[0].DownloadCommand != "depot ci logs att-finished --output-file logs.txt --org org-123" {
+		t.Fatalf("unexpected finished download affordance: %+v", attempts[0])
+	}
+	if attempts[0].ViewURL != "https://depot.dev/orgs/org-123/workflows/att-finished" {
+		t.Fatalf("finished view url = %q", attempts[0].ViewURL)
+	}
+	if !attempts[1].SSHAvailable || attempts[1].SSHCommand != "depot ci ssh run-1 --job ci.yml:build --org org-123" {
+		t.Fatalf("unexpected running ssh affordance: %+v", attempts[1])
+	}
+	if attempts[1].DownloadAvailable || attempts[1].DownloadCommand != "" {
+		t.Fatalf("running attempt should not expose download affordance: %+v", attempts[1])
+	}
+	if attempts[2].DownloadAvailable || attempts[2].SSHAvailable || attempts[2].DownloadCommand != "" || attempts[2].SSHCommand != "" {
+		t.Fatalf("failed attempt exposed unavailable affordances: %+v", attempts[2])
+	}
+}
+
+func TestStatusRejectsUnsupportedOutput(t *testing.T) {
+	originalGetRunStatus := ciGetRunStatus
+	t.Cleanup(func() { ciGetRunStatus = originalGetRunStatus })
+
+	ciGetRunStatus = func(ctx context.Context, token, orgID, runID string) (*civ1.GetRunStatusResponse, error) {
+		t.Fatal("ciGetRunStatus should not be called for invalid output")
+		return nil, nil
+	}
+
+	cmd := NewCmdStatus()
+	cmd.SetArgs([]string{"--token", "token-123", "--output", "yaml", "run-1"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	_, err := captureStdout(t, cmd.Execute)
+	if err == nil || !strings.Contains(err.Error(), `unsupported output "yaml"`) {
+		t.Fatalf("expected unsupported output error, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
The status command finally gets a machine-readable lane, so agents do not have to squint at the human checklist.

## What was happening
`depot ci status` was still only printing nested run, workflow, job, and attempt details as text. That made it the odd primary getter out after the rest of the CI command surface had settled on `--output json`.

## What happens now
`depot ci status --output json` and `-o json` now emit structured run status data plus the same useful affordances from the human view: log commands, download availability, Depot view URLs, and SSH availability/commands. Unsupported output modes fail before any API call, and the status tests cover the JSON path plus that validation.

## Anything else?
This keeps the existing `--output` convention instead of introducing `--format`. Linear: DEP-4080.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CLI-only output/flag changes with added tests; main risk is minor breaking expectations for consumers parsing the human output when `--output` is misused.
> 
> **Overview**
> `depot ci status` now accepts `--output/-o json` and, when selected, emits an indented JSON payload instead of the human-readable text.
> 
> The JSON output is produced via a new `statusToJSON` mapper (including per-attempt commands/URLs and availability flags for download/SSH), validates unsupported formats *before* making the API call, and factors the “running” state check into `statusIsRunning`.
> 
> Tests were updated to reuse a shared fixture and add coverage for JSON output correctness and rejection of unsupported `--output` values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f50f12901de6678415788931c69b2afdcf00769d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->