### PR TITLE
Implement convenience command `depot login-docker`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Official CLI for [Depot](https://depot.dev) - you can use the CLI to build Docke
     - [`depot exec`](#depot-exec)
     - [`depot gocache`](#depot-gocache)
     - [`depot configure-docker`](#depot-configure-docker)
+    - [`depot login-docker`](#depot-login-docker)
     - [`depot list`](#depot-list)
       - [`depot list projects`](#depot-list-projects)
       - [`depot list builds`](#depot-list-builds)
@@ -360,6 +361,20 @@ If you want to uninstall the plugin, you can specify the `--uninstall` flag.
 depot configure-docker --uninstall
 ```
 
+### `depot login-docker`
+
+Configure Docker to download from the [Depot Registry](https://depot.dev/docs/registry/overview). This command stores your user API token as a Docker credential so you can `docker pull` images from your organization's registries.
+
+```shell
+depot login-docker
+```
+
+If you want to log out, use the Docker CLI.
+
+```shell
+docker logout {orgId}.registry.depot.dev
+```
+
 ### `depot list`
 
 Interact with Depot projects and builds.
@@ -455,11 +470,11 @@ depot projects delete --project-id your-project-id --yes
 
 #### Flags for `projects delete`
 
-| Name           | Description                                    |
-| -------------- | ---------------------------------------------- |
-| `project-id`   | The ID of the project to delete                |
-| `yes`          | Confirm deletion without interactive prompt    |
-| `token`        | Depot API token                                |
+| Name         | Description                                 |
+| ------------ | ------------------------------------------- |
+| `project-id` | The ID of the project to delete             |
+| `yes`        | Confirm deletion without interactive prompt |
+| `token`      | Depot API token                             |
 
 #### `depot projects list`
 

--- a/pkg/cmd/docker/login.go
+++ b/pkg/cmd/docker/login.go
@@ -30,6 +30,9 @@ func NewCmdLoginDocker() *cobra.Command {
 			if org == "" {
 				org = config.GetCurrentOrganization()
 			}
+			if org == "" {
+				return fmt.Errorf("No organization configured; use the --org flag or verify your project configuration")
+			}
 
 			dockerCli, err := dockerclient.NewDockerCLI()
 			if err != nil {

--- a/pkg/cmd/docker/login.go
+++ b/pkg/cmd/docker/login.go
@@ -1,0 +1,71 @@
+package docker
+
+import (
+	"fmt"
+
+	"github.com/depot/cli/pkg/config"
+	"github.com/depot/cli/pkg/dockerclient"
+	configtypes "github.com/docker/cli/cli/config/types"
+	registrytypes "github.com/docker/docker/api/types/registry"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdLoginDocker() *cobra.Command {
+	var (
+		org   string
+		token string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "login-docker",
+		Short: "Log in Docker to the Depot registry with your user API token",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if token == "" {
+				token = config.GetApiToken()
+			}
+			if token == "" {
+				return fmt.Errorf("missing API token, please run `depot login`")
+			}
+
+			if org == "" {
+				org = config.GetCurrentOrganization()
+			}
+
+			dockerCli, err := dockerclient.NewDockerCLI()
+			if err != nil {
+				return err
+			}
+
+			serverAddress := org + ".registry.depot.dev"
+			client := dockerCli.Client()
+			resp, err := client.RegistryLogin(cmd.Context(), registrytypes.AuthConfig{
+				Username:      "x-token",
+				Password:      token,
+				ServerAddress: serverAddress,
+			})
+			if err != nil {
+				return err
+			}
+
+			cfg := dockerCli.ConfigFile()
+			creds := cfg.GetCredentialsStore(serverAddress)
+			err = creds.Store(configtypes.AuthConfig{
+				Username:      "x-token",
+				Password:      token,
+				ServerAddress: serverAddress,
+			})
+			if err != nil {
+				return err
+			}
+
+			fmt.Println("Successfully stored Docker credentials for" + serverAddress)
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&org, "org", "", "Depot organization ID")
+	flags.StringVar(&token, "token", "", "Depot token")
+
+	return cmd
+}

--- a/pkg/cmd/docker/login.go
+++ b/pkg/cmd/docker/login.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/depot/cli/pkg/config"
 	"github.com/depot/cli/pkg/dockerclient"
+	"github.com/depot/cli/pkg/helpers"
 	configtypes "github.com/docker/cli/cli/config/types"
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/spf13/cobra"
@@ -20,8 +21,9 @@ func NewCmdLoginDocker() *cobra.Command {
 		Use:   "login-docker",
 		Short: "Log in Docker to the Depot registry with your user API token",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if token == "" {
-				token = config.GetApiToken()
+			token, err := helpers.ResolveProjectAuth(cmd.Context(), token)
+			if err != nil {
+				return err
 			}
 			if token == "" {
 				return fmt.Errorf("missing API token, please run `depot login`")
@@ -41,7 +43,7 @@ func NewCmdLoginDocker() *cobra.Command {
 
 			serverAddress := org + ".registry.depot.dev"
 			client := dockerCli.Client()
-			resp, err := client.RegistryLogin(cmd.Context(), registrytypes.AuthConfig{
+			_, err = client.RegistryLogin(cmd.Context(), registrytypes.AuthConfig{
 				Username:      "x-token",
 				Password:      token,
 				ServerAddress: serverAddress,

--- a/pkg/cmd/docker/login.go
+++ b/pkg/cmd/docker/login.go
@@ -21,7 +21,7 @@ func NewCmdLoginDocker() *cobra.Command {
 		Use:   "login-docker",
 		Short: "Log in Docker to the Depot registry with your user API token",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			token, err := helpers.ResolveProjectAuth(cmd.Context(), token)
+			token, err := helpers.ResolveOrgAuth(cmd.Context(), token)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/docker/login.go
+++ b/pkg/cmd/docker/login.go
@@ -58,7 +58,7 @@ func NewCmdLoginDocker() *cobra.Command {
 				return err
 			}
 
-			fmt.Println("Successfully stored Docker credentials for" + serverAddress)
+			fmt.Println("Successfully stored Docker credentials for " + serverAddress)
 			return nil
 		},
 	}

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -78,6 +78,7 @@ func NewCmdRoot(version, buildDate string) *cobra.Command {
 	cmd.AddCommand(push.NewCmdPush())
 	cmd.AddCommand(versionCmd.NewCmdVersion(version, buildDate))
 	cmd.AddCommand(dockerCmd.NewCmdConfigureDocker())
+	cmd.AddCommand(dockerCmd.NewCmdLoginDocker())
 	cmd.AddCommand(registry.NewCmdRegistry())
 	cmd.AddCommand(org.NewCmdOrg())
 	cmd.AddCommand(projects.NewCmdProjects())


### PR DESCRIPTION
Before I start rolling out workflows involving the Depot registry to my org, I'd like to have a nice one-liner for them to make sure they're logged in to Docker. This PR adds a `depot login-docker` command that takes care of the details.

TESTED: I've confirmed locally that this gets `docker pull <org>.registry.depot.dev/[...]` working from a logged-out state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CLI command that logs into Docker registries and persists credentials, which affects local auth/credential storage and could impact users’ Docker config if misused.
> 
> **Overview**
> Adds a new `depot login-docker` command that logs Docker into `{org}.registry.depot.dev` using the user Depot API token and stores it in the Docker credential store for `docker pull`.
> 
> Registers the command in the root CLI and documents it in `README.md`, alongside a small docs table formatting fix for `projects delete` flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1de5c65ff6973dae9967743e61735f7c5ecd68be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->