### PR TITLE
fix(helpers): clearer error when project ID is missing

### DIFF
--- a/pkg/helpers/build.go
+++ b/pkg/helpers/build.go
@@ -11,12 +11,21 @@ import (
 	buildx "github.com/docker/buildx/build"
 )
 
+// ErrMissingProjectID is returned by BeginBuild when no project ID can be
+// resolved from the command line, environment, or depot.json. The message is
+// surfaced to users (including via depot/build-push-action) and is intended to
+// be actionable so they don't have to debug a misleading authentication error.
+var ErrMissingProjectID = errors.New(`no project ID specified. Please provide a project ID via the --project flag, the DEPOT_PROJECT_ID environment variable (the build-push-action sets this from its "project" input), or by adding a depot.json file to your project root (run "depot init")`)
+
 func BeginBuild(ctx context.Context, req *cliv1.CreateBuildRequest, token string) (depotbuild.Build, error) {
 	var build depotbuild.Build
 	var err error
 	if id := os.Getenv("DEPOT_BUILD_ID"); id != "" {
 		build, err = depotbuild.FromExistingBuild(ctx, id, token, nil)
 	} else {
+		if req.GetProjectId() == "" {
+			return depotbuild.Build{}, ErrMissingProjectID
+		}
 		build, err = depotbuild.NewBuild(ctx, req, token)
 	}
 	if err != nil {

--- a/pkg/helpers/build_test.go
+++ b/pkg/helpers/build_test.go
@@ -1,0 +1,56 @@
+package helpers
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	cliv1 "github.com/depot/cli/pkg/proto/depot/cli/v1"
+)
+
+func TestBeginBuildReturnsClearErrorWhenProjectIDMissing(t *testing.T) {
+	// Make sure we don't accidentally take the DEPOT_BUILD_ID branch.
+	t.Setenv("DEPOT_BUILD_ID", "")
+
+	cases := []struct {
+		name string
+		req  *cliv1.CreateBuildRequest
+	}{
+		{
+			name: "nil ProjectId",
+			req:  &cliv1.CreateBuildRequest{},
+		},
+		{
+			name: "empty string ProjectId",
+			req:  &cliv1.CreateBuildRequest{ProjectId: stringPtr("")},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := BeginBuild(context.Background(), tc.req, "fake-token")
+			if err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			if !errors.Is(err, ErrMissingProjectID) {
+				t.Fatalf("expected ErrMissingProjectID, got %v", err)
+			}
+			// Sanity check that the message stays actionable for users.
+			msg := err.Error()
+			for _, want := range []string{
+				"no project ID specified",
+				"--project",
+				"DEPOT_PROJECT_ID",
+				"depot.json",
+				"depot init",
+			} {
+				if !strings.Contains(msg, want) {
+					t.Errorf("error message missing %q: %s", want, msg)
+				}
+			}
+		})
+	}
+}
+
+func stringPtr(s string) *string { return &s }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When `depot build` (or any caller of `helpers.BeginBuild`) is run without a project ID — no `--project` flag, no `DEPOT_PROJECT_ID`, and no `depot.json` — `ResolveProjectID` returns an empty string. We then sent an empty `project_id` to the `NewBuild` API, which responds with `CodeNotFound`. That triggered the interactive onboarding path (`OnboardProject` → `InitializeProject` → `RetrieveProjects`). In CI (notably `depot/build-push-action` with an OIDC token that has no list-projects scope), `RetrieveProjects` fails with:

```
Error: error retrieving projects: permission_denied: Not authorized
```

That message is misleading — it points users at authentication when the real fix is providing a project ID.

## Change

In `pkg/helpers/build.go`, detect an empty `req.ProjectId` up front in `BeginBuild` (when we're not resuming via `DEPOT_BUILD_ID`) and return a clear, actionable error that lists all supported ways to configure a project:

```
no project ID specified. Please provide a project ID via the --project flag, the DEPOT_PROJECT_ID environment variable (the build-push-action sets this from its "project" input), or by adding a depot.json file to your project root (run "depot init")
```

This is exposed as `ErrMissingProjectID` so callers can `errors.Is` it if needed. All `BeginBuild` callers (`build`, `bake`, `buildctl dial-stdio`, `exec`) benefit automatically, including via `depot/build-push-action` which shells out to the CLI.

## Test

Added `pkg/helpers/build_test.go` covering both the `nil` `ProjectId` pointer and an empty-string `ProjectId`, and asserting the message stays actionable.

```
=== RUN   TestBeginBuildReturnsClearErrorWhenProjectIDMissing
--- PASS: TestBeginBuildReturnsClearErrorWhenProjectIDMissing (0.00s)
PASS
ok  	github.com/depot/cli/pkg/helpers
```

## Notes

The issue references `depot/build-push-action@v1`, but the error message itself originates in `depot/cli` (`pkg/helpers/project.go:RetrieveProjects`), and the issue is labeled `depot/cli`. Fixing it here means every caller of the CLI (including the GitHub Action, which shells out to `depot build`) gets the better message without an Action release.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DEP-4447](https://linear.app/depot/issue/DEP-4447/improve-error-message-in-build-push-action-when-project-id-is-missing)

<div><a href="https://cursor.com/agents/bc-634266f9-e7e8-4953-9f1d-19b3aa9552a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-634266f9-e7e8-4953-9f1d-19b3aa9552a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

