### PR TITLE
DEP-4493 Preserve save tags for existing builds

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -28,6 +28,7 @@ type Build struct {
 
 	Response  *connect.Response[cliv1.CreateBuildResponse]
 	projectID string
+	saveTags  []string
 }
 
 type Credential struct {
@@ -43,7 +44,24 @@ type PullInfo struct {
 
 func (b *Build) AdditionalTags() []string {
 	if b.Response == nil || b.Response.Msg == nil {
-		return []string{fmt.Sprintf("registry.depot.dev/%s:%s", b.projectID, b.ID)}
+		tags := []string{fmt.Sprintf("registry.depot.dev/%s:%s", b.projectID, b.ID)}
+		seenTags := map[string]struct{}{tags[0]: {}}
+
+		for _, saveTag := range b.saveTags {
+			if saveTag == "" {
+				continue
+			}
+
+			tag := fmt.Sprintf("registry.depot.dev/%s:%s", b.projectID, saveTag)
+			if _, ok := seenTags[tag]; ok {
+				continue
+			}
+
+			seenTags[tag] = struct{}{}
+			tags = append(tags, tag)
+		}
+
+		return tags
 	}
 
 	tags := make([]string, 0, len(b.Response.Msg.AdditionalTags))
@@ -126,8 +144,9 @@ func NewBuild(ctx context.Context, req *cliv1.CreateBuildRequest, token string) 
 	return build, nil
 }
 
-func FromExistingBuild(ctx context.Context, buildID, token string, buildRes *connect.Response[cliv1.CreateBuildResponse]) (Build, error) {
+func FromExistingBuild(ctx context.Context, buildID, token string, buildRes *connect.Response[cliv1.CreateBuildResponse], saveTags ...string) (Build, error) {
 	client := depotapi.NewBuildClient()
+	saveTags = append([]string(nil), saveTags...)
 
 	finish := func(buildErr error) {
 		req := cliv1.FinishBuildRequest{BuildId: buildID}
@@ -163,6 +182,7 @@ func FromExistingBuild(ctx context.Context, buildID, token string, buildRes *con
 			Finish:    finish,
 			BuildURL:  res.Msg.BuildUrl,
 			projectID: res.Msg.ProjectId,
+			saveTags:  saveTags,
 		}, nil
 	} else {
 		return Build{
@@ -171,6 +191,7 @@ func FromExistingBuild(ctx context.Context, buildID, token string, buildRes *con
 			Finish:   finish,
 			BuildURL: buildRes.Msg.BuildUrl,
 			Response: buildRes,
+			saveTags: saveTags,
 		}, nil
 	}
 

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -1,0 +1,67 @@
+package build
+
+import (
+	"reflect"
+	"testing"
+
+	"connectrpc.com/connect"
+	cliv1 "github.com/depot/cli/pkg/proto/depot/cli/v1"
+)
+
+func TestAdditionalTagsExistingBuildIncludesSaveTags(t *testing.T) {
+	build := Build{
+		ID:        "build123",
+		projectID: "project123",
+		saveTags:  []string{"release", "latest"},
+	}
+
+	got := build.AdditionalTags()
+	want := []string{
+		"registry.depot.dev/project123:build123",
+		"registry.depot.dev/project123:release",
+		"registry.depot.dev/project123:latest",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("AdditionalTags() = %#v, want %#v", got, want)
+	}
+}
+
+func TestAdditionalTagsExistingBuildSkipsEmptyAndDuplicateSaveTags(t *testing.T) {
+	build := Build{
+		ID:        "build123",
+		projectID: "project123",
+		saveTags:  []string{"release", "", "build123", "release"},
+	}
+
+	got := build.AdditionalTags()
+	want := []string{
+		"registry.depot.dev/project123:build123",
+		"registry.depot.dev/project123:release",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("AdditionalTags() = %#v, want %#v", got, want)
+	}
+}
+
+func TestAdditionalTagsUsesCreateBuildResponseWhenAvailable(t *testing.T) {
+	build := Build{
+		ID:        "build123",
+		projectID: "project123",
+		saveTags:  []string{"release"},
+		Response: connect.NewResponse(&cliv1.CreateBuildResponse{
+			AdditionalTags: []*cliv1.CreateBuildResponse_Tag{
+				{Tag: "registry.depot.dev/project123:server-tag"},
+				nil,
+			},
+		}),
+	}
+
+	got := build.AdditionalTags()
+	want := []string{"registry.depot.dev/project123:server-tag"}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("AdditionalTags() = %#v, want %#v", got, want)
+	}
+}

--- a/pkg/helpers/build.go
+++ b/pkg/helpers/build.go
@@ -15,7 +15,7 @@ func BeginBuild(ctx context.Context, req *cliv1.CreateBuildRequest, token string
 	var build depotbuild.Build
 	var err error
 	if id := os.Getenv("DEPOT_BUILD_ID"); id != "" {
-		build, err = depotbuild.FromExistingBuild(ctx, id, token, nil)
+		build, err = depotbuild.FromExistingBuild(ctx, id, token, nil, saveTagsFromRequest(req)...)
 	} else {
 		build, err = depotbuild.NewBuild(ctx, req, token)
 	}
@@ -36,6 +36,34 @@ func BeginBuild(ctx context.Context, req *cliv1.CreateBuildRequest, token string
 	}
 
 	return build, err
+}
+
+func saveTagsFromRequest(req *cliv1.CreateBuildRequest) []string {
+	if req == nil {
+		return nil
+	}
+
+	saveTags := []string{}
+	seenTags := map[string]struct{}{}
+	for _, opts := range req.Options {
+		if opts == nil {
+			continue
+		}
+
+		for _, saveTag := range opts.SaveTags {
+			if saveTag == "" {
+				continue
+			}
+			if _, ok := seenTags[saveTag]; ok {
+				continue
+			}
+
+			seenTags[saveTag] = struct{}{}
+			saveTags = append(saveTags, saveTag)
+		}
+	}
+
+	return saveTags
 }
 
 type UsingDepotFeatures struct {

--- a/pkg/helpers/build_test.go
+++ b/pkg/helpers/build_test.go
@@ -1,0 +1,31 @@
+package helpers
+
+import (
+	"reflect"
+	"testing"
+
+	cliv1 "github.com/depot/cli/pkg/proto/depot/cli/v1"
+)
+
+func TestSaveTagsFromRequest(t *testing.T) {
+	req := &cliv1.CreateBuildRequest{
+		Options: []*cliv1.BuildOptions{
+			{SaveTags: []string{"release", "latest"}},
+			nil,
+			{SaveTags: []string{"latest", "", "canary"}},
+		},
+	}
+
+	got := saveTagsFromRequest(req)
+	want := []string{"release", "latest", "canary"}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("saveTagsFromRequest() = %#v, want %#v", got, want)
+	}
+}
+
+func TestSaveTagsFromRequestNil(t *testing.T) {
+	if got := saveTagsFromRequest(nil); got != nil {
+		t.Fatalf("saveTagsFromRequest(nil) = %#v, want nil", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes `--save-tag` being ignored when `depot build` is attached to an existing build through `DEPOT_BUILD_ID`.

When the CLI creates the build itself, the API response already includes Depot Registry tags derived from `--save-tag`. In the existing-build path, we skip that create-build request, so the CLI now carries the requested save tags locally and includes them in the fallback Depot Registry tag list.

## Changes

- Pass requested save tags from the build request into `FromExistingBuild` when `DEPOT_BUILD_ID` is set.
- Include those save tags in `Build.AdditionalTags()` for existing builds as `registry.depot.dev/<project>:<save-tag>`.
- De-duplicate and ignore empty save tags in the existing-build fallback path.
- Add focused tests for existing-build tag generation and save-tag extraction from build requests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to tag list construction and wiring save tags into the existing-build path, with added tests to cover edge cases.
> 
> **Overview**
> Fixes `--save-tag` being ignored when `DEPOT_BUILD_ID` attaches the CLI to an existing build by threading requested save tags into `FromExistingBuild` and storing them on `Build`.
> 
> Updates `Build.AdditionalTags()` to include `registry.depot.dev/<project>:<save-tag>` in the fallback path (skipping empty/duplicate tags) while still preferring server-provided `AdditionalTags` when present, and adds unit tests for both tag extraction (`saveTagsFromRequest`) and additional-tag generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7febc97be51ec66d4c861734cba839a4b7bed8e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->