### PR TITLE
login: add --quiet flag and `login token` subcommand (DEP-4912)

### DIFF
--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -17,6 +17,7 @@ func NewCmdLogin() *cobra.Command {
 		Short: "Authenticate the Depot CLI",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clear, _ := cmd.Flags().GetBool("clear")
+			quiet, _ := cmd.Flags().GetBool("quiet")
 
 			if clear {
 				err := config.ClearApiToken()
@@ -27,7 +28,13 @@ func NewCmdLogin() *cobra.Command {
 
 			existingToken := config.GetApiToken()
 			if existingToken != "" {
-				fmt.Println("You are already logged in.")
+				// Already authenticated: --quiet turns this into a silent
+				// exit-0 no-op so scripts can call `depot login` defensively
+				// without producing output. Without --quiet the notice prints
+				// exactly as before.
+				if !quiet {
+					fmt.Fprintln(cmd.OutOrStdout(), "You are already logged in.")
+				}
 				return nil
 			}
 
@@ -69,6 +76,9 @@ func NewCmdLogin() *cobra.Command {
 
 	cmd.Flags().String("org-id", "", "The organization ID to login to")
 	cmd.Flags().Bool("clear", false, "Clear any existing token before logging in")
+	cmd.Flags().Bool("quiet", false, "Suppress the notice when already authenticated (exit 0 no-op if logged in)")
+
+	cmd.AddCommand(newCmdLoginToken())
 
 	return cmd
 }

--- a/pkg/cmd/login/login_test.go
+++ b/pkg/cmd/login/login_test.go
@@ -1,0 +1,98 @@
+package login
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// setToken isolates the api_token viper key (and the DEPOT_API_TOKEN env that
+// AutomaticEnv would otherwise read) for the duration of a test so the suite
+// never touches the developer's real ~/.config/depot/depot.yaml. The previous
+// value is restored on cleanup.
+func setToken(t *testing.T, token string) {
+	t.Helper()
+	t.Setenv("DEPOT_API_TOKEN", token)
+	prev := viper.GetString("api_token")
+	viper.Set("api_token", token)
+	t.Cleanup(func() { viper.Set("api_token", prev) })
+}
+
+func TestLoginQuietIsSilentNoOpWhenAlreadyLoggedIn(t *testing.T) {
+	setToken(t, "tok-already-here")
+
+	cmd := NewCmdLogin()
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"--quiet"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("login --quiet returned error: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("login --quiet should produce no stdout, got %q", out.String())
+	}
+}
+
+func TestLoginPrintsNoticeWhenAlreadyLoggedInWithoutQuiet(t *testing.T) {
+	setToken(t, "tok-already-here")
+
+	cmd := NewCmdLogin()
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("login returned error: %v", err)
+	}
+	if !strings.Contains(out.String(), "You are already logged in.") {
+		t.Fatalf("expected already-logged-in notice on stdout, got %q", out.String())
+	}
+}
+
+func TestLoginTokenPrintsStoredToken(t *testing.T) {
+	setToken(t, "tok-12345")
+
+	cmd := NewCmdLogin()
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"token"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("login token returned error: %v", err)
+	}
+	if got := strings.TrimRight(out.String(), "\n"); got != "tok-12345" {
+		t.Fatalf("login token stdout = %q, want exactly the token", out.String())
+	}
+}
+
+func TestLoginTokenErrorsWhenNotLoggedIn(t *testing.T) {
+	setToken(t, "")
+
+	cmd := NewCmdLogin()
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"token"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when no token is stored")
+	}
+	if !strings.Contains(err.Error(), "depot login") {
+		t.Fatalf("error = %q, want it to mention `depot login`", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("login token should print nothing to stdout when not logged in, got %q", out.String())
+	}
+}

--- a/pkg/cmd/login/token.go
+++ b/pkg/cmd/login/token.go
@@ -1,0 +1,31 @@
+package login
+
+import (
+	"fmt"
+
+	"github.com/depot/cli/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+// newCmdLoginToken builds `depot login token`, which prints the stored Depot
+// API token to stdout so it can be captured in shells, e.g. `$(depot login
+// token)`. When no token is stored it returns an error (written to stderr by
+// cobra) and prints nothing to stdout, keeping command substitution clean.
+func newCmdLoginToken() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "token",
+		Short: "Print the stored Depot API token",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			token := config.GetApiToken()
+			if token == "" {
+				return fmt.Errorf("not logged in: no Depot API token found, please run `depot login`")
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), token)
+			return nil
+		},
+	}
+
+	return cmd
+}


### PR DESCRIPTION
## Login ergonomics for scripting

Two small additions to `depot login` so scripts (e.g. SDK-driven automation) can authenticate quietly and read the API token programmatically, instead of parsing `~/.config/depot/depot.yaml` by hand. Addresses cli#410.

### `depot login --quiet`
A new `--quiet` flag: when a token is already present, login is a **silent exit-0 no-op** (the 'You are already logged in.' notice is suppressed). Without `--quiet`, the notice prints exactly as before, and the device-flow login, `--clear`, org selection, and 'Successfully authenticated!' output are all unchanged. The flag's only effect is silencing the already-authenticated message -- useful for an idempotent auth preflight in a script.

### `depot login token`
A new child subcommand that prints the stored Depot API token to **stdout** (single line), mirroring `depot pull-token`'s discipline, so it can be captured with command substitution: `TOKEN=$(depot login token)`. When no token is stored it returns a clean error (to stderr, non-zero exit) and prints nothing to stdout, keeping the substitution clean. It reads the same `config.GetApiToken()` the CLI authenticates with (which also resolves `DEPOT_API_TOKEN` from the environment), so it prints whatever the CLI itself would use.

### Scope
Confined to `pkg/cmd/login/` (`config.GetApiToken()` already existed; no config change). Token validity/expiry reporting is intentionally left as a follow-on -- the CLI stores a bare opaque token with no expiry metadata, so a validity readout would require a new API introspect call, which is a distinct change.

### Tests
Four tests in `login_test.go`, each isolating config state (viper `api_token` + `DEPOT_API_TOKEN`) so they don't read the developer's real config: `--quiet` is a silent no-op when logged in (with a non-quiet control proving the notice still prints), `login token` prints exactly the token when logged in, and `login token` errors with nothing on stdout when not logged in. `go build` / `go test ./pkg/cmd/login/...` / `go vet` / `golangci-lint` all clean.

DEP-4912.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `login token` writes the full API credential to stdout, increasing accidental exposure in logs/history; behavior is read-only and mirrors existing config resolution.
> 
> **Overview**
> Adds **script-friendly login behavior** without changing the device-flow login path when no token exists.
> 
> **`depot login --quiet`** — When a token is already stored, the command still exits 0 but **suppresses** the “You are already logged in.” message (stdout now goes through `cmd.OutOrStdout()` for that notice). Default behavior is unchanged.
> 
> **`depot login token`** — New subcommand that prints the stored API token from `config.GetApiToken()` (including `DEPOT_API_TOKEN`) as a single stdout line for shell capture; errors with no stdout when unauthenticated.
> 
> **Tests** in `login_test.go` isolate viper/env token state and cover quiet vs non-quiet already-logged-in paths and token success/failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 973784a37585a4cfd99d9b738bafe4e51862f8da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->