### PR TITLE
Update workflow actions to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,20 +8,20 @@ jobs:
     runs-on: depot-ubuntu-latest-16
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.24.4"
           check-latest: true
           cache: true
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4.0.0
+        uses: pnpm/action-setup@v5
         with:
           version: 8.x.x
 
       - name: Install Node 18
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "18"
           cache: pnpm
@@ -51,7 +51,7 @@ jobs:
           assert-nothing-changed go mod tidy
           exit $STATUS
 
-      - uses: golangci/golangci-lint-action@v7
+      - uses: golangci/golangci-lint-action@v9
         with:
           version: v2.2.1
           only-new-issues: false
@@ -69,20 +69,20 @@ jobs:
     runs-on: depot-ubuntu-latest-16
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.24.4"
           check-latest: true
           cache: true
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4.0.0
+        uses: pnpm/action-setup@v5
         with:
           version: 8.x.x
 
       - name: Install Node 18
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "18"
           cache: pnpm
@@ -92,7 +92,7 @@ jobs:
         run: pnpm install --frozen-lockfile --ignore-scripts
         working-directory: npm
 
-      - uses: goreleaser/goreleaser-action@v5
+      - uses: goreleaser/goreleaser-action@v7
         with:
           version: 1.19.0
           args: build --clean --snapshot
@@ -104,8 +104,8 @@ jobs:
   test:
     runs-on: depot-ubuntu-latest-16
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.24"
           check-latest: true
@@ -121,9 +121,9 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: depot/setup-action@v1
-      - uses: docker/metadata-action@v5
+      - uses: docker/metadata-action@v6
         id: meta
         with:
           images: |
@@ -142,12 +142,12 @@ jobs:
           echo "::set-output name=version::${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}"
           echo "::set-output name=date::$(date +'%Y-%m-%d')"
           echo "::set-output name=sentry-environment::${{ fromJSON('{"true":"release","false":"development"}')[startsWith(github.ref, 'refs/tags/v')] }}"
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::375021575472:role/github-actions
           aws-region: us-east-1

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,7 +24,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,6 +8,6 @@ jobs:
   release-drafter:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@v7
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_PUBLIC_GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,21 +13,21 @@ jobs:
     runs-on: ubuntu-latest-16-cores
     if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev-')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.21"
           check-latest: true
           cache: true
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4.0.0
+        uses: pnpm/action-setup@v5
         with:
           version: 8.x.x
 
       - name: Install Node 24
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: https://registry.npmjs.org
@@ -38,7 +38,7 @@ jobs:
         run: pnpm install --frozen-lockfile --ignore-scripts
         working-directory: npm
 
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::375021575472:role/github-actions
           aws-region: us-east-1
@@ -47,7 +47,7 @@ jobs:
         id: tag-name
         run: echo "tag-name=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
-      - uses: goreleaser/goreleaser-action@v5
+      - uses: goreleaser/goreleaser-action@v7
         with:
           version: 1.19.0
           args: release --clean


### PR DESCRIPTION
Updates workflow action versions to Node 24-based releases. No intended workflow behavior changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only changes to CI/release automation; no application or runtime logic is modified, though a bad action upgrade could break pipelines until reverted.
> 
> **Overview**
> Bumps third-party GitHub Actions across **ci**, **release**, **release-drafter**, and **claude** workflows to newer major tags aligned with Node 24–based action runtimes, with no intended changes to job steps, inputs, or triggers.
> 
> **ci.yml** updates checkout/setup-go/setup-node/pnpm, **golangci-lint-action** (v7→v9), **goreleaser-action** (v5→v7), **docker/metadata-action** (v5→v6), **docker/login-action** (v3→v4), and **configure-aws-credentials** (v4→v6) on lint, build, test, and package jobs. **release.yml** and **claude.yml** / **release-drafter.yml** get the same pattern for their respective steps (e.g. release-drafter v6→v7).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31531bb1fc83e4b2630b2dffd609ba8fb6d62b44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->