### PR TITLE
Fail fast on a wedged builder connection (DEP-5153)

### DIFF
--- a/pkg/buildx/commands/build.go
+++ b/pkg/buildx/commands/build.go
@@ -207,7 +207,10 @@ type nopCloser struct {
 func (c nopCloser) Close() error { return nil }
 
 func buildTargets(ctx context.Context, dockerCli command.Cli, nodes []builder.Node, opts map[string]build.Options, depotOpts DepotOptions, progressMode, metadataFile string, exportLoad, allowNoOutput bool) (imageIDs []string, res *build.ResultContext, err error) {
-	ctx2, cancel := context.WithCancel(context.TODO())
+	// Derive from the build context (not context.TODO) so cancellation — a dead
+	// builder, a signal, a parent deadline — propagates to the progress printer
+	// instead of leaving it blocked on a connection that will never return.
+	ctx2, cancel := context.WithCancel(ctx)
 
 	printer, err := progress.NewPrinter(ctx2, os.Stderr, os.Stderr, progressMode)
 	if err != nil {

--- a/pkg/machine/machine.go
+++ b/pkg/machine/machine.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"connectrpc.com/connect"
@@ -74,7 +75,12 @@ func Acquire(ctx context.Context, buildID, token, platform string) (*Machine, er
 			BuildId:  m.BuildID,
 			Platform: builderPlatform,
 		}
-		resp, err := client.GetBuildKitConnection(ctx, api.WithAuthentication(connect.NewRequest(&req), m.Token))
+		// Bound each poll with a per-call deadline so a half-open API connection
+		// can't wedge acquisition forever; an error aborts so the build surfaces
+		// it instead of hanging.
+		callCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		resp, err := client.GetBuildKitConnection(callCtx, api.WithAuthentication(connect.NewRequest(&req), m.Token))
+		cancel()
 		if err != nil {
 			return nil, err
 		}
@@ -164,15 +170,53 @@ func (m *Machine) Release() error {
 	return nil
 }
 
+// buildKitKeepaliveOnce guards the one-time keepalive env defaults below.
+var buildKitKeepaliveOnce sync.Once
+
+// applyBuildKitKeepaliveDefaults sets the DEPOT_KEEPALIVE_CLIENT_* values the
+// depot/buildkit fork reads when it builds the gRPC client, unless the operator
+// already set them. Time is the idle interval between keepalive pings and
+// Timeout is how long to wait for a ping ack before closing the connection, so a
+// dead builder is detected in roughly Time+Timeout while a solve stream is
+// active. PermitWithoutStream is left off on purpose: the builder's keepalive
+// enforcement policy can GOAWAY a client that pings on an idle, stream-less
+// connection, and the hang we care about (DEP-5143) happens during an active
+// solve where pings flow regardless.
+func applyBuildKitKeepaliveDefaults() {
+	buildKitKeepaliveOnce.Do(func() {
+		setEnvDefault("DEPOT_KEEPALIVE_CLIENT_TIME_MS", "30000")
+		setEnvDefault("DEPOT_KEEPALIVE_CLIENT_TIMEOUT_MS", "10000")
+	})
+}
+
+func setEnvDefault(key, value string) {
+	if os.Getenv(key) == "" {
+		_ = os.Setenv(key, value)
+	}
+}
+
 func (m *Machine) Client(ctx context.Context) (*client.Client, error) {
 	if m.client != nil {
 		return m.client, nil
 	}
 
+	// Enable gRPC keepalive on the BuildKit connection. buildkit's client.New
+	// already wires grpc.WithKeepaliveParams, but the depot fork sources those
+	// values from DEPOT_KEEPALIVE_CLIENT_* env vars and leaves them zero (i.e.
+	// disabled) when unset — so a wedged solve stream to a dead builder blocks
+	// forever and the build is pinned `running` (DEP-5143). Set sane defaults so
+	// a half-open connection is detected in seconds.
+	applyBuildKitKeepaliveDefaults()
+
 	opts := []client.ClientOpt{
 		client.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
 			addr = strings.TrimPrefix(addr, "tcp://")
-			return net.Dial("tcp", addr)
+			// A bare net.Dial has no connect timeout and ignores the context, so a
+			// builder that accepts the TCP connection but never responds, or a DNS
+			// hang, blocks indefinitely. Bound the dial and turn on TCP keepalive
+			// as an OS-level backstop to the gRPC pings.
+			dialer := &net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}
+			return dialer.DialContext(ctx, "tcp", addr)
 		}),
 	}
 

--- a/pkg/machine/machine_test.go
+++ b/pkg/machine/machine_test.go
@@ -1,0 +1,49 @@
+package machine
+
+import (
+	"os"
+	"testing"
+)
+
+func TestSetEnvDefault(t *testing.T) {
+	const key = "DEPOT_TEST_SET_ENV_DEFAULT"
+
+	t.Run("sets the value when unset", func(t *testing.T) {
+		os.Unsetenv(key)
+		t.Cleanup(func() { os.Unsetenv(key) })
+
+		setEnvDefault(key, "default")
+
+		if got := os.Getenv(key); got != "default" {
+			t.Fatalf("expected %q, got %q", "default", got)
+		}
+	})
+
+	t.Run("preserves an operator-provided value", func(t *testing.T) {
+		t.Setenv(key, "operator")
+
+		setEnvDefault(key, "default")
+
+		if got := os.Getenv(key); got != "operator" {
+			t.Fatalf("expected operator value to be preserved, got %q", got)
+		}
+	})
+}
+
+func TestApplyBuildKitKeepaliveDefaults(t *testing.T) {
+	os.Unsetenv("DEPOT_KEEPALIVE_CLIENT_TIME_MS")
+	os.Unsetenv("DEPOT_KEEPALIVE_CLIENT_TIMEOUT_MS")
+	t.Cleanup(func() {
+		os.Unsetenv("DEPOT_KEEPALIVE_CLIENT_TIME_MS")
+		os.Unsetenv("DEPOT_KEEPALIVE_CLIENT_TIMEOUT_MS")
+	})
+
+	applyBuildKitKeepaliveDefaults()
+
+	if got := os.Getenv("DEPOT_KEEPALIVE_CLIENT_TIME_MS"); got != "30000" {
+		t.Fatalf("expected keepalive time default 30000, got %q", got)
+	}
+	if got := os.Getenv("DEPOT_KEEPALIVE_CLIENT_TIMEOUT_MS"); got != "10000" {
+		t.Fatalf("expected keepalive timeout default 10000, got %q", got)
+	}
+}


### PR DESCRIPTION
## What

When a `depot build` is running and the CLI can still reach the Depot API but its connection to the *builder* goes half-open mid-build (the builder dies, a network partition, a wedged proxy), nothing currently notices. The CLI keeps heartbeating the API, the build never progresses and never errors, and it stays pinned `running` until a server-side backstop cron eventually sweeps it (DEP-5143). This makes that connection fail fast instead of hanging.

## How

Two commits along the connection lifecycle:

1. **Fail fast on a wedged builder connection** (`pkg/machine/machine.go`). Three gaps let the builder connection hang indefinitely:
   - The dialer was a bare `net.Dial("tcp", addr)` — no connect timeout, and it ignored the context. Replaced with a `net.Dialer` carrying a 10s connect timeout and TCP keepalive, dialed with the context so cancellation aborts it.
   - gRPC keepalive was effectively **off**. buildkit's `client.New` does wire `grpc.WithKeepaliveParams`, but the depot/buildkit fork sources those values from `DEPOT_KEEPALIVE_CLIENT_*` env vars and leaves them zero when unset — and gRPC treats `Time: 0` as "never ping." We now set sane defaults (ping every 30s, 10s ack timeout) unless the operator has set them, so a dead builder is detected in seconds while a solve stream is active. `PermitWithoutStream` is deliberately left off so an idle connection can't trip the builder's keepalive enforcement policy. *(The fork exposes no way to pass a `grpc.DialOption`, so the env vars are the only client-side lever today; a first-class option there would be the cleaner long-term home.)*
   - The connection poll (`GetBuildKitConnection`) ran on the raw context with no per-call deadline. Each poll now gets a 30s deadline so a half-open API connection can't wedge acquisition either.

2. **Tie the build progress printer to the build context** (`pkg/buildx/commands/build.go`). `buildTargets` built its progress printer from `context.TODO()`, detaching it from the build's own context. On cancellation the printer was left blocked on a connection that would never return, so the command could hang even after the build gave up. Derived from the passed-in `ctx`, matching upstream buildx.

This is the CLI end of the RUN-step-OOM hang fix; the API end (finalize in-flight builds when the machine reports shutdown) landed separately.

## Testing

`go test ./pkg/machine/...` covers the env-default helper (sets when unset, preserves an operator value) and the keepalive defaults. `go build`, `go vet`, and `golangci-lint` are clean. The dial-timeout / keepalive / context-propagation behavior is transport-level and not unit-testable without a live builder.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core build connectivity, timeouts, and cancellation on the hot path; mis-tuned keepalive or dial behavior could affect live builds, though defaults are conservative and operator env overrides are preserved.
> 
> **Overview**
> Addresses builds that stay **`running`** when the Depot API is reachable but the **builder** connection goes half-open mid-solve (DEP-5143).
> 
> In **`pkg/machine`**, acquisition and BuildKit client setup now bound waits: each **`GetBuildKitConnection`** poll uses a **30s** deadline; the TCP dial uses **`DialContext`** with a **10s** connect timeout and TCP keepalive instead of a blocking **`net.Dial`**; and default **`DEPOT_KEEPALIVE_CLIENT_*`** env values enable gRPC keepalive on the depot/buildkit fork when the operator has not set them (without **`PermitWithoutStream`**).
> 
> In **`buildTargets`**, the progress printer context is derived from the build **`ctx`** instead of **`context.TODO()`**, so cancellation propagates and the command does not hang on the printer after the build aborts.
> 
> Unit tests cover **`setEnvDefault`** and keepalive default application.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac21c4a940aeccfdcffa413ce816e6a3c3d3259c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->