### PR TITLE
Normalize Compose service additional contexts in bake

### DIFF
--- a/pkg/buildx/bake/bake_test.go
+++ b/pkg/buildx/bake/bake_test.go
@@ -75,6 +75,31 @@ target "webapp" {
 	require.Equal(t, []string{"linux/amd64"}, targets2["webapp"].Platforms)
 }
 
+func TestReadTargetsComposeServiceAdditionalContext(t *testing.T) {
+	dt := []byte(`
+services:
+  api.docs:
+    build:
+      context: ./api-docs
+  django:
+    build:
+      context: .
+      additional_contexts:
+        api-schema-docs: service:api.docs
+        local-docs: ./docs
+`)
+
+	targets, _, err := bake.ReadTargets(context.TODO(), []bake.File{{Name: "compose.yaml", Data: dt}}, []string{"django"}, nil, nil)
+	require.NoError(t, err)
+
+	require.Contains(t, targets, "django")
+	require.Equal(t, "target:api_docs", targets["django"].Contexts["api-schema-docs"])
+	require.Equal(t, "docs", targets["django"].Contexts["local-docs"])
+
+	require.Contains(t, targets, "api_docs")
+	require.Equal(t, "api-docs", *targets["api_docs"].Context)
+}
+
 func TestVariableValidation(t *testing.T) {
 	fp := bake.File{
 		Name: "docker-bake.hcl",

--- a/pkg/buildx/bake/compose.go
+++ b/pkg/buildx/bake/compose.go
@@ -53,6 +53,11 @@ func ParseCompose(cfgs []compose.ConfigFile, envs map[string]string) (*Config, e
 
 	var c Config
 	if len(cfg.Services) > 0 {
+		serviceTargetNames, err := composeBuildTargetNames(cfg.Services)
+		if err != nil {
+			return nil, err
+		}
+
 		c.Groups = []*Group{}
 		c.Targets = []*Target{}
 
@@ -63,10 +68,7 @@ func ParseCompose(cfgs []compose.ConfigFile, envs map[string]string) (*Config, e
 				continue
 			}
 
-			targetName := sanitizeTargetName(s.Name)
-			if err = validateTargetName(targetName); err != nil {
-				return nil, errors.Wrapf(err, "invalid service name %q", targetName)
-			}
+			targetName := serviceTargetNames[s.Name]
 
 			var contextPathP *string
 			if s.Build.Context != "" {
@@ -88,7 +90,7 @@ func ParseCompose(cfgs []compose.ConfigFile, envs map[string]string) (*Config, e
 			if s.Build.AdditionalContexts != nil {
 				additionalContexts = map[string]string{}
 				for k, v := range s.Build.AdditionalContexts {
-					additionalContexts[k] = v
+					additionalContexts[k] = normalizeComposeAdditionalContext(v, serviceTargetNames)
 				}
 			}
 
@@ -167,6 +169,35 @@ func ParseCompose(cfgs []compose.ConfigFile, envs map[string]string) (*Config, e
 	}
 
 	return &c, nil
+}
+
+func composeBuildTargetNames(services compose.Services) (map[string]string, error) {
+	targetNames := map[string]string{}
+	for _, s := range services {
+		if s.Build == nil {
+			continue
+		}
+
+		targetName := sanitizeTargetName(s.Name)
+		if err := validateTargetName(targetName); err != nil {
+			return nil, errors.Wrapf(err, "invalid service name %q", targetName)
+		}
+		targetNames[s.Name] = targetName
+	}
+	return targetNames, nil
+}
+
+func normalizeComposeAdditionalContext(context string, serviceTargetNames map[string]string) string {
+	serviceName, ok := strings.CutPrefix(context, compose.ServicePrefix)
+	if !ok {
+		return context
+	}
+
+	targetName, ok := serviceTargetNames[serviceName]
+	if !ok {
+		return context
+	}
+	return "target:" + targetName
 }
 
 func validateComposeFile(dt []byte, fn string) (bool, error) {


### PR DESCRIPTION
## Summary
- Translate Compose `additional_contexts` values like `service:api.docs` into generated bake target links like `target:api_docs`.
- Preserve non-service additional contexts unchanged.
- Add regression coverage for linked Compose build targets.

## Test plan
- `GOCACHE=/private/tmp/go-cache go test ./pkg/buildx/bake`

Support thread: T-9318

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to compose bake target generation and additional context mapping; behavior change only affects `service:` additional context values.
> 
> **Overview**
> Compose-to-bake conversion now rewrites **`additional_contexts`** entries that reference another service (e.g. `service:api.docs`) into bake **`target:`** links that match sanitized target names (e.g. `target:api_docs`). Path and other non-service values are left unchanged.
> 
> Service-to-target naming is built once via **`composeBuildTargetNames`** and reused when emitting targets, so linked contexts stay consistent with how compose services become bake targets (including dot-to-underscore sanitization). A regression test covers a service-linked context plus a local path context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 138f26b37cb637d10dd782a217cdd0795d44d968. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->