### PR TITLE
fix: fix auth for Dockerfiles referencing cross-project base images

### DIFF
--- a/pkg/registry/auth.go
+++ b/pkg/registry/auth.go
@@ -29,24 +29,24 @@ var (
 type AuthProvider struct {
 	inner       auth.AuthServer
 	credentials []build.Credential
+	projectID   string
 }
 
 // NewAuthProvider searches the session.Attachables for the first auth.AuthServer,
 // wraps it in an AuthProvider, and returns it.
 func ReplaceDockerAuth(credentials []build.Credential, as []session.Attachable) []session.Attachable {
+	return ReplaceDockerAuthForProject("", credentials, as)
+}
+
+func ReplaceDockerAuthForProject(projectID string, credentials []build.Credential, as []session.Attachable) []session.Attachable {
 	dockerConfig := config.LoadDefaultConfigFile(os.Stderr)
-	for _, c := range credentials {
-		dockerConfig.AuthConfigs[c.Host] = types.AuthConfig{
-			Auth:          c.Token,
-			ServerAddress: c.Host,
-		}
-	}
 
 	for i, a := range as {
 		if _, ok := a.(auth.AuthServer); ok {
 			p := authprovider.NewDockerAuthProvider(dockerConfig)
 			as[i] = &AuthProvider{
 				credentials: credentials,
+				projectID:   projectID,
 				inner:       p.(auth.AuthServer),
 			}
 		}
@@ -83,6 +83,10 @@ func (a *AuthProvider) Credentials(ctx context.Context, req *auth.CredentialsReq
 }
 
 func (a *AuthProvider) FetchToken(ctx context.Context, req *auth.FetchTokenRequest) (*auth.FetchTokenResponse, error) {
+	if !a.shouldUseDepotCredentials(req.Scopes) {
+		return a.inner.FetchToken(ctx, req)
+	}
+
 	creds, err := a.findCredentials(req.Host)
 	if err != nil {
 		return nil, err
@@ -97,6 +101,22 @@ func (a *AuthProvider) FetchToken(ctx context.Context, req *auth.FetchTokenReque
 
 	// No secret, fall back to inner provider.
 	return a.inner.FetchToken(ctx, req)
+}
+
+func (a *AuthProvider) shouldUseDepotCredentials(scopes []string) bool {
+	if a.projectID == "" {
+		return true
+	}
+
+	for _, scope := range scopes {
+		for _, part := range strings.Split(scope, " ") {
+			if strings.HasPrefix(part, "repository:"+a.projectID+":") {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // findCredentials looks up decoded credentials for a host from the depot credential list.

--- a/pkg/registry/auth_test.go
+++ b/pkg/registry/auth_test.go
@@ -1,0 +1,54 @@
+package registry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/moby/buildkit/session/auth"
+)
+
+func TestShouldUseDepotCredentialsForCurrentProjectScope(t *testing.T) {
+	provider := &AuthProvider{projectID: "current-project"}
+
+	if !provider.shouldUseDepotCredentials([]string{"repository:current-project:pull,push"}) {
+		t.Fatal("expected current project scope to use Depot credentials")
+	}
+}
+
+func TestShouldUseDepotCredentialsFallsBackForOtherProjectScope(t *testing.T) {
+	provider := &AuthProvider{projectID: "current-project"}
+
+	if provider.shouldUseDepotCredentials([]string{"repository:other-project:pull"}) {
+		t.Fatal("expected other project scope to use Docker credentials")
+	}
+}
+
+func TestFetchTokenFallsBackForOtherProjectScope(t *testing.T) {
+	inner := &recordingAuthServer{}
+	provider := &AuthProvider{
+		inner:       inner,
+		projectID:   "current-project",
+		credentials: nil,
+	}
+
+	_, err := provider.FetchToken(context.Background(), &auth.FetchTokenRequest{
+		Host:   "registry.depot.dev",
+		Scopes: []string{"repository:other-project:pull"},
+	})
+	if err != nil {
+		t.Fatalf("FetchToken returned error: %v", err)
+	}
+	if !inner.fetchTokenCalled {
+		t.Fatal("expected FetchToken to fall back to inner auth server")
+	}
+}
+
+type recordingAuthServer struct {
+	auth.UnimplementedAuthServer
+	fetchTokenCalled bool
+}
+
+func (r *recordingAuthServer) FetchToken(context.Context, *auth.FetchTokenRequest) (*auth.FetchTokenResponse, error) {
+	r.fetchTokenCalled = true
+	return &auth.FetchTokenResponse{Token: "docker-token"}, nil
+}

--- a/pkg/registry/cli.go
+++ b/pkg/registry/cli.go
@@ -32,7 +32,7 @@ func WithDepotSave(buildOpts map[string]buildx.Options, opts SaveOptions) map[st
 		if len(opts.RequestedTargets) > 0 && !slices.Contains(opts.RequestedTargets, target) {
 			continue
 		}
-		buildOpt.Session = ReplaceDockerAuth(opts.AdditionalCredentials, buildOpt.Session)
+		buildOpt.Session = ReplaceDockerAuthForProject(opts.ProjectID, opts.AdditionalCredentials, buildOpt.Session)
 
 		hadPush := false
 		imageExportIndices := []int{}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes build-time registry authentication and token selection; incorrect scope logic could break pushes/pulls for the current project or still mis-auth cross-project images.
> 
> **Overview**
> **Registry auth now picks credentials from the OAuth scope**, so pulls of base images in another Depot project use the user’s Docker config instead of the build’s Depot credentials.
> 
> `AuthProvider` stores a **project ID** and `FetchToken` only uses Depot credentials when scopes include `repository:<projectID>:...`; otherwise it delegates to the inner Docker auth provider. `WithDepotSave` wires this via `ReplaceDockerAuthForProject`. Setup no longer merges Depot credentials into the Docker config file up front.
> 
> Tests cover scope matching and `FetchToken` fallback for other-project scopes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cc974444fda6b159f79dfa081dbe30cca3efd7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->