### PR TITLE
Fix release Go version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.21"
+          go-version: "1.24.4"
           check-latest: true
           cache: true
 


### PR DESCRIPTION
## Summary
- update the release workflow to install Go 1.24.4 before running GoReleaser
- match the Go version required by go.mod and already used by CI lint/build jobs

## Root cause
The release job for https://github.com/depot/cli/actions/runs/28864769396/job/85611937100 installed Go 1.21.13, then GoReleaser ran `go mod tidy`. Since go.mod requires Go 1.24.4 and the workflow sets `GOTOOLCHAIN=local`, the hook failed with `go: go.mod requires go >= 1.24.4 (running go 1.21.13; GOTOOLCHAIN=local)`.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "ok"'`\n- `go version` -> `go version go1.24.4 darwin/arm64`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single workflow version pin change with no application or runtime behavior changes.
> 
> **Overview**
> The **release** workflow’s `actions/setup-go` step now installs **Go 1.24.4** instead of **1.21**, matching `go.mod` and the lint/build jobs in CI.
> 
> This fixes tag releases where GoReleaser runs `go mod tidy` under `GOTOOLCHAIN=local` and previously failed because the job used an older toolchain than `go >= 1.24.4`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8350f6e29be811ae53dc14b0fa5a07573eda6fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->