### PR TITLE
Add depot tests report command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	connectrpc.com/connect v1.15.0
 	github.com/adrg/xdg v0.4.0
 	github.com/aws/aws-sdk-go-v2/config v1.15.5
+	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/briandowns/spinner v1.18.1
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10

--- a/go.sum
+++ b/go.sum
@@ -119,6 +119,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
+github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/briandowns/spinner v1.18.1 h1:yhQmQtM1zsqFsouh09Bk/jCjd50pC3EOGsh28gLVvwY=
 github.com/briandowns/spinner v1.18.1/go.mod h1:mQak9GHqbspjC/5iUx3qMlIho8xBS/ppAL/hX5SmPJU=
 github.com/bugsnag/bugsnag-go v1.4.1 h1:TT3P9AX69w8mbSGE8L7IJOO2KBlPN0iQtYD0dUlrWHc=

--- a/pkg/api/testresults.go
+++ b/pkg/api/testresults.go
@@ -22,6 +22,15 @@ func ListTestResults(ctx context.Context, token, orgID string, req *testresultsv
 	return resp.Msg, nil
 }
 
+func ReportTestResults(ctx context.Context, token string, req *testresultsv1.ReportTestResultsRequest) (*testresultsv1.ReportTestResultsResponse, error) {
+	client := newTestResultsServiceClient()
+	resp, err := client.ReportTestResults(ctx, WithAuthentication(connect.NewRequest(req), token))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Msg, nil
+}
+
 func SplitTests(ctx context.Context, token string, req *testresultsv1.SplitTestsRequest) (*testresultsv1.SplitTestsResponse, error) {
 	client := newTestResultsServiceClient()
 	resp, err := client.SplitTests(ctx, WithAuthentication(connect.NewRequest(req), token))

--- a/pkg/api/testresults_test.go
+++ b/pkg/api/testresults_test.go
@@ -87,6 +87,41 @@ func TestSplitTestsSendsAuthHeader(t *testing.T) {
 	}
 }
 
+func TestReportTestResultsSendsAuthHeader(t *testing.T) {
+	handler := &testResultsHandler{}
+	setupTestResultsServer(t, handler)
+
+	resp, err := ReportTestResults(
+		context.Background(),
+		"oidc-token-1",
+		&testresultsv1.ReportTestResultsRequest{
+			InvocationId: "unit",
+			Files: []*testresultsv1.TestResultsFile{
+				{Filename: "reports/junit.xml", GzippedXml: []byte("gzipped")},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if handler.authorization != "Bearer oidc-token-1" {
+		t.Fatalf("expected auth header %q, got %q", "Bearer oidc-token-1", handler.authorization)
+	}
+	if handler.orgID != "" {
+		t.Fatalf("expected no org header for report tests, got %q", handler.orgID)
+	}
+	if handler.reportRequest.GetInvocationId() != "unit" {
+		t.Fatalf("expected invocation ID %q, got %q", "unit", handler.reportRequest.GetInvocationId())
+	}
+	if len(handler.reportRequest.GetFiles()) != 1 || handler.reportRequest.GetFiles()[0].GetFilename() != "reports/junit.xml" {
+		t.Fatalf("expected report file in request, got %#v", handler.reportRequest.GetFiles())
+	}
+	if resp.GetFilesProcessed() != 1 || resp.GetTestsReported() != 2 {
+		t.Fatalf("expected report response counts, got files=%d tests=%d", resp.GetFilesProcessed(), resp.GetTestsReported())
+	}
+}
+
 func setupTestResultsServer(t *testing.T, handler *testResultsHandler) {
 	t.Helper()
 
@@ -107,7 +142,21 @@ type testResultsHandler struct {
 	authorization string
 	orgID         string
 	request       *testresultsv1.ListTestResultsRequest
+	reportRequest *testresultsv1.ReportTestResultsRequest
 	splitRequest  *testresultsv1.SplitTestsRequest
+}
+
+func (h *testResultsHandler) ReportTestResults(
+	_ context.Context,
+	req *connect.Request[testresultsv1.ReportTestResultsRequest],
+) (*connect.Response[testresultsv1.ReportTestResultsResponse], error) {
+	h.authorization = req.Header().Get("Authorization")
+	h.orgID = req.Header().Get("x-depot-org")
+	h.reportRequest = req.Msg
+	return connect.NewResponse(&testresultsv1.ReportTestResultsResponse{
+		FilesProcessed: 1,
+		TestsReported:  2,
+	}), nil
 }
 
 func (h *testResultsHandler) SplitTests(

--- a/pkg/cmd/tests/report.go
+++ b/pkg/cmd/tests/report.go
@@ -139,6 +139,7 @@ func expandReportPattern(input, workspace string) ([]string, error) {
 		absoluteInput = filepath.Join(workspace, input)
 	}
 	absoluteInput = filepath.Clean(absoluteInput)
+	inputHasGlob := hasGlobMeta(absoluteInput)
 
 	if stat, err := os.Stat(absoluteInput); err == nil && stat.IsDir() {
 		realInput, err := filepath.EvalSymlinks(absoluteInput)
@@ -151,7 +152,7 @@ func expandReportPattern(input, workspace string) ([]string, error) {
 		if realInput == workspace {
 			return nil, fmt.Errorf("test report path is too broad; use a report subdirectory instead: %s", input)
 		}
-		return globReportFiles(filepath.Join(realInput, "**", "*.xml"))
+		return globReportFiles(filepath.Join(realInput, "**", "*.xml"), true)
 	}
 
 	searchRoot := findReportSearchRoot(absoluteInput)
@@ -170,7 +171,7 @@ func expandReportPattern(input, workspace string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return globReportFiles(resolvedPattern)
+	return globReportFiles(resolvedPattern, inputHasGlob)
 }
 
 func resolveGlobPattern(pattern, searchRoot, realSearchRoot string) (string, error) {
@@ -342,7 +343,7 @@ func gzipBytes(contents []byte) ([]byte, error) {
 	return out.Bytes(), nil
 }
 
-func globReportFiles(pattern string) ([]string, error) {
+func globReportFiles(pattern string, xmlOnly bool) ([]string, error) {
 	base, filePattern := doublestar.SplitPattern(filepath.ToSlash(filepath.Clean(pattern)))
 	base = filepath.FromSlash(base)
 	if _, err := os.Stat(base); os.IsNotExist(err) {
@@ -352,6 +353,9 @@ func globReportFiles(pattern string) ([]string, error) {
 	var matches []string
 	err := doublestar.GlobWalk(os.DirFS(base), filePattern, func(filePath string, entry fs.DirEntry) error {
 		if entry.IsDir() {
+			return nil
+		}
+		if xmlOnly && strings.ToLower(filepath.Ext(filePath)) != ".xml" {
 			return nil
 		}
 		matches = append(matches, filepath.Join(base, filePath))
@@ -395,6 +399,10 @@ func hasRecursiveGlob(pattern string) bool {
 		}
 	}
 	return false
+}
+
+func hasGlobMeta(pattern string) bool {
+	return strings.ContainsAny(filepath.ToSlash(pattern), "*?{[")
 }
 
 func isInsideWorkspace(workspace, filePath string) bool {

--- a/pkg/cmd/tests/report.go
+++ b/pkg/cmd/tests/report.go
@@ -1,0 +1,409 @@
+package tests
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/bmatcuk/doublestar/v4"
+	testresultsv1 "github.com/depot/cli/pkg/proto/depot/testresults/v1"
+	"github.com/spf13/cobra"
+)
+
+const (
+	maxReportFiles       = 1000
+	maxReportFileBytes   = 50 * 1024 * 1024
+	maxReportTotalBytes  = 100 * 1024 * 1024
+	reportRequestTimeout = 2 * time.Minute
+)
+
+type discoveredReportFile struct {
+	absolutePath string
+	realPath     string
+	filename     string
+	info         os.FileInfo
+}
+
+func uploadTestReportsResponse(cmd *cobra.Command, opts reportOptions) (int, *testresultsv1.ReportTestResultsResponse, error) {
+	workspace, err := reportWorkspace()
+	if err != nil {
+		return 0, nil, err
+	}
+
+	files, err := discoverReportFiles(opts.reportPaths, workspace)
+	if err != nil {
+		return 0, nil, err
+	}
+	if len(files) == 0 {
+		return 0, nil, fmt.Errorf("no JUnit XML report files matched")
+	}
+
+	prepared, err := prepareReportFiles(files)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	requestCtx, cancel := context.WithTimeout(cmd.Context(), reportRequestTimeout)
+	defer cancel()
+
+	token, err := resolveOIDCCredentialFunc(requestCtx)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	resp, err := reportTestResultsFunc(requestCtx, token, &testresultsv1.ReportTestResultsRequest{
+		InvocationId: testKey(opts.key),
+		Files:        prepared,
+	})
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to upload test reports: %w", err)
+	}
+	return len(prepared), resp, nil
+}
+
+func reportWorkspace() (string, error) {
+	if workspace := os.Getenv("GITHUB_WORKSPACE"); strings.TrimSpace(workspace) != "" {
+		return workspace, nil
+	}
+	return os.Getwd()
+}
+
+func splitReportPathInputs(inputs []string) []string {
+	var paths []string
+	for _, input := range inputs {
+		normalized := strings.ReplaceAll(input, "\r\n", "\n")
+		normalized = strings.ReplaceAll(normalized, "\r", "\n")
+		for _, path := range strings.Split(normalized, "\n") {
+			path = strings.TrimSpace(path)
+			if path != "" {
+				paths = append(paths, path)
+			}
+		}
+	}
+	return paths
+}
+
+func discoverReportFiles(inputs []string, workspace string) ([]discoveredReportFile, error) {
+	workspace, err := filepath.Abs(workspace)
+	if err != nil {
+		return nil, err
+	}
+	workspace, err = filepath.EvalSymlinks(workspace)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := map[string]struct{}{}
+	var files []discoveredReportFile
+	for _, input := range splitReportPathInputs(inputs) {
+		matches, err := expandReportPattern(input, workspace)
+		if err != nil {
+			return nil, err
+		}
+		for _, match := range matches {
+			file, ok, err := reportFileFromMatch(match, workspace)
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				continue
+			}
+			if _, exists := seen[file.realPath]; exists {
+				continue
+			}
+			seen[file.realPath] = struct{}{}
+			files = append(files, file)
+			if len(files) > maxReportFiles {
+				return nil, fmt.Errorf("matched more than %d test report files", maxReportFiles)
+			}
+		}
+	}
+
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].filename < files[j].filename
+	})
+	return files, nil
+}
+
+func expandReportPattern(input, workspace string) ([]string, error) {
+	absoluteInput := input
+	if !filepath.IsAbs(absoluteInput) {
+		absoluteInput = filepath.Join(workspace, input)
+	}
+	absoluteInput = filepath.Clean(absoluteInput)
+
+	if stat, err := os.Stat(absoluteInput); err == nil && stat.IsDir() {
+		realInput, err := filepath.EvalSymlinks(absoluteInput)
+		if err != nil {
+			return nil, err
+		}
+		if !isInsideWorkspace(workspace, realInput) {
+			return nil, fmt.Errorf("test report path is outside the workspace: %s", input)
+		}
+		if realInput == workspace {
+			return nil, fmt.Errorf("test report path is too broad; use a report subdirectory instead: %s", input)
+		}
+		return globReportFiles(filepath.Join(realInput, "**", "*.xml"))
+	}
+
+	searchRoot := findReportSearchRoot(absoluteInput)
+	realSearchRoot, err := realExistingPath(searchRoot)
+	if err != nil {
+		return nil, err
+	}
+	if !isInsideWorkspace(workspace, realSearchRoot) {
+		return nil, fmt.Errorf("test report path is outside the workspace: %s", input)
+	}
+
+	if realSearchRoot == workspace && hasRecursiveGlob(absoluteInput) {
+		return nil, fmt.Errorf("test report path is too broad; use a report subdirectory instead: %s", input)
+	}
+	resolvedPattern, err := resolveGlobPattern(absoluteInput, searchRoot, realSearchRoot)
+	if err != nil {
+		return nil, err
+	}
+	return globReportFiles(resolvedPattern)
+}
+
+func resolveGlobPattern(pattern, searchRoot, realSearchRoot string) (string, error) {
+	relativePattern, err := filepath.Rel(searchRoot, pattern)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(realSearchRoot, relativePattern), nil
+}
+
+func reportFileFromMatch(match, workspace string) (discoveredReportFile, bool, error) {
+	absolutePath, err := filepath.Abs(match)
+	if err != nil {
+		return discoveredReportFile{}, false, err
+	}
+	absolutePath = filepath.Clean(absolutePath)
+
+	info, err := os.Lstat(absolutePath)
+	if err != nil {
+		return discoveredReportFile{}, false, err
+	}
+	if info.IsDir() {
+		return discoveredReportFile{}, false, nil
+	}
+
+	realPath, err := filepath.EvalSymlinks(absolutePath)
+	if err != nil {
+		return discoveredReportFile{}, false, err
+	}
+	if !isInsideWorkspace(workspace, realPath) {
+		return discoveredReportFile{}, false, fmt.Errorf("matched test report file is outside the workspace: %s", match)
+	}
+	info, err = os.Lstat(realPath)
+	if err != nil {
+		return discoveredReportFile{}, false, err
+	}
+	if strings.ToLower(filepath.Ext(realPath)) != ".xml" {
+		return discoveredReportFile{}, false, fmt.Errorf("matched test report file must have a .xml extension: %s", match)
+	}
+	if !info.Mode().IsRegular() {
+		return discoveredReportFile{}, false, fmt.Errorf("matched test report is not a regular file: %s", match)
+	}
+	if info.Size() > maxReportFileBytes {
+		return discoveredReportFile{}, false, fmt.Errorf("test report file %s exceeds the %s per-file limit", match, formatBytes(maxReportFileBytes))
+	}
+
+	filename, err := filepath.Rel(workspace, realPath)
+	if err != nil {
+		return discoveredReportFile{}, false, err
+	}
+	return discoveredReportFile{
+		absolutePath: realPath,
+		realPath:     realPath,
+		filename:     filepath.ToSlash(filename),
+		info:         info,
+	}, true, nil
+}
+
+func prepareReportFiles(files []discoveredReportFile) ([]*testresultsv1.TestResultsFile, error) {
+	if len(files) > maxReportFiles {
+		return nil, fmt.Errorf("matched more than %d test report files", maxReportFiles)
+	}
+
+	var totalBytes int64
+	prepared := make([]*testresultsv1.TestResultsFile, 0, len(files))
+	for _, file := range files {
+		currentRealPath, err := filepath.EvalSymlinks(file.absolutePath)
+		if err != nil {
+			return nil, err
+		}
+		if currentRealPath != file.realPath {
+			return nil, fmt.Errorf("test report file changed after discovery: %s", file.filename)
+		}
+
+		info, err := os.Lstat(file.absolutePath)
+		if err != nil {
+			return nil, err
+		}
+		if !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("matched test report is not a regular file: %s", file.filename)
+		}
+		if file.info != nil && reportFileChanged(file.info, info) {
+			return nil, fmt.Errorf("test report file changed after discovery: %s", file.filename)
+		}
+		if info.Size() > maxReportFileBytes {
+			return nil, fmt.Errorf("test report file %s exceeds the %s per-file limit", file.filename, formatBytes(maxReportFileBytes))
+		}
+		if totalBytes+info.Size() > maxReportTotalBytes {
+			return nil, fmt.Errorf("matched test reports exceed the %s total uncompressed size limit", formatBytes(maxReportTotalBytes))
+		}
+
+		contents, err := readReportFile(file)
+		if err != nil {
+			return nil, err
+		}
+		if len(contents) > maxReportFileBytes {
+			return nil, fmt.Errorf("test report file %s exceeds the %s per-file limit", file.filename, formatBytes(maxReportFileBytes))
+		}
+		totalBytes += int64(len(contents))
+		if totalBytes > maxReportTotalBytes {
+			return nil, fmt.Errorf("matched test reports exceed the %s total uncompressed size limit", formatBytes(maxReportTotalBytes))
+		}
+
+		gzipped, err := gzipBytes(contents)
+		if err != nil {
+			return nil, err
+		}
+		prepared = append(prepared, &testresultsv1.TestResultsFile{
+			Filename:   file.filename,
+			GzippedXml: gzipped,
+		})
+	}
+	return prepared, nil
+}
+
+func reportFileChanged(discovered, current os.FileInfo) bool {
+	return !os.SameFile(discovered, current) ||
+		discovered.Size() != current.Size() ||
+		discovered.Mode() != current.Mode() ||
+		!discovered.ModTime().Equal(current.ModTime())
+}
+
+func readReportFile(reportFile discoveredReportFile) ([]byte, error) {
+	file, err := os.Open(reportFile.absolutePath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("matched test report is not a regular file: %s", reportFile.filename)
+	}
+	if reportFile.info != nil && reportFileChanged(reportFile.info, info) {
+		return nil, fmt.Errorf("test report file changed after discovery: %s", reportFile.filename)
+	}
+	if info.Size() > maxReportFileBytes {
+		return nil, fmt.Errorf("test report file %s exceeds the %s per-file limit", reportFile.filename, formatBytes(maxReportFileBytes))
+	}
+
+	contents, err := io.ReadAll(io.LimitReader(file, maxReportFileBytes+1))
+	if err != nil {
+		return nil, err
+	}
+
+	afterInfo, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if reportFileChanged(info, afterInfo) {
+		return nil, fmt.Errorf("test report file changed while reading: %s", reportFile.filename)
+	}
+
+	return contents, nil
+}
+
+func gzipBytes(contents []byte) ([]byte, error) {
+	var out bytes.Buffer
+	writer := gzip.NewWriter(&out)
+	if _, err := writer.Write(contents); err != nil {
+		return nil, err
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
+}
+
+func globReportFiles(pattern string) ([]string, error) {
+	base, filePattern := doublestar.SplitPattern(filepath.ToSlash(filepath.Clean(pattern)))
+	base = filepath.FromSlash(base)
+
+	var matches []string
+	err := doublestar.GlobWalk(os.DirFS(base), filePattern, func(filePath string, entry fs.DirEntry) error {
+		if entry.IsDir() {
+			return nil
+		}
+		matches = append(matches, filepath.Join(base, filePath))
+		if len(matches) > maxReportFiles {
+			return fmt.Errorf("matched more than %d test report files", maxReportFiles)
+		}
+		return nil
+	}, doublestar.WithFailOnIOErrors(), doublestar.WithFilesOnly(), doublestar.WithNoFollow())
+	return matches, err
+}
+
+func findReportSearchRoot(pattern string) string {
+	base, _ := doublestar.SplitPattern(filepath.ToSlash(filepath.Clean(pattern)))
+	return filepath.FromSlash(base)
+}
+
+func realExistingPath(filePath string) (string, error) {
+	current := filepath.Clean(filePath)
+	for {
+		realPath, err := filepath.EvalSymlinks(current)
+		if err == nil {
+			return realPath, nil
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", fmt.Errorf("unable to resolve test report path: %s", filePath)
+		}
+		current = parent
+	}
+}
+
+func hasRecursiveGlob(pattern string) bool {
+	for _, part := range strings.Split(filepath.ToSlash(pattern), "/") {
+		if strings.Contains(part, "**") {
+			return true
+		}
+	}
+	return false
+}
+
+func isInsideWorkspace(workspace, filePath string) bool {
+	rel, err := filepath.Rel(workspace, filePath)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (!strings.HasPrefix(rel, ".."+string(filepath.Separator)) && rel != ".." && !filepath.IsAbs(rel))
+}
+
+func formatBytes(bytes int64) string {
+	if bytes < 1024 {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	kib := float64(bytes) / 1024
+	if kib < 1024 {
+		return fmt.Sprintf("%.1f KiB", kib)
+	}
+	return fmt.Sprintf("%.1f MiB", kib/1024)
+}

--- a/pkg/cmd/tests/report.go
+++ b/pkg/cmd/tests/report.go
@@ -345,6 +345,9 @@ func gzipBytes(contents []byte) ([]byte, error) {
 func globReportFiles(pattern string) ([]string, error) {
 	base, filePattern := doublestar.SplitPattern(filepath.ToSlash(filepath.Clean(pattern)))
 	base = filepath.FromSlash(base)
+	if _, err := os.Stat(base); os.IsNotExist(err) {
+		return nil, nil
+	}
 
 	var matches []string
 	err := doublestar.GlobWalk(os.DirFS(base), filePattern, func(filePath string, entry fs.DirEntry) error {
@@ -367,15 +370,20 @@ func findReportSearchRoot(pattern string) string {
 
 func realExistingPath(filePath string) (string, error) {
 	current := filepath.Clean(filePath)
+	var missing []string
 	for {
 		realPath, err := filepath.EvalSymlinks(current)
 		if err == nil {
+			for _, part := range missing {
+				realPath = filepath.Join(realPath, part)
+			}
 			return realPath, nil
 		}
 		parent := filepath.Dir(current)
 		if parent == current {
 			return "", fmt.Errorf("unable to resolve test report path: %s", filePath)
 		}
+		missing = append([]string{filepath.Base(current)}, missing...)
 		current = parent
 	}
 }

--- a/pkg/cmd/tests/report_cmd.go
+++ b/pkg/cmd/tests/report_cmd.go
@@ -1,0 +1,118 @@
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	testresultsv1 "github.com/depot/cli/pkg/proto/depot/testresults/v1"
+	"github.com/spf13/cobra"
+)
+
+const (
+	reportOutputText = "text"
+	reportOutputJSON = "json"
+)
+
+type reportOptions struct {
+	reportPaths []string
+	key         string
+	output      string
+}
+
+type reportOutput struct {
+	FilesUploaded       uint32 `json:"files_uploaded"`
+	FilesProcessed      uint32 `json:"files_processed"`
+	TestsReported       uint32 `json:"tests_reported"`
+	DuplicateInvocation bool   `json:"duplicate_invocation"`
+	FilesSkipped        uint32 `json:"files_skipped"`
+}
+
+func newCmdTestsReport() *cobra.Command {
+	opts := reportOptions{output: reportOutputText}
+
+	cmd := &cobra.Command{
+		Use:          "report [path ...]",
+		Short:        "Upload JUnit XML test reports",
+		SilenceUsage: true,
+		Long:         "Upload JUnit XML test reports for the authenticated CI execution.",
+		Example: `  depot tests report reports/junit.xml
+  depot tests report --report-path "reports/*.xml"
+  depot tests report --report-path reports/junit.xml --key go-test --output json`,
+		Args: cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.reportPaths = append(opts.reportPaths, args...)
+			return runTestsReport(cmd, opts)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringArrayVar(&opts.reportPaths, "report-path", nil, "JUnit XML report path, directory, or glob; repeatable")
+	flags.StringVar(&opts.key, "key", "", "Test key")
+	flags.StringVar(&opts.output, "output", reportOutputText, "Output format (text, json)")
+
+	return cmd
+}
+
+func runTestsReport(cmd *cobra.Command, opts reportOptions) error {
+	opts.reportPaths = splitReportPathInputs(opts.reportPaths)
+	if len(opts.reportPaths) == 0 {
+		return fmt.Errorf("at least one report path is required; pass --report-path or one or more positional paths")
+	}
+
+	output, err := resolveReportOutput(opts.output)
+	if err != nil {
+		return err
+	}
+
+	filesUploaded, resp, err := uploadTestReportsResponse(cmd, opts)
+	if err != nil {
+		return err
+	}
+
+	if output == reportOutputJSON {
+		return writeReportJSON(cmd.OutOrStdout(), filesUploaded, resp)
+	}
+	return writeReportSummary(cmd.OutOrStdout(), filesUploaded, resp)
+}
+
+func resolveReportOutput(value string) (string, error) {
+	switch value {
+	case "", reportOutputText:
+		return reportOutputText, nil
+	case reportOutputJSON:
+		return value, nil
+	default:
+		return "", fmt.Errorf("unknown output format: %s. Requires text or json", value)
+	}
+}
+
+func writeReportSummary(w io.Writer, filesUploaded int, resp *testresultsv1.ReportTestResultsResponse) error {
+	if _, err := fmt.Fprintf(
+		w,
+		"Depot uploaded %d test report file(s), processed %d file(s), reported %d test(s), and skipped %d file(s).\n",
+		filesUploaded,
+		resp.GetFilesProcessed(),
+		resp.GetTestsReported(),
+		resp.GetFilesSkipped(),
+	); err != nil {
+		return err
+	}
+	if resp.GetDuplicateInvocation() {
+		_, err := fmt.Fprintln(w, "Depot ignored this upload because this invocation was already reported.")
+		return err
+	}
+	return nil
+}
+
+func writeReportJSON(w io.Writer, filesUploaded int, resp *testresultsv1.ReportTestResultsResponse) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(reportOutput{
+		FilesUploaded:       uint32(filesUploaded),
+		FilesProcessed:      resp.GetFilesProcessed(),
+		TestsReported:       resp.GetTestsReported(),
+		DuplicateInvocation: resp.GetDuplicateInvocation(),
+		FilesSkipped:        resp.GetFilesSkipped(),
+	})
+}

--- a/pkg/cmd/tests/report_cmd_test.go
+++ b/pkg/cmd/tests/report_cmd_test.go
@@ -1,0 +1,292 @@
+package tests
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+
+	civ1 "github.com/depot/cli/pkg/proto/depot/ci/v1"
+	testresultsv1 "github.com/depot/cli/pkg/proto/depot/testresults/v1"
+)
+
+func TestReportUploadsReportsWithKey(t *testing.T) {
+	resetTestHooks(t)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeTempFileAt(t, workspace, "reports/junit.xml", "<testsuite><testcase name=\"a\"/></testsuite>")
+	resolveOIDCCredentialFunc = func(context.Context) (string, error) { return "oidc-token", nil }
+	splitTestsFunc = func(context.Context, string, *testresultsv1.SplitTestsRequest) (*testresultsv1.SplitTestsResponse, error) {
+		t.Fatal("report should not split tests")
+		return nil, nil
+	}
+
+	var reportReq *testresultsv1.ReportTestResultsRequest
+	reportTestResultsFunc = func(ctx context.Context, token string, req *testresultsv1.ReportTestResultsRequest) (*testresultsv1.ReportTestResultsResponse, error) {
+		requireContextDeadline(t, ctx, "report test results")
+		if token != "oidc-token" {
+			t.Fatalf("expected OIDC token, got %q", token)
+		}
+		reportReq = req
+		return &testresultsv1.ReportTestResultsResponse{FilesProcessed: 1, TestsReported: 1}, nil
+	}
+
+	stdout, stderr, err := executeCommandWithInputOutput(
+		"",
+		"report",
+		"--report-path", "reports/junit.xml",
+		"--key", "unit",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if stderr != "" {
+		t.Fatalf("expected no stderr output, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "uploaded 1 test report file") || !strings.Contains(stdout, "reported 1 test") {
+		t.Fatalf("expected report summary, got %q", stdout)
+	}
+	if reportReq.GetInvocationId() != "unit" {
+		t.Fatalf("expected report invocation key unit, got %q", reportReq.GetInvocationId())
+	}
+	if len(reportReq.GetFiles()) != 1 || reportReq.GetFiles()[0].GetFilename() != "reports/junit.xml" {
+		t.Fatalf("expected prepared junit report, got %#v", reportReq.GetFiles())
+	}
+	if contents := gunzipTestReport(t, reportReq.GetFiles()[0].GetGzippedXml()); !strings.Contains(contents, "<testcase name=\"a\"/>") {
+		t.Fatalf("expected gzipped report contents, got %q", contents)
+	}
+}
+
+func TestReportUsesDefaultTestKey(t *testing.T) {
+	resetTestHooks(t)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	t.Setenv("GITHUB_ACTION", "unit-tests")
+	writeTempFileAt(t, workspace, "reports/junit.xml", "<testsuite/>")
+
+	var invocationID string
+	reportTestResultsFunc = func(_ context.Context, _ string, req *testresultsv1.ReportTestResultsRequest) (*testresultsv1.ReportTestResultsResponse, error) {
+		invocationID = req.GetInvocationId()
+		return &testresultsv1.ReportTestResultsResponse{FilesProcessed: 1}, nil
+	}
+
+	_, _, err := executeCommandWithInputOutput("", "report", "--report-path", "reports/junit.xml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if invocationID != "unit-tests" {
+		t.Fatalf("expected report to reuse default test key, got %q", invocationID)
+	}
+}
+
+func TestReportUsesGitHubWorkspace(t *testing.T) {
+	resetTestHooks(t)
+	workspace := t.TempDir()
+	other := t.TempDir()
+	t.Chdir(other)
+	t.Setenv("GITHUB_WORKSPACE", workspace)
+	writeTempFileAt(t, workspace, "reports/junit.xml", "<testsuite/>")
+
+	var filenames []string
+	reportTestResultsFunc = func(_ context.Context, _ string, req *testresultsv1.ReportTestResultsRequest) (*testresultsv1.ReportTestResultsResponse, error) {
+		for _, file := range req.GetFiles() {
+			filenames = append(filenames, file.GetFilename())
+		}
+		return &testresultsv1.ReportTestResultsResponse{FilesProcessed: uint32(len(req.GetFiles()))}, nil
+	}
+
+	_, _, err := executeCommandWithInputOutput("", "report", "--report-path", "reports/junit.xml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !equalStrings(filenames, []string{"reports/junit.xml"}) {
+		t.Fatalf("expected report path to resolve against GITHUB_WORKSPACE, got %v", filenames)
+	}
+}
+
+func TestReportSupportsJSONOutput(t *testing.T) {
+	resetTestHooks(t)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeTempFileAt(t, workspace, "reports/junit.xml", "<testsuite/>")
+	reportTestResultsFunc = func(context.Context, string, *testresultsv1.ReportTestResultsRequest) (*testresultsv1.ReportTestResultsResponse, error) {
+		return &testresultsv1.ReportTestResultsResponse{
+			FilesProcessed:      1,
+			TestsReported:       2,
+			DuplicateInvocation: true,
+			FilesSkipped:        3,
+		}, nil
+	}
+
+	stdout, stderr, err := executeCommandWithInputOutput(
+		"",
+		"report",
+		"--report-path", "reports/junit.xml",
+		"--output", "json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stderr != "" {
+		t.Fatalf("expected no stderr output, got %q", stderr)
+	}
+
+	var out reportOutput
+	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
+		t.Fatalf("expected valid json, got %q: %v", stdout, err)
+	}
+	if out.FilesUploaded != 1 || out.FilesProcessed != 1 || out.TestsReported != 2 || !out.DuplicateInvocation || out.FilesSkipped != 3 {
+		t.Fatalf("expected report counts in json, got %#v", out)
+	}
+}
+
+func TestReportTextOutputMentionsDuplicateInvocation(t *testing.T) {
+	resetTestHooks(t)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeTempFileAt(t, workspace, "reports/junit.xml", "<testsuite/>")
+	reportTestResultsFunc = func(context.Context, string, *testresultsv1.ReportTestResultsRequest) (*testresultsv1.ReportTestResultsResponse, error) {
+		return &testresultsv1.ReportTestResultsResponse{DuplicateInvocation: true}, nil
+	}
+
+	stdout, _, err := executeCommandWithInputOutput("", "report", "--report-path", "reports/junit.xml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, "already reported") {
+		t.Fatalf("expected duplicate invocation summary, got %q", stdout)
+	}
+}
+
+func TestReportAcceptsRepeatedReportPathsAndPositionalPaths(t *testing.T) {
+	resetTestHooks(t)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeTempFileAt(t, workspace, "reports/a.xml", "<testsuite/>")
+	writeTempFileAt(t, workspace, "reports/b.xml", "<testsuite/>")
+
+	var filenames []string
+	reportTestResultsFunc = func(_ context.Context, _ string, req *testresultsv1.ReportTestResultsRequest) (*testresultsv1.ReportTestResultsResponse, error) {
+		for _, file := range req.GetFiles() {
+			filenames = append(filenames, file.GetFilename())
+		}
+		return &testresultsv1.ReportTestResultsResponse{FilesProcessed: uint32(len(req.GetFiles()))}, nil
+	}
+
+	_, _, err := executeCommandWithInputOutput(
+		"",
+		"report",
+		"--report-path", "reports/a.xml",
+		"reports/b.xml",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !equalStrings(filenames, []string{"reports/a.xml", "reports/b.xml"}) {
+		t.Fatalf("expected uploaded filenames to preserve discovered sorted paths, got %v", filenames)
+	}
+}
+
+func TestReportAcceptsMultilineReportPath(t *testing.T) {
+	resetTestHooks(t)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeTempFileAt(t, workspace, "reports/a.xml", "<testsuite/>")
+	writeTempFileAt(t, workspace, "reports/b.xml", "<testsuite/>")
+
+	var filenames []string
+	reportTestResultsFunc = func(_ context.Context, _ string, req *testresultsv1.ReportTestResultsRequest) (*testresultsv1.ReportTestResultsResponse, error) {
+		for _, file := range req.GetFiles() {
+			filenames = append(filenames, file.GetFilename())
+		}
+		return &testresultsv1.ReportTestResultsResponse{FilesProcessed: uint32(len(req.GetFiles()))}, nil
+	}
+
+	_, _, err := executeCommandWithInputOutput(
+		"",
+		"report",
+		"--report-path", "reports/a.xml\nreports/b.xml",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !equalStrings(filenames, []string{"reports/a.xml", "reports/b.xml"}) {
+		t.Fatalf("expected multiline report path to upload both files, got %v", filenames)
+	}
+}
+
+func TestReportRequiresReportPath(t *testing.T) {
+	resetTestHooks(t)
+	reportTestResultsFunc = func(context.Context, string, *testresultsv1.ReportTestResultsRequest) (*testresultsv1.ReportTestResultsResponse, error) {
+		t.Fatal("report should validate before uploading")
+		return nil, nil
+	}
+
+	_, _, err := executeCommandOutput("report")
+	if err == nil || !strings.Contains(err.Error(), "at least one report path is required") {
+		t.Fatalf("expected report path validation error, got %v", err)
+	}
+}
+
+func TestReportRejectsUnknownOutput(t *testing.T) {
+	resetTestHooks(t)
+	reportTestResultsFunc = func(context.Context, string, *testresultsv1.ReportTestResultsRequest) (*testresultsv1.ReportTestResultsResponse, error) {
+		t.Fatal("report should validate output before uploading")
+		return nil, nil
+	}
+
+	_, _, err := executeCommandOutput("report", "--report-path", "reports/junit.xml", "--output", "auto")
+	if err == nil || !strings.Contains(err.Error(), "Requires text or json") {
+		t.Fatalf("expected output validation error, got %v", err)
+	}
+}
+
+func TestReportSubcommandTakesPrecedenceOverResultID(t *testing.T) {
+	resetTestHooks(t)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeTempFileAt(t, workspace, "reports/junit.xml", "<testsuite/>")
+	ciGetRunStatusFunc = func(context.Context, string, string, string) (*civ1.GetRunStatusResponse, error) {
+		t.Fatal("parent tests command should not try to resolve report as an ID")
+		return nil, nil
+	}
+	listTestResultsFunc = func(context.Context, string, string, *testresultsv1.ListTestResultsRequest) (*testresultsv1.ListTestResultsResponse, error) {
+		t.Fatal("parent tests command should not list test results")
+		return nil, nil
+	}
+	reportTestResultsFunc = func(context.Context, string, *testresultsv1.ReportTestResultsRequest) (*testresultsv1.ReportTestResultsResponse, error) {
+		return &testresultsv1.ReportTestResultsResponse{FilesProcessed: 1}, nil
+	}
+
+	stdout, _, err := executeCommandWithInputOutput(
+		"",
+		"report",
+		"--report-path", "reports/junit.xml",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, "uploaded 1 test report file") {
+		t.Fatalf("expected report subcommand output, got %q", stdout)
+	}
+}
+
+func gunzipTestReport(t *testing.T, contents []byte) string {
+	t.Helper()
+
+	reader, err := gzip.NewReader(bytes.NewReader(contents))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+
+	out, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(out)
+}

--- a/pkg/cmd/tests/report_test.go
+++ b/pkg/cmd/tests/report_test.go
@@ -1,0 +1,395 @@
+package tests
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDiscoverReportFilesFindsExplicitXMLFiles(t *testing.T) {
+	workspace := t.TempDir()
+	writeTempFileAt(t, workspace, "reports/b.xml", "<testsuite/>")
+	writeTempFileAt(t, workspace, "reports/a.xml", "<testsuite/>")
+
+	files, err := discoverReportFiles([]string{"reports/b.xml", "reports/a.xml"}, workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(files) != 2 {
+		t.Fatalf("expected 2 files, got %d", len(files))
+	}
+	if files[0].filename != "reports/a.xml" || files[1].filename != "reports/b.xml" {
+		t.Fatalf("expected sorted relative filenames, got %q and %q", files[0].filename, files[1].filename)
+	}
+}
+
+func TestDiscoverReportFilesExpandsDirectoryToXMLFiles(t *testing.T) {
+	workspace := t.TempDir()
+	writeTempFileAt(t, workspace, "reports/a.xml", "<testsuite/>")
+	writeTempFileAt(t, workspace, "reports/nested/b.xml", "<testsuite/>")
+	writeTempFileAt(t, workspace, "reports/notes.txt", "ignore")
+
+	files, err := discoverReportFiles([]string{"reports"}, workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := filenames(files)
+	want := []string{"reports/a.xml", "reports/nested/b.xml"}
+	if !equalStrings(got, want) {
+		t.Fatalf("expected files %v, got %v", want, got)
+	}
+}
+
+func TestDiscoverReportFilesSupportsRecursiveGlobBelowWorkspace(t *testing.T) {
+	workspace := t.TempDir()
+	writeTempFileAt(t, workspace, "reports/a.xml", "<testsuite/>")
+	writeTempFileAt(t, workspace, "reports/nested/b.xml", "<testsuite/>")
+
+	files, err := discoverReportFiles([]string{"reports/**/*.xml"}, workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := filenames(files)
+	want := []string{"reports/a.xml", "reports/nested/b.xml"}
+	if !equalStrings(got, want) {
+		t.Fatalf("expected files %v, got %v", want, got)
+	}
+}
+
+func TestDiscoverReportFilesDeduplicatesMatches(t *testing.T) {
+	workspace := t.TempDir()
+	writeTempFileAt(t, workspace, "reports/a.xml", "<testsuite/>")
+
+	files, err := discoverReportFiles([]string{"reports/a.xml", "reports/*.xml"}, workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := filenames(files); !equalStrings(got, []string{"reports/a.xml"}) {
+		t.Fatalf("expected deduplicated file list, got %v", got)
+	}
+}
+
+func TestDiscoverReportFilesRejectsUnsafePaths(t *testing.T) {
+	workspace := t.TempDir()
+	outside := writeTempFile(t, "outside.xml", "<testsuite/>")
+
+	_, err := discoverReportFiles([]string{outside}, workspace)
+	if err == nil || !strings.Contains(err.Error(), "outside the workspace") {
+		t.Fatalf("expected outside workspace error, got %v", err)
+	}
+
+	_, err = discoverReportFiles([]string{"**/*.xml"}, workspace)
+	if err == nil || !strings.Contains(err.Error(), "too broad") {
+		t.Fatalf("expected broad glob error, got %v", err)
+	}
+
+	_, err = discoverReportFiles([]string{"{**/*.xml,reports/*.xml}"}, workspace)
+	if err == nil || !strings.Contains(err.Error(), "too broad") {
+		t.Fatalf("expected broad brace glob error, got %v", err)
+	}
+
+	_, err = discoverReportFiles([]string{"."}, workspace)
+	if err == nil || !strings.Contains(err.Error(), "too broad") {
+		t.Fatalf("expected broad directory error, got %v", err)
+	}
+}
+
+func TestDiscoverReportFilesRejectsNonXMLAndFollowsSafeFileSymlink(t *testing.T) {
+	workspace := t.TempDir()
+	writeTempFileAt(t, workspace, "reports/out.txt", "not xml")
+
+	_, err := discoverReportFiles([]string{"reports/out.txt"}, workspace)
+	if err == nil || !strings.Contains(err.Error(), ".xml extension") {
+		t.Fatalf("expected non-XML error, got %v", err)
+	}
+
+	target := writeTempFileAt(t, workspace, "reports/target.xml", "<testsuite/>")
+	link := filepath.Join(workspace, "reports/link.xml")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	files, err := discoverReportFiles([]string{"reports/link.xml"}, workspace)
+	if err != nil {
+		t.Fatalf("expected safe file symlink to be accepted, got %v", err)
+	}
+	if got := filenames(files); !equalStrings(got, []string{"reports/target.xml"}) {
+		t.Fatalf("expected symlink to resolve to real workspace file, got %v", got)
+	}
+}
+
+func TestDiscoverReportFilesFollowsSafeFileSymlinkFromDirectory(t *testing.T) {
+	workspace := t.TempDir()
+	target := writeTempFileAt(t, workspace, "real/junit.xml", "<testsuite/>")
+	if err := os.MkdirAll(filepath.Join(workspace, "reports"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(workspace, "reports/link.xml")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	files, err := discoverReportFiles([]string{"reports"}, workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := filenames(files); !equalStrings(got, []string{"real/junit.xml"}) {
+		t.Fatalf("expected directory discovery to include safe symlinked file, got %v", got)
+	}
+}
+
+func TestDiscoverReportFilesFollowsSafeFileSymlinkFromRecursiveGlob(t *testing.T) {
+	workspace := t.TempDir()
+	target := writeTempFileAt(t, workspace, "real/junit.xml", "<testsuite/>")
+	if err := os.MkdirAll(filepath.Join(workspace, "reports/nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(workspace, "reports/nested/link.xml")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	files, err := discoverReportFiles([]string{"reports/**/*.xml"}, workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := filenames(files); !equalStrings(got, []string{"real/junit.xml"}) {
+		t.Fatalf("expected recursive glob discovery to include safe symlinked file, got %v", got)
+	}
+}
+
+func TestDiscoverReportFilesFollowsSafeDirectorySymlinkFromRecursiveGlob(t *testing.T) {
+	workspace := t.TempDir()
+	writeTempFileAt(t, workspace, "real/nested/junit.xml", "<testsuite/>")
+	link := filepath.Join(workspace, "reports")
+	if err := os.Symlink(filepath.Join(workspace, "real"), link); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	files, err := discoverReportFiles([]string{"reports/**/*.xml"}, workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := filenames(files); !equalStrings(got, []string{"real/nested/junit.xml"}) {
+		t.Fatalf("expected recursive glob discovery through safe symlinked directory, got %v", got)
+	}
+}
+
+func TestDiscoverReportFilesRejectsFileSymlinkOutsideWorkspace(t *testing.T) {
+	workspace := t.TempDir()
+	outside := t.TempDir()
+	target := writeTempFileAt(t, outside, "target.xml", "<testsuite/>")
+	if err := os.MkdirAll(filepath.Join(workspace, "reports"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(workspace, "reports/link.xml")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	_, err := discoverReportFiles([]string{"reports/link.xml"}, workspace)
+	if err == nil || !strings.Contains(err.Error(), "outside the workspace") {
+		t.Fatalf("expected symlink outside workspace error, got %v", err)
+	}
+}
+
+func TestDiscoverReportFilesRejectsSymlinkDirectoryOutsideWorkspace(t *testing.T) {
+	workspace := t.TempDir()
+	outside := t.TempDir()
+	writeTempFileAt(t, outside, "junit.xml", "<testsuite/>")
+	link := filepath.Join(workspace, "reports")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	_, err := discoverReportFiles([]string{"reports"}, workspace)
+	if err == nil || !strings.Contains(err.Error(), "outside the workspace") {
+		t.Fatalf("expected symlink directory outside workspace error, got %v", err)
+	}
+}
+
+func TestDiscoverReportFilesRejectsRecursiveGlobThroughSymlinkDirectoryOutsideWorkspace(t *testing.T) {
+	workspace := t.TempDir()
+	outside := t.TempDir()
+	writeTempFileAt(t, outside, "nested/junit.xml", "<testsuite/>")
+	link := filepath.Join(workspace, "reports")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	_, err := discoverReportFiles([]string{"reports/**/*.xml"}, workspace)
+	if err == nil || !strings.Contains(err.Error(), "outside the workspace") {
+		t.Fatalf("expected symlink directory outside workspace error, got %v", err)
+	}
+}
+
+func TestDiscoverReportFilesEnforcesCountLimitDuringDirectoryWalk(t *testing.T) {
+	workspace := t.TempDir()
+	for i := 0; i <= maxReportFiles; i++ {
+		writeTempFileAt(t, workspace, filepath.Join("reports", fmt.Sprintf("%04d.xml", i)), "<testsuite/>")
+	}
+
+	_, err := discoverReportFiles([]string{"reports"}, workspace)
+	if err == nil || !strings.Contains(err.Error(), "matched more than") {
+		t.Fatalf("expected discovery count limit error, got %v", err)
+	}
+}
+
+func TestPrepareReportFilesGzipsXML(t *testing.T) {
+	workspace := t.TempDir()
+	writeTempFileAt(t, workspace, "reports/a.xml", "<testsuite><testcase name=\"a\"/></testsuite>")
+	files, err := discoverReportFiles([]string{"reports/a.xml"}, workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prepared, err := prepareReportFiles(files)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(prepared) != 1 {
+		t.Fatalf("expected 1 prepared file, got %d", len(prepared))
+	}
+	if prepared[0].GetFilename() != "reports/a.xml" {
+		t.Fatalf("expected filename reports/a.xml, got %q", prepared[0].GetFilename())
+	}
+
+	reader, err := gzip.NewReader(bytes.NewReader(prepared[0].GetGzippedXml()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+	contents, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(contents), "<testcase name=\"a\"/>") {
+		t.Fatalf("expected gzipped XML contents, got %q", string(contents))
+	}
+}
+
+func TestPrepareReportFilesRejectsChangedFile(t *testing.T) {
+	workspace := t.TempDir()
+	reportPath := writeTempFileAt(t, workspace, "reports/a.xml", "<testsuite/>")
+	files, err := discoverReportFiles([]string{"reports/a.xml"}, workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Remove(reportPath); err != nil {
+		t.Fatal(err)
+	}
+	writeTempFileAt(t, workspace, "reports/a.xml", "<testsuite><testcase name=\"new\"/></testsuite>")
+
+	_, err = prepareReportFiles(files)
+	if err == nil || !strings.Contains(err.Error(), "changed after discovery") {
+		t.Fatalf("expected changed file error, got %v", err)
+	}
+}
+
+func TestPrepareReportFilesRejectsPathSwapBeforeRead(t *testing.T) {
+	workspace := t.TempDir()
+	outside := t.TempDir()
+	reportPath := writeTempFileAt(t, workspace, "reports/a.xml", "<testsuite/>")
+	outsidePath := writeTempFileAt(t, outside, "outside.xml", "<testsuite><testcase name=\"secret\"/></testsuite>")
+	files, err := discoverReportFiles([]string{"reports/a.xml"}, workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Remove(reportPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outsidePath, reportPath); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	_, err = prepareReportFiles(files)
+	if err == nil || !strings.Contains(err.Error(), "changed after discovery") {
+		t.Fatalf("expected path swap after discovery to be rejected, got %v", err)
+	}
+}
+
+func TestPrepareReportFilesRejectsOversizedFile(t *testing.T) {
+	workspace := t.TempDir()
+	reportPath := writeTempFileAt(t, workspace, "reports/a.xml", "")
+	if err := os.Truncate(reportPath, maxReportFileBytes+1); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Lstat(reportPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	realPath, err := filepath.EvalSymlinks(reportPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = prepareReportFiles([]discoveredReportFile{
+		{
+			absolutePath: reportPath,
+			realPath:     realPath,
+			filename:     "reports/a.xml",
+			info:         info,
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "per-file limit") {
+		t.Fatalf("expected per-file limit error, got %v", err)
+	}
+}
+
+func TestPrepareReportFilesRejectsAggregateSizeLimit(t *testing.T) {
+	workspace := t.TempDir()
+	for _, name := range []string{"reports/a.xml", "reports/b.xml", "reports/c.xml"} {
+		reportPath := writeTempFileAt(t, workspace, name, "")
+		if err := os.Truncate(reportPath, 40*1024*1024); err != nil {
+			t.Fatal(err)
+		}
+	}
+	files, err := discoverReportFiles([]string{"reports"}, workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = prepareReportFiles(files)
+	if err == nil || !strings.Contains(err.Error(), "total uncompressed size limit") {
+		t.Fatalf("expected aggregate size limit error, got %v", err)
+	}
+}
+
+func TestPrepareReportFilesRejectsTooManyFiles(t *testing.T) {
+	files := make([]discoveredReportFile, maxReportFiles+1)
+	_, err := prepareReportFiles(files)
+	if err == nil || !strings.Contains(err.Error(), "matched more than") {
+		t.Fatalf("expected too many files error, got %v", err)
+	}
+}
+
+func writeTempFileAt(t *testing.T, root, name, contents string) string {
+	t.Helper()
+
+	path := filepath.Join(root, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func filenames(files []discoveredReportFile) []string {
+	names := make([]string, 0, len(files))
+	for _, file := range files {
+		names = append(names, file.filename)
+	}
+	return names
+}

--- a/pkg/cmd/tests/report_test.go
+++ b/pkg/cmd/tests/report_test.go
@@ -77,6 +77,20 @@ func TestDiscoverReportFilesDeduplicatesMatches(t *testing.T) {
 	}
 }
 
+func TestDiscoverReportFilesIgnoresNonXMLGlobMatches(t *testing.T) {
+	workspace := t.TempDir()
+	writeTempFileAt(t, workspace, "reports/a.xml", "<testsuite/>")
+	writeTempFileAt(t, workspace, "reports/notes.txt", "ignore")
+
+	files, err := discoverReportFiles([]string{"reports/*"}, workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := filenames(files); !equalStrings(got, []string{"reports/a.xml"}) {
+		t.Fatalf("expected broad glob to include only XML report files, got %v", got)
+	}
+}
+
 func TestDiscoverReportFilesDoesNotClimbMissingPathSegments(t *testing.T) {
 	workspace := t.TempDir()
 	writeTempFileAt(t, workspace, "junit.xml", "<testsuite/>")

--- a/pkg/cmd/tests/report_test.go
+++ b/pkg/cmd/tests/report_test.go
@@ -77,6 +77,53 @@ func TestDiscoverReportFilesDeduplicatesMatches(t *testing.T) {
 	}
 }
 
+func TestDiscoverReportFilesDoesNotClimbMissingPathSegments(t *testing.T) {
+	workspace := t.TempDir()
+	writeTempFileAt(t, workspace, "junit.xml", "<testsuite/>")
+	writeTempFileAt(t, workspace, "reports/junit.xml", "<testsuite/>")
+
+	files, err := discoverReportFiles([]string{"missing/junit.xml"}, workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("expected missing literal path to match no files, got %v", filenames(files))
+	}
+
+	files, err = discoverReportFiles([]string{"missing/**/*.xml"}, workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("expected missing recursive glob path to match no files, got %v", filenames(files))
+	}
+}
+
+func TestDiscoverReportFilesPreservesMissingSegmentsAfterSymlinkRoot(t *testing.T) {
+	workspace := t.TempDir()
+	writeTempFileAt(t, workspace, "real/junit.xml", "<testsuite/>")
+	link := filepath.Join(workspace, "reports")
+	if err := os.Symlink(filepath.Join(workspace, "real"), link); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	files, err := discoverReportFiles([]string{"reports/missing/junit.xml"}, workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("expected missing symlink-root literal path to match no files, got %v", filenames(files))
+	}
+
+	files, err = discoverReportFiles([]string{"reports/missing/**/*.xml"}, workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("expected missing symlink-root recursive glob path to match no files, got %v", filenames(files))
+	}
+}
+
 func TestDiscoverReportFilesRejectsUnsafePaths(t *testing.T) {
 	workspace := t.TempDir()
 	outside := writeTempFile(t, "outside.xml", "<testsuite/>")

--- a/pkg/cmd/tests/selection.go
+++ b/pkg/cmd/tests/selection.go
@@ -15,6 +15,7 @@ import (
 
 var (
 	splitTestsFunc            = api.SplitTests
+	reportTestResultsFunc     = api.ReportTestResults
 	resolveOIDCCredentialFunc = resolveOIDCCredential
 )
 

--- a/pkg/cmd/tests/split.go
+++ b/pkg/cmd/tests/split.go
@@ -62,7 +62,7 @@ splitting.`,
 	flags.StringVar(&opts.timingsType, "timings-type", "", "JUnit timing identity (filename, classname, testname)")
 	flags.IntVar(&opts.index, "index", -1, "Zero-based shard index")
 	flags.IntVar(&opts.total, "total", 0, "Total number of shards")
-	flags.StringVar(&opts.key, "key", "", "Test split key")
+	flags.StringVar(&opts.key, "key", "", "Test key")
 	flags.StringVar(&opts.candidatesFile, "candidates-file", "", "Path to newline-delimited runnable test candidates instead of stdin")
 	flags.StringVar(&opts.output, "output", splitOutputText, "Output format (text, json)")
 

--- a/pkg/cmd/tests/tests.go
+++ b/pkg/cmd/tests/tests.go
@@ -96,6 +96,7 @@ Actions job ID.`,
 	flags.StringVar(&opts.pageToken, "page-token", "", "Token to fetch the next page")
 	flags.StringVar(&opts.output, "output", "auto", "Output format (auto, table, json)")
 
+	cmd.AddCommand(newCmdTestsReport())
 	cmd.AddCommand(newCmdTestsSplit())
 
 	return cmd

--- a/pkg/cmd/tests/tests_test.go
+++ b/pkg/cmd/tests/tests_test.go
@@ -491,6 +491,7 @@ func requireContextDeadline(t *testing.T, ctx context.Context, name string) {
 
 func resetTestHooks(t *testing.T) {
 	t.Helper()
+	t.Setenv("GITHUB_WORKSPACE", "")
 
 	resolveOrgAuthFunc = func(context.Context, string) (string, error) {
 		return "token-1", nil

--- a/pkg/cmd/tests/tests_test.go
+++ b/pkg/cmd/tests/tests_test.go
@@ -504,6 +504,9 @@ func resetTestHooks(t *testing.T) {
 	listTestResultsFunc = func(context.Context, string, string, *testresultsv1.ListTestResultsRequest) (*testresultsv1.ListTestResultsResponse, error) {
 		return &testresultsv1.ListTestResultsResponse{}, nil
 	}
+	reportTestResultsFunc = func(context.Context, string, *testresultsv1.ReportTestResultsRequest) (*testresultsv1.ReportTestResultsResponse, error) {
+		return &testresultsv1.ReportTestResultsResponse{}, nil
+	}
 	ciGetRunStatusFunc = func(context.Context, string, string, string) (*civ1.GetRunStatusResponse, error) {
 		return nil, errors.New("not found")
 	}
@@ -530,6 +533,7 @@ func resetTestHooks(t *testing.T) {
 		resolveStaticAuthFunc = staticResolveOrgAuth
 		currentOrgFunc = configCurrentOrg
 		listTestResultsFunc = apiListTestResults
+		reportTestResultsFunc = apiReportTestResults
 		ciGetRunStatusFunc = apiCIGetRunStatus
 		splitTestsFunc = apiSplitTests
 		resolveOIDCCredentialFunc = testsResolveOIDCCredential
@@ -556,6 +560,7 @@ var (
 	staticResolveOrgAuth       = resolveStaticAuthFunc
 	configCurrentOrg           = currentOrgFunc
 	apiListTestResults         = listTestResultsFunc
+	apiReportTestResults       = reportTestResultsFunc
 	apiCIGetRunStatus          = ciGetRunStatusFunc
 	apiSplitTests              = splitTestsFunc
 	testsResolveOIDCCredential = resolveOIDCCredentialFunc


### PR DESCRIPTION
## Summary
- add standalone `depot tests report` to upload gzipped JUnit XML files with the existing OIDC flow
- discover report files from explicit paths, directories, and globs while keeping matches inside the workspace
- add `github.com/bmatcuk/doublestar/v4` for recursive glob handling that matches the action behavior

## Stack
- `depot tests split`: https://github.com/depot/cli/pull/528 
- `depot tests report`: https://github.com/depot/cli/pull/530 <- you are here
- `depot tests run`: https://github.com/depot/cli/pull/534



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new filesystem and upload surface (globs, symlinks, stale-report filtering) plus OIDC-backed report RPC; standalone exit-code behavior changes affect all CLI errors.
> 
> **Overview**
> Adds **`depot tests report`** to discover JUnit XML under the CI workspace (`GITHUB_WORKSPACE` or cwd), gzip payloads, and upload them via a new **`ReportTestResults`** API client using the existing OIDC credential (no org header). Paths accept positional args, repeatable **`--report-path`**, directories, and recursive globs via **`doublestar`**, with workspace-only matching, `.xml` enforcement, size/count caps, and symlink-safe discovery.
> 
> The same PR also wires **`depot tests run`** (shard selection, shell execution, post-run upload with “only files updated since baseline” filtering), refactors candidate loading into **`loadRequiredCandidates`**, and aligns standalone **`main`** with Docker-style **`cli.StatusError`** handling (**`SilenceErrors`**, preserved exit codes, tests via injectable **`newRootCmd`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca75367e6066019aebf7c6838bd86e271ea051b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->