### PR TITLE
Add depot tests run command

### DIFF
--- a/cmd/depot/main.go
+++ b/cmd/depot/main.go
@@ -26,6 +26,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+var newRootCmd = root.NewCmdRoot
+
 func main() {
 	// Explicitly set the Docker API version to 1.44 to avoid the Docker daemon breaking change.
 	if os.Getenv("DOCKER_API_VERSION") == "" {
@@ -100,9 +102,20 @@ func runMain() int {
 	}()
 
 	if plugin.RunningStandalone() {
-		rootCmd := root.NewCmdRoot(buildVersion, buildDate)
+		rootCmd := newRootCmd(buildVersion, buildDate)
+		rootCmd.SilenceErrors = true
 
 		if err := rootCmd.Execute(); err != nil {
+			if sterr, ok := err.(cli.StatusError); ok {
+				if sterr.Status != "" {
+					fmt.Fprintln(os.Stderr, sterr.Status)
+				}
+				if sterr.StatusCode == 0 {
+					return 1
+				}
+				return sterr.StatusCode
+			}
+			fmt.Fprintln(os.Stderr, err)
 			return 1
 		}
 	} else {
@@ -112,7 +125,8 @@ func runMain() int {
 			return 1
 		}
 
-		rootCmd := root.NewCmdRoot(buildVersion, buildDate)
+		rootCmd := newRootCmd(buildVersion, buildDate)
+		rootCmd.SilenceErrors = true
 
 		err = plugin.RunPlugin(cmd, rootCmd, manager.Metadata{
 			SchemaVersion: "0.1.0",
@@ -127,7 +141,7 @@ func runMain() int {
 					fmt.Fprintln(cmd.Err(), sterr.Status)
 				}
 				// StatusError should only be used for errors, and all errors should
-				// have a non-zero exit status, so never exit with 0
+				// have a non-zero exit status, so never exit with 0.
 				if sterr.StatusCode == 0 {
 					return 1
 				}

--- a/cmd/depot/main_test.go
+++ b/cmd/depot/main_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/docker/cli/cli"
+	"github.com/spf13/cobra"
+)
+
+func TestRunMainStandalonePreservesStatusErrorExitCode(t *testing.T) {
+	t.Setenv("DEPOT_ERROR_TELEMETRY", "0")
+	t.Setenv("DEPOT_NO_UPDATE_NOTIFIER", "1")
+
+	originalArgs := os.Args
+	t.Cleanup(func() { os.Args = originalArgs })
+	os.Args = []string{"depot"}
+
+	originalNewRootCmd := newRootCmd
+	t.Cleanup(func() { newRootCmd = originalNewRootCmd })
+	newRootCmd = func(string, string) *cobra.Command {
+		return &cobra.Command{
+			Use: "depot",
+			RunE: func(*cobra.Command, []string) error {
+				return cli.StatusError{StatusCode: 7}
+			},
+		}
+	}
+
+	if code := runMain(); code != 7 {
+		t.Fatalf("expected status code 7, got %d", code)
+	}
+}
+
+func TestRunMainStandaloneStatusErrorNeverReturnsZero(t *testing.T) {
+	t.Setenv("DEPOT_ERROR_TELEMETRY", "0")
+	t.Setenv("DEPOT_NO_UPDATE_NOTIFIER", "1")
+
+	originalArgs := os.Args
+	t.Cleanup(func() { os.Args = originalArgs })
+	os.Args = []string{"depot"}
+
+	originalNewRootCmd := newRootCmd
+	t.Cleanup(func() { newRootCmd = originalNewRootCmd })
+	newRootCmd = func(string, string) *cobra.Command {
+		return &cobra.Command{
+			Use: "depot",
+			RunE: func(*cobra.Command, []string) error {
+				return cli.StatusError{StatusCode: 0}
+			},
+		}
+	}
+
+	if code := runMain(); code != 1 {
+		t.Fatalf("expected zero status code to normalize to 1, got %d", code)
+	}
+}
+
+func TestRunMainStandalonePrintsStatusErrorStatus(t *testing.T) {
+	t.Setenv("DEPOT_ERROR_TELEMETRY", "0")
+	t.Setenv("DEPOT_NO_UPDATE_NOTIFIER", "1")
+
+	originalArgs := os.Args
+	t.Cleanup(func() { os.Args = originalArgs })
+	os.Args = []string{"depot"}
+
+	stderr := captureStderr(t)
+
+	originalNewRootCmd := newRootCmd
+	t.Cleanup(func() { newRootCmd = originalNewRootCmd })
+	newRootCmd = func(string, string) *cobra.Command {
+		return &cobra.Command{
+			Use: "depot",
+			RunE: func(*cobra.Command, []string) error {
+				return cli.StatusError{Status: "exit status 7", StatusCode: 7}
+			},
+		}
+	}
+
+	if code := runMain(); code != 7 {
+		t.Fatalf("expected status code 7, got %d", code)
+	}
+	if got := stderr(); !strings.Contains(got, "exit status 7") {
+		t.Fatalf("expected status on stderr, got %q", got)
+	}
+}
+
+func captureStderr(t *testing.T) func() string {
+	t.Helper()
+	original := os.Stderr
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = writer
+	t.Cleanup(func() {
+		os.Stderr = original
+		_ = reader.Close()
+	})
+
+	return func() string {
+		_ = writer.Close()
+		contents, err := io.ReadAll(reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(contents)
+	}
+}

--- a/pkg/cmd/tests/report.go
+++ b/pkg/cmd/tests/report.go
@@ -32,6 +32,8 @@ type discoveredReportFile struct {
 	info         os.FileInfo
 }
 
+type reportFileBaseline map[string]os.FileInfo
+
 func uploadTestReportsResponse(cmd *cobra.Command, opts reportOptions) (int, *testresultsv1.ReportTestResultsResponse, error) {
 	workspace, err := reportWorkspace()
 	if err != nil {
@@ -44,6 +46,12 @@ func uploadTestReportsResponse(cmd *cobra.Command, opts reportOptions) (int, *te
 	}
 	if len(files) == 0 {
 		return 0, nil, fmt.Errorf("no JUnit XML report files matched")
+	}
+	if opts.requireUpdatedByCommand != nil {
+		files = updatedReportFiles(files, opts.requireUpdatedByCommand)
+		if len(files) == 0 {
+			return 0, nil, fmt.Errorf("no JUnit XML report files were updated by command; remove stale report files before running, use a narrower --report-path, or ensure --command writes matching reports")
+		}
 	}
 
 	prepared, err := prepareReportFiles(files)
@@ -67,6 +75,37 @@ func uploadTestReportsResponse(cmd *cobra.Command, opts reportOptions) (int, *te
 		return 0, nil, fmt.Errorf("failed to upload test reports: %w", err)
 	}
 	return len(prepared), resp, nil
+}
+
+func snapshotReportFiles(reportPaths []string) (reportFileBaseline, error) {
+	workspace, err := reportWorkspace()
+	if err != nil {
+		return nil, err
+	}
+	files, err := discoverReportFiles(reportPaths, workspace)
+	if err != nil {
+		return nil, err
+	}
+
+	baseline := reportFileBaseline{}
+	for _, file := range files {
+		baseline[file.realPath] = file.info
+	}
+	return baseline, nil
+}
+
+func updatedReportFiles(files []discoveredReportFile, baseline reportFileBaseline) []discoveredReportFile {
+	if len(baseline) == 0 {
+		return files
+	}
+	updated := files[:0]
+	for _, file := range files {
+		if previous, ok := baseline[file.realPath]; ok && !reportFileChanged(previous, file.info) {
+			continue
+		}
+		updated = append(updated, file)
+	}
+	return updated
 }
 
 func reportWorkspace() (string, error) {

--- a/pkg/cmd/tests/report.go
+++ b/pkg/cmd/tests/report.go
@@ -32,7 +32,10 @@ type discoveredReportFile struct {
 	info         os.FileInfo
 }
 
-type reportFileBaseline map[string]os.FileInfo
+type reportFileBaseline struct {
+	snapshotAt time.Time
+	files      map[string]os.FileInfo
+}
 
 func uploadTestReportsResponse(cmd *cobra.Command, opts reportOptions) (int, *testresultsv1.ReportTestResultsResponse, error) {
 	workspace, err := reportWorkspace()
@@ -48,7 +51,7 @@ func uploadTestReportsResponse(cmd *cobra.Command, opts reportOptions) (int, *te
 		return 0, nil, fmt.Errorf("no JUnit XML report files matched")
 	}
 	if opts.requireUpdatedByCommand != nil {
-		files = updatedReportFiles(files, opts.requireUpdatedByCommand)
+		files = updatedReportFiles(files, *opts.requireUpdatedByCommand)
 		if len(files) == 0 {
 			return 0, nil, fmt.Errorf("no JUnit XML report files were updated by command; remove stale report files before running, use a narrower --report-path, or ensure --command writes matching reports")
 		}
@@ -80,27 +83,31 @@ func uploadTestReportsResponse(cmd *cobra.Command, opts reportOptions) (int, *te
 func snapshotReportFiles(reportPaths []string) (reportFileBaseline, error) {
 	workspace, err := reportWorkspace()
 	if err != nil {
-		return nil, err
+		return reportFileBaseline{}, err
 	}
 	files, err := discoverReportFiles(reportPaths, workspace)
 	if err != nil {
-		return nil, err
+		return reportFileBaseline{}, err
 	}
 
-	baseline := reportFileBaseline{}
+	baseline := reportFileBaseline{
+		snapshotAt: time.Now(),
+		files:      map[string]os.FileInfo{},
+	}
 	for _, file := range files {
-		baseline[file.realPath] = file.info
+		baseline.files[file.realPath] = file.info
 	}
 	return baseline, nil
 }
 
 func updatedReportFiles(files []discoveredReportFile, baseline reportFileBaseline) []discoveredReportFile {
-	if len(baseline) == 0 {
-		return files
-	}
 	updated := files[:0]
 	for _, file := range files {
-		if previous, ok := baseline[file.realPath]; ok && !reportFileChanged(previous, file.info) {
+		if previous, ok := baseline.files[file.realPath]; ok {
+			if !reportFileChanged(previous, file.info) {
+				continue
+			}
+		} else if file.info.ModTime().Before(baseline.snapshotAt) {
 			continue
 		}
 		updated = append(updated, file)

--- a/pkg/cmd/tests/report_cmd.go
+++ b/pkg/cmd/tests/report_cmd.go
@@ -18,7 +18,7 @@ type reportOptions struct {
 	reportPaths             []string
 	key                     string
 	output                  string
-	requireUpdatedByCommand reportFileBaseline
+	requireUpdatedByCommand *reportFileBaseline
 }
 
 type reportOutput struct {

--- a/pkg/cmd/tests/report_cmd.go
+++ b/pkg/cmd/tests/report_cmd.go
@@ -15,9 +15,10 @@ const (
 )
 
 type reportOptions struct {
-	reportPaths []string
-	key         string
-	output      string
+	reportPaths             []string
+	key                     string
+	output                  string
+	requireUpdatedByCommand reportFileBaseline
 }
 
 type reportOutput struct {

--- a/pkg/cmd/tests/run.go
+++ b/pkg/cmd/tests/run.go
@@ -1,0 +1,245 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"os/signal"
+	"runtime"
+	"strings"
+	"syscall"
+
+	testresultsv1 "github.com/depot/cli/pkg/proto/depot/testresults/v1"
+	"github.com/docker/cli/cli"
+	"github.com/spf13/cobra"
+)
+
+var runShellCommandFunc = runShellCommand
+
+type runOptions struct {
+	candidateType  string
+	timingsType    string
+	index          int
+	total          int
+	command        string
+	reportPaths    []string
+	candidatesFile string
+	key            string
+}
+
+func newCmdTestsRun() *cobra.Command {
+	opts := runOptions{index: -1}
+
+	cmd := &cobra.Command{
+		Use:          "run",
+		Short:        "Run a test shard and upload JUnit XML reports",
+		SilenceUsage: true,
+		Long: `Run a test command against the candidates assigned to this shard and upload JUnit XML reports.
+
+Candidates are newline-delimited runnable units read from stdin or --candidates-file. Pass --index and --total to split
+candidates across shards. Depot uses historical test timings to select a balanced shard. If no timings are available for
+filename candidates, Depot falls back to file-size splitting.`,
+		Example: `  # Run a timing-balanced shard from stdin candidates
+  go list ./... | depot tests run --index 0 --total 4 --command "xargs go test -json | go-junit-report -out reports/junit.xml" --report-path reports/junit.xml
+
+  # Run with an explicit candidates file
+  depot tests run --candidates-file tests.txt --index 0 --total 4 --command "xargs npm test -- --reporter junit --reporter-options output=reports/junit.xml" --report-path "reports/*.xml"`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runTestsRun(cmd, opts)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&opts.candidateType, "candidate-type", "", "Runnable candidate identity (filename, classname)")
+	flags.StringVar(&opts.timingsType, "timings-type", "", "JUnit timing identity (filename, classname, testname)")
+	flags.IntVar(&opts.index, "index", -1, "Zero-based shard index; pass with --total to split")
+	flags.IntVar(&opts.total, "total", 0, "Total number of shards; pass with --index to split")
+	flags.StringVar(&opts.command, "command", "", "Shell command that receives selected candidates on stdin (required)")
+	flags.StringArrayVar(&opts.reportPaths, "report-path", nil, "JUnit XML report path, directory, or glob (required, repeatable)")
+	flags.StringVar(&opts.candidatesFile, "candidates-file", "", "Path to newline-delimited runnable test candidates instead of stdin")
+	flags.StringVar(&opts.key, "key", "", "Stable test suite key for split timings and report upload idempotency (defaults to GITHUB_ACTION or default; set when running multiple suites)")
+
+	return cmd
+}
+
+func runTestsRun(cmd *cobra.Command, opts runOptions) error {
+	ctx, stop := newRunSignalContext(cmd.Context())
+	defer stop()
+	originalCtx := cmd.Context()
+	cmd.SetContext(ctx)
+	defer cmd.SetContext(originalCtx)
+
+	if strings.TrimSpace(opts.command) == "" {
+		return fmt.Errorf("--command is required")
+	}
+
+	reportPaths := splitReportPathInputs(opts.reportPaths)
+	if len(reportPaths) == 0 {
+		return fmt.Errorf("at least one report path is required; pass --report-path")
+	}
+
+	splitOpts := splitOptions{
+		candidateType:  opts.candidateType,
+		timingsType:    opts.timingsType,
+		index:          opts.index,
+		total:          opts.total,
+		candidatesFile: opts.candidatesFile,
+		key:            opts.key,
+		output:         splitOutputText,
+	}
+	splitRequested := runSplitRequested(splitOpts)
+	mode, candidates, selectedCandidates, splitResponse, err := selectRunCandidates(cmd, splitOpts)
+	if err != nil {
+		return cancellationErrorOr(err)
+	}
+
+	summaryOpts := splitOpts
+	if !splitRequested {
+		summaryOpts.index = 0
+		summaryOpts.total = 1
+	}
+	writeSplitSummary(cmd.ErrOrStderr(), mode, summaryOpts, len(candidates), selectedCandidates, splitResponse)
+	if len(selectedCandidates) == 0 {
+		fmt.Fprintln(cmd.ErrOrStderr(), "Depot skipped test command because this shard has no candidates.")
+		return nil
+	}
+
+	reportBaseline, err := snapshotReportFiles(reportPaths)
+	if err != nil {
+		return cancellationErrorOr(err)
+	}
+	if err := cancellationErrorOr(ctx.Err()); err != nil {
+		return err
+	}
+
+	exitCode, commandErr := runShellCommandFunc(cmd.Context(), opts.command, selectedCandidates, cmd.OutOrStdout(), cmd.ErrOrStderr())
+	if commandErr != nil && errors.Is(commandErr, context.Canceled) {
+		return cli.StatusError{Status: commandCanceledStatus(commandErr, exitCode), StatusCode: 1}
+	}
+	if err := ctx.Err(); err != nil && exitCode == 0 {
+		return cancellationErrorOr(err)
+	}
+	reportErr := uploadAndSummarizeTestReports(cmd, reportPaths, opts.key, reportBaseline)
+	if reportErr != nil && errors.Is(reportErr, context.Canceled) && exitCode == 0 {
+		return cancellationErrorOr(reportErr)
+	}
+
+	if exitCode != 0 {
+		status := commandStatus(commandErr, exitCode)
+		if reportErr != nil {
+			status = fmt.Sprintf("%s; additionally, %v", status, reportErr)
+		}
+		return cli.StatusError{Status: status, StatusCode: exitCode}
+	}
+	if commandErr != nil {
+		if reportErr != nil {
+			return fmt.Errorf("%w; additionally, %v", commandErr, reportErr)
+		}
+		return commandErr
+	}
+	if reportErr != nil {
+		return reportErr
+	}
+	return nil
+}
+
+func newRunSignalContext(parent context.Context) (context.Context, func()) {
+	return signal.NotifyContext(parent, os.Interrupt, syscall.SIGTERM)
+}
+
+func cancellationErrorOr(err error) error {
+	if err != nil && errors.Is(err, context.Canceled) {
+		return cli.StatusError{Status: err.Error(), StatusCode: 1}
+	}
+	return err
+}
+
+func commandCanceledStatus(err error, exitCode int) string {
+	if exitCode != 0 {
+		return fmt.Sprintf("test command canceled after child exited with status %d: %v", exitCode, err)
+	}
+	return fmt.Sprintf("test command canceled: %v", err)
+}
+
+func selectRunCandidates(cmd *cobra.Command, opts splitOptions) (splitMode, []string, []string, *testresultsv1.SplitTestsResponse, error) {
+	if !runSplitRequested(opts) {
+		if err := validateExplicitSplitIdentityFlags(opts); err != nil {
+			return "", nil, nil, nil, err
+		}
+		candidates, err := loadRequiredCandidates(cmd, opts.candidatesFile)
+		if err != nil {
+			return "", nil, nil, nil, err
+		}
+		opts.index = 0
+		opts.total = 1
+		return splitModePassthrough, candidates, candidates, nil, nil
+	}
+
+	return selectTestCandidates(cmd, opts)
+}
+
+func runSplitRequested(opts splitOptions) bool {
+	return opts.index >= 0 || opts.total != 0
+}
+
+func uploadAndSummarizeTestReports(cmd *cobra.Command, reportPaths []string, key string, baseline reportFileBaseline) error {
+	filesUploaded, reportResp, err := uploadTestReportsResponse(cmd, reportOptions{
+		reportPaths:             reportPaths,
+		key:                     key,
+		output:                  reportOutputText,
+		requireUpdatedByCommand: baseline,
+	})
+	if err != nil {
+		return err
+	}
+	if err := writeReportSummary(cmd.ErrOrStderr(), filesUploaded, reportResp); err != nil {
+		return fmt.Errorf("failed to write test report summary: %w", err)
+	}
+	return nil
+}
+
+func runShellCommand(ctx context.Context, command string, candidates []string, stdout, stderr io.Writer) (int, error) {
+	shell, args := shellCommand(command)
+	subCmd := exec.Command(shell, args...)
+	configureShellCommand(subCmd)
+	if len(candidates) == 0 {
+		subCmd.Stdin = strings.NewReader("")
+	} else {
+		subCmd.Stdin = strings.NewReader(strings.Join(candidates, "\n") + "\n")
+	}
+	subCmd.Stdout = stdout
+	subCmd.Stderr = stderr
+
+	err := runCancellableShellCommand(ctx, subCmd)
+	if err == nil {
+		return 0, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return commandExitCode(exitErr), err
+	}
+	return 1, err
+}
+
+func shellCommand(command string) (string, []string) {
+	if runtime.GOOS == "windows" {
+		shell := os.Getenv("COMSPEC")
+		if shell == "" {
+			shell = "cmd"
+		}
+		return shell, []string{"/C", command}
+	}
+
+	return "/bin/sh", []string{"-c", command}
+}
+
+func commandStatus(err error, exitCode int) string {
+	if err != nil {
+		return err.Error()
+	}
+	return fmt.Sprintf("test command exited with status %d", exitCode)
+}

--- a/pkg/cmd/tests/run.go
+++ b/pkg/cmd/tests/run.go
@@ -191,7 +191,7 @@ func uploadAndSummarizeTestReports(cmd *cobra.Command, reportPaths []string, key
 		reportPaths:             reportPaths,
 		key:                     key,
 		output:                  reportOutputText,
-		requireUpdatedByCommand: baseline,
+		requireUpdatedByCommand: &baseline,
 	})
 	if err != nil {
 		return err

--- a/pkg/cmd/tests/run_process_unix.go
+++ b/pkg/cmd/tests/run_process_unix.go
@@ -1,0 +1,115 @@
+//go:build !windows
+
+package tests
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+const processTerminationGracePeriod = 2 * time.Second
+
+func configureShellCommand(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+func commandExitCode(exitErr *exec.ExitError) int {
+	if code := exitErr.ExitCode(); code >= 0 {
+		return code
+	}
+	if status, ok := exitErr.Sys().(syscall.WaitStatus); ok && status.Signaled() {
+		return 128 + int(status.Signal())
+	}
+	return 1
+}
+
+func runCancellableShellCommand(ctx context.Context, cmd *exec.Cmd) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		pgid := processGroupID(cmd)
+		killProcessGroup(pgid, syscall.SIGTERM)
+		timer := time.NewTimer(processTerminationGracePeriod)
+		defer timer.Stop()
+		err, commandExited := waitForCommandAndProcessGroup(pgid, done, timer.C)
+		if !commandExited || processGroupExists(pgid) {
+			killProcessGroup(pgid, syscall.SIGKILL)
+		}
+		if !commandExited {
+			err = <-done
+		}
+		waitForProcessGroupExit(pgid)
+		if err == nil {
+			return ctx.Err()
+		}
+		return errors.Join(ctx.Err(), err)
+	}
+}
+
+func processGroupID(cmd *exec.Cmd) int {
+	if cmd.Process == nil {
+		return 0
+	}
+	return cmd.Process.Pid
+}
+
+func killProcessGroup(pgid int, signal syscall.Signal) {
+	if pgid <= 0 {
+		return
+	}
+	_ = syscall.Kill(-pgid, signal)
+}
+
+func waitForCommandAndProcessGroup(pgid int, done <-chan error, timeout <-chan time.Time) (error, bool) {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	var waitErr error
+	commandExited := false
+	for {
+		if commandExited && !processGroupExists(pgid) {
+			return waitErr, true
+		}
+		select {
+		case waitErr = <-done:
+			commandExited = true
+		case <-ticker.C:
+		case <-timeout:
+			return waitErr, commandExited
+		}
+	}
+}
+
+func waitForProcessGroupExit(pgid int) {
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if !processGroupExists(pgid) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func processGroupExists(pgid int) bool {
+	if pgid <= 0 {
+		return false
+	}
+	err := syscall.Kill(-pgid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}

--- a/pkg/cmd/tests/run_process_unix_test.go
+++ b/pkg/cmd/tests/run_process_unix_test.go
@@ -1,0 +1,172 @@
+//go:build !windows
+
+package tests
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestRunShellCommandCancellationKillsChildProcesses(t *testing.T) {
+	dir := t.TempDir()
+	readyPath := filepath.Join(dir, "ready")
+	survivedPath := filepath.Join(dir, "survived")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		var stdout, stderr bytes.Buffer
+		_, err := runShellCommand(
+			ctx,
+			"(trap '' TERM; touch "+shellQuote(readyPath)+"; sleep 10; touch "+shellQuote(survivedPath)+") & wait",
+			nil,
+			&stdout,
+			&stderr,
+		)
+		done <- err
+	}()
+
+	waitForFile(t, readyPath)
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context cancellation error, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected canceled command to exit")
+	}
+
+	time.Sleep(500 * time.Millisecond)
+	if _, err := os.Stat(survivedPath); !os.IsNotExist(err) {
+		t.Fatalf("expected child process to be killed before writing survived marker, stat err %v", err)
+	}
+}
+
+func TestRunShellCommandCancellationAllowsTermCleanup(t *testing.T) {
+	dir := t.TempDir()
+	readyPath := filepath.Join(dir, "ready")
+	termPath := filepath.Join(dir, "term")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		var stdout, stderr bytes.Buffer
+		_, err := runShellCommand(
+			ctx,
+			"trap 'touch "+shellQuote(termPath)+"; exit 0' TERM; touch "+shellQuote(readyPath)+"; sleep 10",
+			nil,
+			&stdout,
+			&stderr,
+		)
+		done <- err
+	}()
+
+	waitForFile(t, readyPath)
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context cancellation error, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected command to exit during TERM grace period")
+	}
+	if _, err := os.Stat(termPath); err != nil {
+		t.Fatalf("expected child cleanup trap to run, stat err %v", err)
+	}
+}
+
+func TestRunShellCommandCancellationKillsIgnoredTermChildAfterShellExits(t *testing.T) {
+	dir := t.TempDir()
+	readyPath := filepath.Join(dir, "ready")
+	childPIDPath := filepath.Join(dir, "child-pid")
+	survivedPath := filepath.Join(dir, "survived")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		var stdout, stderr bytes.Buffer
+		_, err := runShellCommand(
+			ctx,
+			"(trap '' TERM; touch "+shellQuote(readyPath)+"; sleep 10; touch "+shellQuote(survivedPath)+") & child=$!; echo $child > "+shellQuote(childPIDPath)+"; trap 'exit 0' TERM; wait $child",
+			nil,
+			&stdout,
+			&stderr,
+		)
+		done <- err
+	}()
+
+	waitForFile(t, readyPath)
+	childPID := readPID(t, childPIDPath)
+	pgid, err := syscall.Getpgid(childPID)
+	if err != nil {
+		t.Fatalf("expected child process group before cancellation: %v", err)
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context cancellation error, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected canceled command to exit")
+	}
+	if processGroupExists(pgid) {
+		t.Fatalf("expected canceled command process group %d to be gone", pgid)
+	}
+	if _, err := os.Stat(survivedPath); !os.IsNotExist(err) {
+		t.Fatalf("expected ignored-TERM child to be killed before writing survived marker, stat err %v", err)
+	}
+}
+
+func TestRunShellCommandReturnsSignalExitCode(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	exitCode, err := runShellCommand(context.Background(), "kill -TERM $$", nil, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("expected signaled command error")
+	}
+	if exitCode != 143 {
+		t.Fatalf("expected SIGTERM exit code 143, got %d", exitCode)
+	}
+}
+
+func waitForFile(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", path)
+}
+
+func readPID(t *testing.T, path string) int {
+	t.Helper()
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(contents)))
+	if err != nil {
+		t.Fatalf("expected pid in %s, got %q", path, string(contents))
+	}
+	return pid
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+}

--- a/pkg/cmd/tests/run_process_windows.go
+++ b/pkg/cmd/tests/run_process_windows.go
@@ -1,0 +1,62 @@
+//go:build windows
+
+package tests
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"strconv"
+	"time"
+)
+
+const processTerminationGracePeriod = 2 * time.Second
+
+func configureShellCommand(cmd *exec.Cmd) {}
+
+func commandExitCode(exitErr *exec.ExitError) int {
+	if code := exitErr.ExitCode(); code >= 0 {
+		return code
+	}
+	return 1
+}
+
+func runCancellableShellCommand(ctx context.Context, cmd *exec.Cmd) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		killProcessTree(cmd)
+		err := <-done
+		if err == nil {
+			return ctx.Err()
+		}
+		return errors.Join(ctx.Err(), err)
+	}
+}
+
+func killProcessTree(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), processTerminationGracePeriod)
+	defer cancel()
+
+	killCmd := exec.CommandContext(ctx, "taskkill", "/T", "/F", "/PID", strconv.Itoa(cmd.Process.Pid))
+	if err := killCmd.Run(); err != nil {
+		_ = cmd.Process.Kill()
+	}
+}

--- a/pkg/cmd/tests/run_test.go
+++ b/pkg/cmd/tests/run_test.go
@@ -1,0 +1,886 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/docker/cli/cli"
+
+	civ1 "github.com/depot/cli/pkg/proto/depot/ci/v1"
+	testresultsv1 "github.com/depot/cli/pkg/proto/depot/testresults/v1"
+)
+
+func TestRunDefaultsToTimingSplitAndReportsWithKey(t *testing.T) {
+	resetTestHooks(t)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeTempFileAt(t, workspace, "reports/junit.xml", "<testsuite/>")
+	resolveOIDCCredentialFunc = func(context.Context) (string, error) { return "oidc-token", nil }
+
+	var splitReq *testresultsv1.SplitTestsRequest
+	splitTestsFunc = func(ctx context.Context, token string, req *testresultsv1.SplitTestsRequest) (*testresultsv1.SplitTestsResponse, error) {
+		requireContextDeadline(t, ctx, "split tests")
+		if token != "oidc-token" {
+			t.Fatalf("expected OIDC token, got %q", token)
+		}
+		splitReq = req
+		return &testresultsv1.SplitTestsResponse{
+			Candidates:            []string{"b.test.ts"},
+			CandidatesRequested:   2,
+			CandidatesSelected:    1,
+			CandidatesWithTimings: 1,
+		}, nil
+	}
+
+	var commandCandidates []string
+	runShellCommandFunc = func(_ context.Context, command string, candidates []string, stdout, stderr io.Writer) (int, error) {
+		if command != "test-command" {
+			t.Fatalf("expected command %q, got %q", "test-command", command)
+		}
+		commandCandidates = append([]string(nil), candidates...)
+		writeRunReport(t, workspace)
+		return 0, nil
+	}
+
+	var reportReq *testresultsv1.ReportTestResultsRequest
+	reportTestResultsFunc = func(ctx context.Context, token string, req *testresultsv1.ReportTestResultsRequest) (*testresultsv1.ReportTestResultsResponse, error) {
+		requireContextDeadline(t, ctx, "report test results")
+		if token != "oidc-token" {
+			t.Fatalf("expected OIDC token, got %q", token)
+		}
+		reportReq = req
+		return &testresultsv1.ReportTestResultsResponse{FilesProcessed: 1, TestsReported: 1}, nil
+	}
+
+	stdout, stderr, err := executeCommandWithInputOutput(
+		"a.test.ts\nb.test.ts\n",
+		"run",
+		"--candidate-type", "filename",
+		"--timings-type", "testname",
+		"--key", "unit",
+		"--index", "1",
+		"--total", "2",
+		"--command", "test-command",
+		"--report-path", "reports/junit.xml",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if stdout != "" {
+		t.Fatalf("expected run command to preserve test command stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "using timings") || !strings.Contains(stderr, "Depot found timings for 1 candidate") {
+		t.Fatalf("expected timing summary on stderr, got %q", stderr)
+	}
+	if !strings.Contains(stderr, "Depot uploaded 1 test report file") || !strings.Contains(stderr, "reported 1 test") {
+		t.Fatalf("expected report summary on stderr, got %q", stderr)
+	}
+	if splitReq == nil {
+		t.Fatal("expected SplitTests to be called")
+	}
+	if splitReq.GetCandidateIdentity() != testresultsv1.TestCandidateIdentity_TEST_CANDIDATE_IDENTITY_FILENAME {
+		t.Fatalf("expected filename candidate identity, got %v", splitReq.GetCandidateIdentity())
+	}
+	if splitReq.GetTimingIdentity() != testresultsv1.TestTimingIdentity_TEST_TIMING_IDENTITY_TESTNAME {
+		t.Fatalf("expected testname timing identity, got %v", splitReq.GetTimingIdentity())
+	}
+	if splitReq.GetSplitKey() != "unit" {
+		t.Fatalf("expected split key unit, got %q", splitReq.GetSplitKey())
+	}
+	if !equalStrings(commandCandidates, []string{"b.test.ts"}) {
+		t.Fatalf("expected selected command candidate, got %v", commandCandidates)
+	}
+	if reportReq == nil || reportReq.GetInvocationId() != "unit" || len(reportReq.GetFiles()) != 1 {
+		t.Fatalf("expected report upload with unit key, got %#v", reportReq)
+	}
+}
+
+func TestRunWithoutShardFlagsRunsAllCandidatesWithoutSplitting(t *testing.T) {
+	resetTestHooks(t)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeTempFileAt(t, workspace, "reports/junit.xml", "<testsuite/>")
+	resolveOIDCCredentialFunc = func(context.Context) (string, error) { return "oidc-token", nil }
+	splitTestsFunc = func(context.Context, string, *testresultsv1.SplitTestsRequest) (*testresultsv1.SplitTestsResponse, error) {
+		t.Fatal("SplitTests should not be called without shard flags")
+		return nil, nil
+	}
+
+	var commandCandidates []string
+	runShellCommandFunc = func(_ context.Context, _ string, candidates []string, _ io.Writer, _ io.Writer) (int, error) {
+		commandCandidates = append([]string(nil), candidates...)
+		writeRunReport(t, workspace)
+		return 0, nil
+	}
+	var reported bool
+	reportTestResultsFunc = func(context.Context, string, *testresultsv1.ReportTestResultsRequest) (*testresultsv1.ReportTestResultsResponse, error) {
+		reported = true
+		return &testresultsv1.ReportTestResultsResponse{FilesProcessed: 1}, nil
+	}
+
+	_, stderr, err := executeCommandWithInputOutput(
+		"a.test.ts\nb.test.ts\n",
+		"run",
+		"--command", "test-command",
+		"--report-path", "reports/junit.xml",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !equalStrings(commandCandidates, []string{"a.test.ts", "b.test.ts"}) {
+		t.Fatalf("expected all candidates on command stdin, got %v", commandCandidates)
+	}
+	if !reported {
+		t.Fatal("expected report upload after command")
+	}
+	if !strings.Contains(stderr, "Depot selected all 2 candidate") {
+		t.Fatalf("expected single shard summary, got %q", stderr)
+	}
+}
+
+func TestRunPreservesRealCommandStdout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX shell syntax")
+	}
+
+	resetTestHooks(t)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	runShellCommandFunc = runShellCommand
+	reportTestResultsFunc = func(context.Context, string, *testresultsv1.ReportTestResultsRequest) (*testresultsv1.ReportTestResultsResponse, error) {
+		return &testresultsv1.ReportTestResultsResponse{FilesProcessed: 1, TestsReported: 1}, nil
+	}
+
+	stdout, stderr, err := executeCommandWithInputOutput(
+		"a.test.ts\n",
+		"run",
+		"--index", "0",
+		"--total", "1",
+		"--command", "mkdir -p reports; printf '<testsuite><testcase name=\"updated\"/></testsuite>' > reports/junit.xml; printf 'child stdout\\n'",
+		"--report-path", "reports/junit.xml",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stdout != "child stdout\n" {
+		t.Fatalf("expected child stdout to pass through unchanged, got %q", stdout)
+	}
+	if strings.Contains(stderr, "child stdout") {
+		t.Fatalf("expected child stdout to stay out of stderr, got %q", stderr)
+	}
+	if !strings.Contains(stderr, "Depot selected all 1 candidate") || !strings.Contains(stderr, "Depot uploaded 1 test report file") {
+		t.Fatalf("expected run summaries on stderr, got %q", stderr)
+	}
+}
+
+func TestRunSkipsCommandAndReportForEmptySelectedShard(t *testing.T) {
+	resetTestHooks(t)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	resolveOIDCCredentialFunc = func(context.Context) (string, error) { return "oidc-token", nil }
+	splitTestsFunc = func(context.Context, string, *testresultsv1.SplitTestsRequest) (*testresultsv1.SplitTestsResponse, error) {
+		return &testresultsv1.SplitTestsResponse{
+			Candidates:            nil,
+			CandidatesRequested:   2,
+			CandidatesSelected:    0,
+			CandidatesWithTimings: 1,
+		}, nil
+	}
+
+	runShellCommandFunc = func(_ context.Context, _ string, candidates []string, _ io.Writer, _ io.Writer) (int, error) {
+		t.Fatalf("command should not run for empty shard; got candidates %v", candidates)
+		return 1, nil
+	}
+	reportTestResultsFunc = func(context.Context, string, *testresultsv1.ReportTestResultsRequest) (*testresultsv1.ReportTestResultsResponse, error) {
+		t.Fatal("report upload should not run for empty shard")
+		return nil, nil
+	}
+
+	_, stderr, err := executeCommandWithInputOutput(
+		"com.example.A\ncom.example.B\n",
+		"run",
+		"--candidate-type", "classname",
+		"--index", "1",
+		"--total", "2",
+		"--command", "test-command",
+		"--report-path", "reports/junit.xml",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stderr, "selected 0 of 2 candidate") {
+		t.Fatalf("expected empty shard summary, got %q", stderr)
+	}
+	if !strings.Contains(stderr, "Depot skipped test command because this shard has no candidates.") {
+		t.Fatalf("expected empty shard skip summary, got %q", stderr)
+	}
+}
+
+func TestRunFallsBackToFileSizeWhenNoTimingsAreAvailable(t *testing.T) {
+	resetTestHooks(t)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	small := writeSizedFile(t, workspace, "small.test.ts", 1)
+	large := writeSizedFile(t, workspace, "large.test.ts", 100)
+	writeTempFileAt(t, workspace, "reports/junit.xml", "<testsuite/>")
+	resolveOIDCCredentialFunc = func(context.Context) (string, error) { return "oidc-token", nil }
+	splitTestsFunc = func(context.Context, string, *testresultsv1.SplitTestsRequest) (*testresultsv1.SplitTestsResponse, error) {
+		return &testresultsv1.SplitTestsResponse{
+			Candidates:            []string{large},
+			CandidatesRequested:   2,
+			CandidatesSelected:    1,
+			CandidatesWithTimings: 0,
+		}, nil
+	}
+
+	var commandCandidates []string
+	runShellCommandFunc = func(_ context.Context, _ string, candidates []string, _ io.Writer, _ io.Writer) (int, error) {
+		commandCandidates = append([]string(nil), candidates...)
+		writeRunReport(t, workspace)
+		return 0, nil
+	}
+
+	_, stderr, err := executeCommandWithInputOutput(
+		small+"\n"+large+"\n",
+		"run",
+		"--candidate-type", "filename",
+		"--index", "1",
+		"--total", "2",
+		"--command", "test-command",
+		"--report-path", "reports/junit.xml",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !equalStrings(commandCandidates, []string{small}) {
+		t.Fatalf("expected filesize fallback shard on command stdin, got %v", commandCandidates)
+	}
+	if !strings.Contains(stderr, "using filesize") {
+		t.Fatalf("expected filesize fallback summary, got %q", stderr)
+	}
+}
+
+func TestRunReadsCandidatesFile(t *testing.T) {
+	resetTestHooks(t)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	candidatesPath := writeTempFileAt(t, workspace, "candidates.txt", "a.test.ts\nb.test.ts\n")
+	writeTempFileAt(t, workspace, "reports/junit.xml", "<testsuite/>")
+
+	var commandCandidates []string
+	runShellCommandFunc = func(_ context.Context, _ string, candidates []string, _ io.Writer, _ io.Writer) (int, error) {
+		commandCandidates = append([]string(nil), candidates...)
+		writeRunReport(t, workspace)
+		return 0, nil
+	}
+
+	_, _, err := executeCommandWithInputOutput(
+		"ignored.test.ts\n",
+		"run",
+		"--candidates-file", candidatesPath,
+		"--index", "0",
+		"--total", "1",
+		"--command", "test-command",
+		"--report-path", "reports/junit.xml",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !equalStrings(commandCandidates, []string{"a.test.ts", "b.test.ts"}) {
+		t.Fatalf("expected candidates file to drive command stdin, got %v", commandCandidates)
+	}
+}
+
+func TestRunSubcommandTakesPrecedenceOverResultID(t *testing.T) {
+	resetTestHooks(t)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeTempFileAt(t, workspace, "reports/junit.xml", "<testsuite/>")
+	ciGetRunStatusFunc = func(context.Context, string, string, string) (*civ1.GetRunStatusResponse, error) {
+		t.Fatal("parent tests command should not try to resolve run as an ID")
+		return nil, nil
+	}
+	listTestResultsFunc = func(context.Context, string, string, *testresultsv1.ListTestResultsRequest) (*testresultsv1.ListTestResultsResponse, error) {
+		t.Fatal("parent tests command should not list test results")
+		return nil, nil
+	}
+
+	var commandRan bool
+	runShellCommandFunc = func(context.Context, string, []string, io.Writer, io.Writer) (int, error) {
+		commandRan = true
+		writeRunReport(t, workspace)
+		return 0, nil
+	}
+
+	_, _, err := executeCommandWithInputOutput(
+		"a.test.ts\n",
+		"run",
+		"--index", "0",
+		"--total", "1",
+		"--command", "test-command",
+		"--report-path", "reports/junit.xml",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !commandRan {
+		t.Fatal("expected run subcommand to execute")
+	}
+}
+
+func TestRunPreservesCommandExitStatusAfterReportUpload(t *testing.T) {
+	resetTestHooks(t)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeTempFileAt(t, workspace, "reports/junit.xml", "<testsuite/>")
+	splitTestsFunc = func(context.Context, string, *testresultsv1.SplitTestsRequest) (*testresultsv1.SplitTestsResponse, error) {
+		return &testresultsv1.SplitTestsResponse{Candidates: []string{"a.test.ts"}, CandidatesWithTimings: 1}, nil
+	}
+	var calls []string
+	runShellCommandFunc = func(context.Context, string, []string, io.Writer, io.Writer) (int, error) {
+		calls = append(calls, "command")
+		writeRunReport(t, workspace)
+		return 7, errors.New("exit status 7")
+	}
+	reportTestResultsFunc = func(context.Context, string, *testresultsv1.ReportTestResultsRequest) (*testresultsv1.ReportTestResultsResponse, error) {
+		calls = append(calls, "report")
+		return &testresultsv1.ReportTestResultsResponse{FilesProcessed: 1}, nil
+	}
+
+	_, _, err := executeCommandWithInputOutput(
+		"a.test.ts\n",
+		"run",
+		"--index", "0",
+		"--total", "2",
+		"--command", "test-command",
+		"--report-path", "reports/junit.xml",
+	)
+	statusErr, ok := err.(cli.StatusError)
+	if !ok {
+		t.Fatalf("expected cli.StatusError, got %T: %v", err, err)
+	}
+	if statusErr.StatusCode != 7 {
+		t.Fatalf("expected status code 7, got %d", statusErr.StatusCode)
+	}
+	if !equalStrings(calls, []string{"command", "report"}) {
+		t.Fatalf("expected report upload after command failure, got calls %v", calls)
+	}
+}
+
+func TestRunPreservesCommandExitStatusWhenReportUploadAlsoFails(t *testing.T) {
+	resetTestHooks(t)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeTempFileAt(t, workspace, "reports/junit.xml", "<testsuite/>")
+	splitTestsFunc = func(context.Context, string, *testresultsv1.SplitTestsRequest) (*testresultsv1.SplitTestsResponse, error) {
+		return &testresultsv1.SplitTestsResponse{Candidates: []string{"a.test.ts"}, CandidatesWithTimings: 1}, nil
+	}
+	runShellCommandFunc = func(context.Context, string, []string, io.Writer, io.Writer) (int, error) {
+		writeRunReport(t, workspace)
+		return 7, errors.New("exit status 7")
+	}
+	reportTestResultsFunc = func(context.Context, string, *testresultsv1.ReportTestResultsRequest) (*testresultsv1.ReportTestResultsResponse, error) {
+		return nil, errors.New("upload failed")
+	}
+
+	_, _, err := executeCommandWithInputOutput(
+		"a.test.ts\n",
+		"run",
+		"--index", "0",
+		"--total", "2",
+		"--command", "test-command",
+		"--report-path", "reports/junit.xml",
+	)
+	statusErr, ok := err.(cli.StatusError)
+	if !ok {
+		t.Fatalf("expected cli.StatusError, got %T: %v", err, err)
+	}
+	if statusErr.StatusCode != 7 {
+		t.Fatalf("expected status code 7, got %d", statusErr.StatusCode)
+	}
+	if !strings.Contains(statusErr.Status, "exit status 7") || !strings.Contains(statusErr.Status, "failed to upload test reports: upload failed") {
+		t.Fatalf("expected command and report failures in status, got %q", statusErr.Status)
+	}
+}
+
+func TestRunSkipsReportUploadAfterCancellation(t *testing.T) {
+	resetTestHooks(t)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeTempFileAt(t, workspace, "reports/junit.xml", "<testsuite/>")
+	runShellCommandFunc = func(context.Context, string, []string, io.Writer, io.Writer) (int, error) {
+		return 143, context.Canceled
+	}
+	reportTestResultsFunc = func(context.Context, string, *testresultsv1.ReportTestResultsRequest) (*testresultsv1.ReportTestResultsResponse, error) {
+		t.Fatal("report upload should not run after cancellation")
+		return nil, nil
+	}
+
+	_, _, err := executeCommandWithInputOutput(
+		"a.test.ts\n",
+		"run",
+		"--index", "0",
+		"--total", "1",
+		"--command", "test-command",
+		"--report-path", "reports/junit.xml",
+	)
+	statusErr, ok := err.(cli.StatusError)
+	if !ok {
+		t.Fatalf("expected cli.StatusError, got %T: %v", err, err)
+	}
+	if statusErr.StatusCode != 1 {
+		t.Fatalf("expected cancellation status code 1, got %d", statusErr.StatusCode)
+	}
+	if !strings.Contains(statusErr.Status, "context canceled") || !strings.Contains(statusErr.Status, "status 143") {
+		t.Fatalf("expected cancellation status, got %q", statusErr.Status)
+	}
+}
+
+func TestRunSkipsReportUploadWhenCanceledAfterSuccessfulCommand(t *testing.T) {
+	resetTestHooks(t)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeTempFileAt(t, workspace, "reports/junit.xml", "<testsuite/>")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runShellCommandFunc = func(context.Context, string, []string, io.Writer, io.Writer) (int, error) {
+		writeRunReport(t, workspace)
+		cancel()
+		return 0, nil
+	}
+	reportTestResultsFunc = func(context.Context, string, *testresultsv1.ReportTestResultsRequest) (*testresultsv1.ReportTestResultsResponse, error) {
+		t.Fatal("report upload should not run after cancellation")
+		return nil, nil
+	}
+
+	cmd := newCmdTestsRun()
+	var stdout, stderr bytes.Buffer
+	cmd.SetContext(ctx)
+	cmd.SetIn(strings.NewReader("a.test.ts\n"))
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"--index", "0",
+		"--total", "1",
+		"--command", "test-command",
+		"--report-path", "reports/junit.xml",
+	})
+
+	err := cmd.Execute()
+	statusErr, ok := err.(cli.StatusError)
+	if !ok {
+		t.Fatalf("expected cli.StatusError, got %T: %v", err, err)
+	}
+	if statusErr.StatusCode != 1 {
+		t.Fatalf("expected cancellation status code 1, got %d", statusErr.StatusCode)
+	}
+	if !strings.Contains(statusErr.Status, "context canceled") {
+		t.Fatalf("expected cancellation status, got %q", statusErr.Status)
+	}
+}
+
+func TestRunSplitCancellationExitsOne(t *testing.T) {
+	resetTestHooks(t)
+
+	splitTestsFunc = func(context.Context, string, *testresultsv1.SplitTestsRequest) (*testresultsv1.SplitTestsResponse, error) {
+		return nil, context.Canceled
+	}
+	runShellCommandFunc = func(context.Context, string, []string, io.Writer, io.Writer) (int, error) {
+		t.Fatal("command should not run after split cancellation")
+		return 0, nil
+	}
+
+	cmd := newCmdTestsRun()
+	var stdout, stderr bytes.Buffer
+	cmd.SetIn(strings.NewReader("a.test.ts\n"))
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"--index", "0",
+		"--total", "2",
+		"--command", "test-command",
+		"--report-path", "reports/junit.xml",
+	})
+
+	err := cmd.Execute()
+	statusErr, ok := err.(cli.StatusError)
+	if !ok {
+		t.Fatalf("expected cli.StatusError, got %T: %v", err, err)
+	}
+	if statusErr.StatusCode != 1 {
+		t.Fatalf("expected cancellation status code 1, got %d", statusErr.StatusCode)
+	}
+	if !strings.Contains(statusErr.Status, "context canceled") {
+		t.Fatalf("expected cancellation status, got %q", statusErr.Status)
+	}
+}
+
+func TestRunReportUploadCancellationAfterSuccessfulCommandExitsOne(t *testing.T) {
+	resetTestHooks(t)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeTempFileAt(t, workspace, "reports/junit.xml", "<testsuite/>")
+	runShellCommandFunc = func(context.Context, string, []string, io.Writer, io.Writer) (int, error) {
+		writeRunReport(t, workspace)
+		return 0, nil
+	}
+	reportTestResultsFunc = func(context.Context, string, *testresultsv1.ReportTestResultsRequest) (*testresultsv1.ReportTestResultsResponse, error) {
+		return nil, context.Canceled
+	}
+
+	_, _, err := executeCommandWithInputOutput(
+		"a.test.ts\n",
+		"run",
+		"--index", "0",
+		"--total", "1",
+		"--command", "test-command",
+		"--report-path", "reports/junit.xml",
+	)
+	statusErr, ok := err.(cli.StatusError)
+	if !ok {
+		t.Fatalf("expected cli.StatusError, got %T: %v", err, err)
+	}
+	if statusErr.StatusCode != 1 {
+		t.Fatalf("expected cancellation status code 1, got %d", statusErr.StatusCode)
+	}
+	if !strings.Contains(statusErr.Status, "failed to upload test reports") {
+		t.Fatalf("expected upload error status, got %q", statusErr.Status)
+	}
+}
+
+func TestRunReportUploadCancellationPreservesFailedCommandExitStatus(t *testing.T) {
+	resetTestHooks(t)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeTempFileAt(t, workspace, "reports/junit.xml", "<testsuite/>")
+	runShellCommandFunc = func(context.Context, string, []string, io.Writer, io.Writer) (int, error) {
+		writeRunReport(t, workspace)
+		return 7, errors.New("exit status 7")
+	}
+	reportTestResultsFunc = func(context.Context, string, *testresultsv1.ReportTestResultsRequest) (*testresultsv1.ReportTestResultsResponse, error) {
+		return nil, context.Canceled
+	}
+
+	_, _, err := executeCommandWithInputOutput(
+		"a.test.ts\n",
+		"run",
+		"--index", "0",
+		"--total", "1",
+		"--command", "test-command",
+		"--report-path", "reports/junit.xml",
+	)
+	statusErr, ok := err.(cli.StatusError)
+	if !ok {
+		t.Fatalf("expected cli.StatusError, got %T: %v", err, err)
+	}
+	if statusErr.StatusCode != 7 {
+		t.Fatalf("expected command status code 7, got %d", statusErr.StatusCode)
+	}
+	if !strings.Contains(statusErr.Status, "exit status 7") || !strings.Contains(statusErr.Status, "context canceled") {
+		t.Fatalf("expected command and upload cancellation failures in status, got %q", statusErr.Status)
+	}
+}
+
+func TestRunFailsWhenReportUploadFailsAfterSuccessfulCommand(t *testing.T) {
+	resetTestHooks(t)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeTempFileAt(t, workspace, "reports/junit.xml", "<testsuite/>")
+	runShellCommandFunc = func(context.Context, string, []string, io.Writer, io.Writer) (int, error) {
+		writeRunReport(t, workspace)
+		return 0, nil
+	}
+	reportTestResultsFunc = func(context.Context, string, *testresultsv1.ReportTestResultsRequest) (*testresultsv1.ReportTestResultsResponse, error) {
+		return nil, errors.New("upload failed")
+	}
+
+	_, _, err := executeCommandWithInputOutput(
+		"a.test.ts\n",
+		"run",
+		"--index", "0",
+		"--total", "1",
+		"--command", "test-command",
+		"--report-path", "reports/junit.xml",
+	)
+	if err == nil || !strings.Contains(err.Error(), "failed to upload test reports") {
+		t.Fatalf("expected report upload error, got %v", err)
+	}
+}
+
+func TestRunRejectsWhenNoReportFileWasUpdatedByCommand(t *testing.T) {
+	resetTestHooks(t)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	reportPath := writeTempFileAt(t, workspace, "reports/junit.xml", "<testsuite><testcase name=\"old\"/></testsuite>")
+	staleTime := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(reportPath, staleTime, staleTime); err != nil {
+		t.Fatal(err)
+	}
+
+	runShellCommandFunc = func(context.Context, string, []string, io.Writer, io.Writer) (int, error) {
+		return 0, nil
+	}
+	reportTestResultsFunc = func(context.Context, string, *testresultsv1.ReportTestResultsRequest) (*testresultsv1.ReportTestResultsResponse, error) {
+		t.Fatal("unchanged report should not upload")
+		return nil, nil
+	}
+
+	_, _, err := executeCommandWithInputOutput(
+		"a.test.ts\n",
+		"run",
+		"--index", "0",
+		"--total", "1",
+		"--command", "test-command",
+		"--report-path", "reports/junit.xml",
+	)
+	if err == nil || !strings.Contains(err.Error(), "no JUnit XML report files were updated by command") {
+		t.Fatalf("expected no updated reports error, got %v", err)
+	}
+}
+
+func TestRunFiltersStaleReportFilesAndUploadsUpdatedReports(t *testing.T) {
+	resetTestHooks(t)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	stalePath := writeTempFileAt(t, workspace, "reports/stale.xml", "<testsuite><testcase name=\"old\"/></testsuite>")
+	staleTime := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(stalePath, staleTime, staleTime); err != nil {
+		t.Fatal(err)
+	}
+
+	runShellCommandFunc = func(context.Context, string, []string, io.Writer, io.Writer) (int, error) {
+		writeTempFileAt(t, workspace, "reports/fresh.xml", "<testsuite><testcase name=\"new\"/></testsuite>")
+		return 0, nil
+	}
+	var filenames []string
+	reportTestResultsFunc = func(_ context.Context, _ string, req *testresultsv1.ReportTestResultsRequest) (*testresultsv1.ReportTestResultsResponse, error) {
+		for _, file := range req.GetFiles() {
+			filenames = append(filenames, file.GetFilename())
+		}
+		return &testresultsv1.ReportTestResultsResponse{FilesProcessed: uint32(len(req.GetFiles()))}, nil
+	}
+
+	_, _, err := executeCommandWithInputOutput(
+		"a.test.ts\n",
+		"run",
+		"--index", "0",
+		"--total", "1",
+		"--command", "test-command",
+		"--report-path", "reports/*.xml",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !equalStrings(filenames, []string{"reports/fresh.xml"}) {
+		t.Fatalf("expected only fresh report upload, got %v", filenames)
+	}
+}
+
+func TestRunReportsDuplicateInvocationOnStderr(t *testing.T) {
+	resetTestHooks(t)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeTempFileAt(t, workspace, "reports/junit.xml", "<testsuite/>")
+	runShellCommandFunc = func(context.Context, string, []string, io.Writer, io.Writer) (int, error) {
+		writeRunReport(t, workspace)
+		return 0, nil
+	}
+	reportTestResultsFunc = func(context.Context, string, *testresultsv1.ReportTestResultsRequest) (*testresultsv1.ReportTestResultsResponse, error) {
+		return &testresultsv1.ReportTestResultsResponse{
+			FilesProcessed:      1,
+			DuplicateInvocation: true,
+		}, nil
+	}
+
+	stdout, stderr, err := executeCommandWithInputOutput(
+		"a.test.ts\n",
+		"run",
+		"--index", "0",
+		"--total", "1",
+		"--command", "test-command",
+		"--report-path", "reports/junit.xml",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stdout != "" {
+		t.Fatalf("expected no run-managed stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "already reported") {
+		t.Fatalf("expected duplicate invocation summary on stderr, got %q", stderr)
+	}
+}
+
+func TestRunValidationFailsBeforeCommandExecution(t *testing.T) {
+	resetTestHooks(t)
+	runShellCommandFunc = func(context.Context, string, []string, io.Writer, io.Writer) (int, error) {
+		t.Fatal("command should not run")
+		return 0, nil
+	}
+
+	_, _, err := executeCommandWithInputOutput("a.test.ts\n", "run", "--index", "0", "--total", "2", "--report-path", "junit.xml")
+	if err == nil || !strings.Contains(err.Error(), "--command is required") {
+		t.Fatalf("expected command validation error, got %v", err)
+	}
+}
+
+func TestRunRequiresReportPathBeforeCommandExecution(t *testing.T) {
+	resetTestHooks(t)
+	runShellCommandFunc = func(context.Context, string, []string, io.Writer, io.Writer) (int, error) {
+		t.Fatal("command should not run")
+		return 0, nil
+	}
+
+	_, _, err := executeCommandWithInputOutput(
+		"a.test.ts\n",
+		"run",
+		"--index", "0",
+		"--total", "2",
+		"--command", "test-command",
+	)
+	if err == nil || !strings.Contains(err.Error(), "at least one report path is required") {
+		t.Fatalf("expected report path validation error, got %v", err)
+	}
+}
+
+func TestRunRejectsUnsupportedTimingIdentityPair(t *testing.T) {
+	resetTestHooks(t)
+	runShellCommandFunc = func(context.Context, string, []string, io.Writer, io.Writer) (int, error) {
+		t.Fatal("command should not run")
+		return 0, nil
+	}
+	splitTestsFunc = func(context.Context, string, *testresultsv1.SplitTestsRequest) (*testresultsv1.SplitTestsResponse, error) {
+		t.Fatal("SplitTests should not be called for invalid identity pairs")
+		return nil, nil
+	}
+
+	_, _, err := executeCommandWithInputOutput(
+		"a.test.ts\n",
+		"run",
+		"--candidate-type", "filename",
+		"--timings-type", "classname",
+		"--index", "0",
+		"--total", "2",
+		"--command", "test-command",
+		"--report-path", "junit.xml",
+	)
+	if err == nil || !strings.Contains(err.Error(), "must match --candidate-type") {
+		t.Fatalf("expected identity pair validation error, got %v", err)
+	}
+}
+
+func TestRunRequiresCandidatesWhenStdinIsTerminal(t *testing.T) {
+	resetTestHooks(t)
+	runShellCommandFunc = func(context.Context, string, []string, io.Writer, io.Writer) (int, error) {
+		t.Fatal("command should not run")
+		return 0, nil
+	}
+
+	_, _, err := executeCommandOutput(
+		"run",
+		"--index", "0",
+		"--total", "1",
+		"--command", "test-command",
+		"--report-path", "junit.xml",
+	)
+	if err == nil || !strings.Contains(err.Error(), "pipe newline-delimited candidates") || !strings.Contains(err.Error(), "--candidates-file") {
+		t.Fatalf("expected missing candidates error, got %v", err)
+	}
+}
+
+func TestRunShellCommandWritesCandidatesToStdin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX shell utilities")
+	}
+
+	var stdout, stderr bytes.Buffer
+	exitCode, err := runShellCommand(context.Background(), "cat", []string{"a.test.ts", "b.test.ts"}, &stdout, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+	if stdout.String() != "a.test.ts\nb.test.ts\n" {
+		t.Fatalf("expected candidates on stdin, got stdout %q stderr %q", stdout.String(), stderr.String())
+	}
+}
+
+func TestRunCancellableShellCommandDoesNotStartWhenAlreadyCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := runCancellableShellCommand(ctx, exec.Command("depot-definitely-not-a-real-command"))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation before process start, got %v", err)
+	}
+}
+
+func TestRunShellCommandWritesEmptyStdin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX shell syntax")
+	}
+
+	var stdout, stderr bytes.Buffer
+	exitCode, err := runShellCommand(context.Background(), "if read line; then echo unexpected; exit 1; fi", nil, &stdout, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d stdout %q stderr %q", exitCode, stdout.String(), stderr.String())
+	}
+}
+
+func TestRunShellCommandReturnsExitCode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX shell syntax")
+	}
+
+	var stdout, stderr bytes.Buffer
+	exitCode, err := runShellCommand(context.Background(), "exit 9", nil, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("expected command error")
+	}
+	if exitCode != 9 {
+		t.Fatalf("expected exit code 9, got %d", exitCode)
+	}
+}
+
+func TestRunShellCommandUsesStableUnixShell(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses Unix shell path")
+	}
+
+	t.Setenv("SHELL", "/bin/false")
+
+	shell, args := shellCommand("printf ok")
+	if shell != "/bin/sh" {
+		t.Fatalf("expected stable /bin/sh shell, got %q with args %v", shell, args)
+	}
+
+	var stdout, stderr bytes.Buffer
+	exitCode, err := runShellCommand(context.Background(), "printf ok", nil, &stdout, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+	if stdout.String() != "ok" {
+		t.Fatalf("expected command to run through /bin/sh, got stdout %q stderr %q", stdout.String(), stderr.String())
+	}
+}
+
+func writeRunReport(t *testing.T, workspace string) {
+	t.Helper()
+	writeTempFileAt(t, workspace, "reports/junit.xml", "<testsuite><testcase name=\"updated\"/></testsuite>")
+}

--- a/pkg/cmd/tests/run_test.go
+++ b/pkg/cmd/tests/run_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -641,6 +642,43 @@ func TestRunRejectsWhenNoReportFileWasUpdatedByCommand(t *testing.T) {
 		"--total", "1",
 		"--command", "test-command",
 		"--report-path", "reports/junit.xml",
+	)
+	if err == nil || !strings.Contains(err.Error(), "no JUnit XML report files were updated by command") {
+		t.Fatalf("expected no updated reports error, got %v", err)
+	}
+}
+
+func TestRunRejectsStaleReportCreatedAfterEmptyBaseline(t *testing.T) {
+	resetTestHooks(t)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	stalePath := writeTempFileAt(t, workspace, "stale/junit.xml", "<testsuite><testcase name=\"old\"/></testsuite>")
+	staleTime := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(stalePath, staleTime, staleTime); err != nil {
+		t.Fatal(err)
+	}
+
+	runShellCommandFunc = func(context.Context, string, []string, io.Writer, io.Writer) (int, error) {
+		if err := os.MkdirAll(filepath.Join(workspace, "reports"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Rename(stalePath, filepath.Join(workspace, "reports", "junit.xml")); err != nil {
+			t.Fatal(err)
+		}
+		return 0, nil
+	}
+	reportTestResultsFunc = func(context.Context, string, *testresultsv1.ReportTestResultsRequest) (*testresultsv1.ReportTestResultsResponse, error) {
+		t.Fatal("stale report should not upload")
+		return nil, nil
+	}
+
+	_, _, err := executeCommandWithInputOutput(
+		"a.test.ts\n",
+		"run",
+		"--index", "0",
+		"--total", "1",
+		"--command", "test-command",
+		"--report-path", "reports/*.xml",
 	)
 	if err == nil || !strings.Contains(err.Error(), "no JUnit XML report files were updated by command") {
 		t.Fatalf("expected no updated reports error, got %v", err)

--- a/pkg/cmd/tests/selection.go
+++ b/pkg/cmd/tests/selection.go
@@ -28,16 +28,9 @@ func selectTestCandidates(cmd *cobra.Command, opts splitOptions) (splitMode, []s
 	if err := validateExplicitSplitIdentityFlags(opts); err != nil {
 		return "", nil, nil, nil, err
 	}
-	if stdin, ok := cmd.InOrStdin().(*os.File); opts.candidatesFile == "" && ok && stdin == os.Stdin && isStdinTerminalFunc() {
-		return "", nil, nil, nil, fmt.Errorf("no candidates provided; pipe newline-delimited candidates to stdin or pass --candidates-file")
-	}
-
-	candidates, err := loadCandidates(cmd.InOrStdin(), opts.candidatesFile)
+	candidates, err := loadRequiredCandidates(cmd, opts.candidatesFile)
 	if err != nil {
-		return "", nil, nil, nil, fmt.Errorf("failed to load candidates: %w", err)
-	}
-	if len(candidates) == 0 {
-		return "", nil, nil, nil, fmt.Errorf("no candidates provided; pipe newline-delimited candidates to stdin or pass --candidates-file")
+		return "", nil, nil, nil, err
 	}
 	if opts.total == 1 {
 		return splitModePassthrough, candidates, candidates, nil, nil
@@ -61,6 +54,20 @@ func selectTestCandidates(cmd *cobra.Command, opts splitOptions) (splitMode, []s
 	}
 
 	return mode, candidates, selectedCandidates, splitResponse, nil
+}
+
+func loadRequiredCandidates(cmd *cobra.Command, candidatesFile string) ([]string, error) {
+	if stdin, ok := cmd.InOrStdin().(*os.File); candidatesFile == "" && ok && stdin == os.Stdin && isStdinTerminalFunc() {
+		return nil, fmt.Errorf("no candidates provided; pipe newline-delimited candidates to stdin or pass --candidates-file")
+	}
+	candidates, err := loadCandidates(cmd.InOrStdin(), candidatesFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load candidates: %w", err)
+	}
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("no candidates provided; pipe newline-delimited candidates to stdin or pass --candidates-file")
+	}
+	return candidates, nil
 }
 
 func validateSplitIdentityFlags(opts splitOptions, candidates []string) error {

--- a/pkg/cmd/tests/tests.go
+++ b/pkg/cmd/tests/tests.go
@@ -97,6 +97,7 @@ Actions job ID.`,
 	flags.StringVar(&opts.output, "output", "auto", "Output format (auto, table, json)")
 
 	cmd.AddCommand(newCmdTestsReport())
+	cmd.AddCommand(newCmdTestsRun())
 	cmd.AddCommand(newCmdTestsSplit())
 
 	return cmd

--- a/pkg/cmd/tests/tests_test.go
+++ b/pkg/cmd/tests/tests_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -521,6 +522,9 @@ func resetTestHooks(t *testing.T) {
 	resolveOIDCCredentialFunc = func(context.Context) (string, error) {
 		return "oidc-token", nil
 	}
+	runShellCommandFunc = func(context.Context, string, []string, io.Writer, io.Writer) (int, error) {
+		return 0, nil
+	}
 	isTerminalFunc = func() bool {
 		return true
 	}
@@ -538,6 +542,7 @@ func resetTestHooks(t *testing.T) {
 		ciGetRunStatusFunc = apiCIGetRunStatus
 		splitTestsFunc = apiSplitTests
 		resolveOIDCCredentialFunc = testsResolveOIDCCredential
+		runShellCommandFunc = testsRunShellCommand
 		isTerminalFunc = helpersIsTerminal
 		isStdinTerminalFunc = helpersIsStdinTerminal
 		oidcDebugWriter = defaultOIDCDebugWriter
@@ -565,6 +570,7 @@ var (
 	apiCIGetRunStatus          = ciGetRunStatusFunc
 	apiSplitTests              = splitTestsFunc
 	testsResolveOIDCCredential = resolveOIDCCredentialFunc
+	testsRunShellCommand       = runShellCommandFunc
 	helpersIsTerminal          = isTerminalFunc
 	helpersIsStdinTerminal     = isStdinTerminalFunc
 	defaultOIDCDebugWriter     = oidcDebugWriter


### PR DESCRIPTION
## Summary

- Adds `depot tests run` to compose candidate selection, test command execution, and JUnit report upload in one command.
- Runs all candidates when no split flags are provided; only splits when `--index` / `--total` are passed.
- Skips command execution and report upload for empty shards.
- Reuses the stable `--key` for split timings and report upload identity, with clearer help text for defaults and multi-suite usage.
- Filters report uploads to files created or changed by the command so stale JUnit XML is not uploaded.

## Plumbing and Process Handling

- Teaches standalone `depot` to honor `cli.StatusError` exit codes so `tests run` can preserve user command failures.
- Keeps cancellation handling local to `depot tests run` instead of adding global CLI signal plumbing.
- Preserves the user command exit code when tests fail, even if report upload later fails or is canceled.
- Uses OS-specific process runners: Unix uses `/bin/sh` with process-group cleanup; Windows uses `%COMSPEC%` / `cmd` and `taskkill /T /F` with a `Process.Kill` fallback.
- On Unix cancellation, sends TERM first for cleanup, waits through a grace period, then kills the process group if descendants remain.

## Stack

- `depot tests split`: https://github.com/depot/cli/pull/528 
- `depot tests report`: https://github.com/depot/cli/pull/530 
- `depot tests run`: https://github.com/depot/cli/pull/531 <- you are here

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New CI workflow surface (split, shell exec, OIDC report upload) and changed standalone exit-code behavior; process-group termination is inherently sensitive but scoped to `tests run` with broad test coverage.
> 
> **Overview**
> Adds **`depot tests run`**, a single CI-oriented flow that optionally shards candidates (timing-balanced via existing split APIs, or all candidates when `--index`/`--total` are omitted), runs a user **`--command`** with selected lines on stdin, then uploads JUnit XML from **`--report-path`**.
> 
> Report upload now supports a **pre-command baseline** so only files created or modified during the run are sent; unchanged or stale XML is rejected with a clear error. Empty shards skip both the test command and upload.
> 
> **Standalone `depot`** now mirrors Docker-plugin error handling: **`cli.StatusError`** drives process exit codes and message printing (with zero normalized to 1), enabled via injectable **`newRootCmd`** for tests.
> 
> **Process execution** is cancellable on SIGINT/SIGTERM: Unix runs **`/bin/sh`** in a process group (TERM grace, then KILL); Windows uses **`taskkill /T`**. User test failures keep their exit code even when report upload fails or is canceled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c79e829bfd4bd73d7011759d27aa0a52c67818eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->