### PR TITLE
Reject empty depot pull build IDs

### DIFF
--- a/pkg/cmd/pull/pull.go
+++ b/pkg/cmd/pull/pull.go
@@ -37,7 +37,7 @@ func NewCmdPull() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pull [flags] [buildID|tag]",
 		Short: "Pull a project's build from the Depot registry",
-		Args:  cli.RequiresMaxArgs(1),
+		Args:  cobra.MatchAll(cli.RequiresMaxArgs(1), requireNonEmptyArg),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			dockerCli, err := dockerclient.NewDockerCLI()
 			if err != nil {
@@ -148,6 +148,13 @@ func NewCmdPull() *cobra.Command {
 	cmd.Flags().StringSliceVar(&targets, "target", nil, "Pulls image for specific bake targets")
 
 	return cmd
+}
+
+func requireNonEmptyArg(_ *cobra.Command, args []string) error {
+	if len(args) == 1 && args[0] == "" {
+		return fmt.Errorf("build ID or tag must not be empty")
+	}
+	return nil
 }
 
 // extractProjectIDAndTag extracts project ID and tag from a registry reference

--- a/pkg/cmd/pull/pull_test.go
+++ b/pkg/cmd/pull/pull_test.go
@@ -5,35 +5,17 @@ import (
 	"testing"
 )
 
-func TestPullArgs(t *testing.T) {
-	tests := []struct {
-		name    string
-		args    []string
-		wantErr string
-	}{
-		{name: "missing"},
-		{name: "empty", args: []string{""}, wantErr: "build ID or tag must not be empty"},
-		{name: "build ID", args: []string{"build-id"}},
-		{name: "whitespace", args: []string{" "}},
-		{name: "too many", args: []string{"build-id", "extra"}, wantErr: "requires at most 1 argument"},
-	}
+func TestPullRejectsEmptyBuildIDBeforeExecution(t *testing.T) {
+	cmd := NewCmdPull()
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{""})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cmd := NewCmdPull()
-			err := cmd.Args(cmd, tt.args)
-			if tt.wantErr == "" {
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				return
-			}
-			if err == nil {
-				t.Fatalf("expected error containing %q", tt.wantErr)
-			}
-			if !strings.Contains(err.Error(), tt.wantErr) {
-				t.Fatalf("unexpected error: %v", err)
-			}
-		})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected an error for an empty build ID")
+	}
+	if !strings.Contains(err.Error(), "build ID or tag must not be empty") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/pkg/cmd/pull/pull_test.go
+++ b/pkg/cmd/pull/pull_test.go
@@ -1,0 +1,39 @@
+package pull
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPullArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{name: "missing"},
+		{name: "empty", args: []string{""}, wantErr: "build ID or tag must not be empty"},
+		{name: "build ID", args: []string{"build-id"}},
+		{name: "whitespace", args: []string{" "}},
+		{name: "too many", args: []string{"build-id", "extra"}, wantErr: "requires at most 1 argument"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := NewCmdPull()
+			err := cmd.Args(cmd, tt.args)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds early CLI argument validation only; no changes to pull, registry, or auth behavior when a valid or missing argument is used.
> 
> **Overview**
> **`depot pull`** now validates the optional positional build ID/tag **before** `RunE` runs, so an explicit empty argument fails immediately instead of continuing into auth, Docker, or API work.
> 
> The command **`Args`** hook combines `RequiresMaxArgs(1)` with new **`requireNonEmptyArg`**, which returns `build ID or tag must not be empty` when exactly one argument is present and it is `""`. Omitting the argument is unchanged (interactive / project selection still happens when `param` is unset).
> 
> A unit test asserts that `depot pull ""` errors with that message and does not succeed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d6f2982bb1d43a91a6b6a0ae619a96708a3eaba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->