### PR TITLE
fix(tests): allow runs without candidates

### DIFF
--- a/pkg/cmd/tests/run.go
+++ b/pkg/cmd/tests/run.go
@@ -39,9 +39,10 @@ func newCmdTestsRun() *cobra.Command {
 		SilenceUsage: true,
 		Long: `Run a test command against the candidates assigned to this shard and upload JUnit XML reports.
 
-Candidates are newline-delimited runnable units read from stdin or --candidates-file. Pass --index and --total to split
-candidates across shards. Depot uses historical test timings to select a balanced shard. If no timings are available for
-filename candidates, Depot falls back to file-size splitting.`,
+Candidates are optional when not splitting. When provided, they are newline-delimited runnable units read from stdin or
+--candidates-file. Pass --index and --total to split candidates across shards; candidates are required when splitting.
+Depot uses historical test timings to select a balanced shard. If no timings are available for filename candidates, Depot
+falls back to file-size splitting.`,
 		Example: `  # Run a timing-balanced shard from stdin candidates
   go list ./... | depot tests run --index 0 --total 4 --command "xargs go test -json | go-junit-report -out reports/junit.xml" --report-path reports/junit.xml
 
@@ -103,7 +104,7 @@ func runTestsRun(cmd *cobra.Command, opts runOptions) error {
 		summaryOpts.total = 1
 	}
 	writeSplitSummary(cmd.ErrOrStderr(), mode, summaryOpts, len(candidates), selectedCandidates, splitResponse)
-	if len(selectedCandidates) == 0 {
+	if splitRequested && len(selectedCandidates) == 0 {
 		fmt.Fprintln(cmd.ErrOrStderr(), "Depot skipped test command because this shard has no candidates.")
 		return nil
 	}
@@ -170,7 +171,7 @@ func selectRunCandidates(cmd *cobra.Command, opts splitOptions) (splitMode, []st
 		if err := validateExplicitSplitIdentityFlags(opts); err != nil {
 			return "", nil, nil, nil, err
 		}
-		candidates, err := loadRequiredCandidates(cmd, opts.candidatesFile)
+		candidates, err := loadOptionalCandidates(cmd, opts.candidatesFile)
 		if err != nil {
 			return "", nil, nil, nil, err
 		}

--- a/pkg/cmd/tests/run_test.go
+++ b/pkg/cmd/tests/run_test.go
@@ -148,6 +148,81 @@ func TestRunWithoutShardFlagsRunsAllCandidatesWithoutSplitting(t *testing.T) {
 	}
 }
 
+func TestRunWithoutShardFlagsRunsWithoutCandidates(t *testing.T) {
+	resetTestHooks(t)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeTempFileAt(t, workspace, "reports/junit.xml", "<testsuite/>")
+	splitTestsFunc = func(context.Context, string, *testresultsv1.SplitTestsRequest) (*testresultsv1.SplitTestsResponse, error) {
+		t.Fatal("SplitTests should not be called without shard flags")
+		return nil, nil
+	}
+
+	var commandCandidates []string
+	runShellCommandFunc = func(_ context.Context, _ string, candidates []string, _ io.Writer, _ io.Writer) (int, error) {
+		commandCandidates = append([]string(nil), candidates...)
+		writeRunReport(t, workspace)
+		return 0, nil
+	}
+	var reported bool
+	reportTestResultsFunc = func(context.Context, string, *testresultsv1.ReportTestResultsRequest) (*testresultsv1.ReportTestResultsResponse, error) {
+		reported = true
+		return &testresultsv1.ReportTestResultsResponse{FilesProcessed: 1}, nil
+	}
+
+	_, stderr, err := executeCommandOutput(
+		"run",
+		"--command", "test-command",
+		"--report-path", "reports/junit.xml",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if commandCandidates != nil {
+		t.Fatalf("expected no command candidates, got %v", commandCandidates)
+	}
+	if !reported {
+		t.Fatal("expected report upload after command")
+	}
+	if !strings.Contains(stderr, "Depot is running against a single shard.") {
+		t.Fatalf("expected no-candidate summary, got %q", stderr)
+	}
+}
+
+func TestRunWithoutShardFlagsRunsWithEmptyPipedCandidates(t *testing.T) {
+	resetTestHooks(t)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeTempFileAt(t, workspace, "reports/junit.xml", "<testsuite/>")
+	splitTestsFunc = func(context.Context, string, *testresultsv1.SplitTestsRequest) (*testresultsv1.SplitTestsResponse, error) {
+		t.Fatal("SplitTests should not be called without shard flags")
+		return nil, nil
+	}
+
+	var commandCandidates []string
+	runShellCommandFunc = func(_ context.Context, _ string, candidates []string, _ io.Writer, _ io.Writer) (int, error) {
+		commandCandidates = append([]string(nil), candidates...)
+		writeRunReport(t, workspace)
+		return 0, nil
+	}
+	reportTestResultsFunc = func(context.Context, string, *testresultsv1.ReportTestResultsRequest) (*testresultsv1.ReportTestResultsResponse, error) {
+		return &testresultsv1.ReportTestResultsResponse{FilesProcessed: 1}, nil
+	}
+
+	_, _, err := executeCommandWithInputOutput(
+		"",
+		"run",
+		"--command", "test-command",
+		"--report-path", "reports/junit.xml",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if commandCandidates != nil {
+		t.Fatalf("expected no command candidates, got %v", commandCandidates)
+	}
+}
+
 func TestRunPreservesRealCommandStdout(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("uses POSIX shell syntax")
@@ -276,6 +351,10 @@ func TestRunReadsCandidatesFile(t *testing.T) {
 	t.Chdir(workspace)
 	candidatesPath := writeTempFileAt(t, workspace, "candidates.txt", "a.test.ts\nb.test.ts\n")
 	writeTempFileAt(t, workspace, "reports/junit.xml", "<testsuite/>")
+	splitTestsFunc = func(context.Context, string, *testresultsv1.SplitTestsRequest) (*testresultsv1.SplitTestsResponse, error) {
+		t.Fatal("SplitTests should not be called without shard flags")
+		return nil, nil
+	}
 
 	var commandCandidates []string
 	runShellCommandFunc = func(_ context.Context, _ string, candidates []string, _ io.Writer, _ io.Writer) (int, error) {
@@ -288,8 +367,6 @@ func TestRunReadsCandidatesFile(t *testing.T) {
 		"ignored.test.ts\n",
 		"run",
 		"--candidates-file", candidatesPath,
-		"--index", "0",
-		"--total", "1",
 		"--command", "test-command",
 		"--report-path", "reports/junit.xml",
 	)

--- a/pkg/cmd/tests/selection.go
+++ b/pkg/cmd/tests/selection.go
@@ -57,15 +57,23 @@ func selectTestCandidates(cmd *cobra.Command, opts splitOptions) (splitMode, []s
 }
 
 func loadRequiredCandidates(cmd *cobra.Command, candidatesFile string) ([]string, error) {
-	if stdin, ok := cmd.InOrStdin().(*os.File); candidatesFile == "" && ok && stdin == os.Stdin && isStdinTerminalFunc() {
+	candidates, err := loadOptionalCandidates(cmd, candidatesFile)
+	if err != nil {
+		return nil, err
+	}
+	if len(candidates) == 0 {
 		return nil, fmt.Errorf("no candidates provided; pipe newline-delimited candidates to stdin or pass --candidates-file")
+	}
+	return candidates, nil
+}
+
+func loadOptionalCandidates(cmd *cobra.Command, candidatesFile string) ([]string, error) {
+	if stdin, ok := cmd.InOrStdin().(*os.File); candidatesFile == "" && ok && stdin == os.Stdin && isStdinTerminalFunc() {
+		return nil, nil
 	}
 	candidates, err := loadCandidates(cmd.InOrStdin(), candidatesFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load candidates: %w", err)
-	}
-	if len(candidates) == 0 {
-		return nil, fmt.Errorf("no candidates provided; pipe newline-delimited candidates to stdin or pass --candidates-file")
 	}
 	return candidates, nil
 }

--- a/pkg/cmd/tests/split.go
+++ b/pkg/cmd/tests/split.go
@@ -110,6 +110,10 @@ func writeCandidates(w io.Writer, candidates []string) error {
 
 func writeSplitSummary(w io.Writer, mode splitMode, opts splitOptions, totalCandidates int, selected []string, resp *testresultsv1.SplitTestsResponse) {
 	if opts.total == 1 {
+		if totalCandidates == 0 {
+			fmt.Fprintln(w, "Depot is running against a single shard.")
+			return
+		}
 		fmt.Fprintf(w, "Depot selected all %d candidate(s) for a single shard.\n", len(selected))
 		return
 	}


### PR DESCRIPTION
## Summary

`depot tests run` can now execute test commands that discover their own tests without a candidate source when sharding is omitted. Sharded invocations still reject missing candidates before the command runs.

- Treat a missing candidate source as empty stdin for no-shard runs.
- Run the command and report upload for no-shard empty candidate lists.
- Preserve the existing candidate requirement for `--index` and `--total`.

## Testing

- `go test ./pkg/cmd/tests`
- Depot CI validation of no-candidate no-shard and 2-shard rejection cases

## Post-Deploy Monitoring & Validation

No additional operational monitoring is required. This is a CLI validation change covered by unit tests and a Depot CI run.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only validation and messaging change with unit tests; sharded behavior and candidate requirements are preserved.
> 
> **Overview**
> **`depot tests run`** no longer requires stdin or `--candidates-file` when **`--index` / `--total` are omitted**. The command still runs **`--command`**, uploads JUnit from **`--report-path`**, and passes empty stdin when there are no candidates—suited to test runners that discover tests themselves.
> 
> **Sharding is unchanged:** with **`--index` and `--total`**, candidates remain required (via **`loadRequiredCandidates`**), and an empty selected shard still skips the test command.
> 
> Candidate loading is split into **`loadOptionalCandidates`** (terminal stdin → empty list; no error on empty) and **`loadRequiredCandidates`** (errors if empty). The early exit that skipped the command on zero candidates now applies only when splitting is requested. **`writeSplitSummary`** prints *"Depot is running against a single shard."* when there are zero candidates on a single-shard run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36969601f4044098eb80676074e77ab821df8548. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->