### PR TITLE
fix(tests): separate split and report keys

### DIFF
--- a/pkg/cmd/tests/run.go
+++ b/pkg/cmd/tests/run.go
@@ -24,6 +24,7 @@ type runOptions struct {
 	timingsType    string
 	index          int
 	total          int
+	splitKey       string
 	command        string
 	reportPaths    []string
 	candidatesFile string
@@ -59,10 +60,11 @@ falls back to file-size splitting.`,
 	flags.StringVar(&opts.timingsType, "timings-type", "", "JUnit timing identity (filename, classname, testname)")
 	flags.IntVar(&opts.index, "index", -1, "Zero-based shard index; pass with --total to split")
 	flags.IntVar(&opts.total, "total", 0, "Total number of shards; pass with --index to split")
+	flags.StringVar(&opts.splitKey, "split-key", "", "Stable test suite key for split timings (defaults to GITHUB_ACTION or default; set when running multiple suites)")
 	flags.StringVar(&opts.command, "command", "", "Shell command that receives selected candidates on stdin (required)")
 	flags.StringArrayVar(&opts.reportPaths, "report-path", nil, "JUnit XML report path, directory, or glob (required, repeatable)")
 	flags.StringVar(&opts.candidatesFile, "candidates-file", "", "Path to newline-delimited runnable test candidates instead of stdin")
-	flags.StringVar(&opts.key, "key", "", "Stable test suite key for split timings and report upload idempotency (defaults to GITHUB_ACTION or default; set when running multiple suites)")
+	flags.StringVar(&opts.key, "key", "", "Report invocation key for idempotent uploads (defaults to GITHUB_ACTION or default)")
 
 	return cmd
 }
@@ -89,7 +91,7 @@ func runTestsRun(cmd *cobra.Command, opts runOptions) error {
 		index:          opts.index,
 		total:          opts.total,
 		candidatesFile: opts.candidatesFile,
-		key:            opts.key,
+		key:            opts.splitKey,
 		output:         splitOutputText,
 	}
 	splitRequested := runSplitRequested(splitOpts)

--- a/pkg/cmd/tests/run_test.go
+++ b/pkg/cmd/tests/run_test.go
@@ -19,7 +19,7 @@ import (
 	testresultsv1 "github.com/depot/cli/pkg/proto/depot/testresults/v1"
 )
 
-func TestRunDefaultsToTimingSplitAndReportsWithKey(t *testing.T) {
+func TestRunUsesIndependentSplitAndReportKeys(t *testing.T) {
 	resetTestHooks(t)
 	workspace := t.TempDir()
 	t.Chdir(workspace)
@@ -66,7 +66,8 @@ func TestRunDefaultsToTimingSplitAndReportsWithKey(t *testing.T) {
 		"run",
 		"--candidate-type", "filename",
 		"--timings-type", "testname",
-		"--key", "unit",
+		"--split-key", "unit-history",
+		"--key", "unit-report",
 		"--index", "1",
 		"--total", "2",
 		"--command", "test-command",
@@ -94,14 +95,14 @@ func TestRunDefaultsToTimingSplitAndReportsWithKey(t *testing.T) {
 	if splitReq.GetTimingIdentity() != testresultsv1.TestTimingIdentity_TEST_TIMING_IDENTITY_TESTNAME {
 		t.Fatalf("expected testname timing identity, got %v", splitReq.GetTimingIdentity())
 	}
-	if splitReq.GetSplitKey() != "unit" {
-		t.Fatalf("expected split key unit, got %q", splitReq.GetSplitKey())
+	if splitReq.GetSplitKey() != "unit-history" {
+		t.Fatalf("expected split key unit-history, got %q", splitReq.GetSplitKey())
 	}
 	if !equalStrings(commandCandidates, []string{"b.test.ts"}) {
 		t.Fatalf("expected selected command candidate, got %v", commandCandidates)
 	}
-	if reportReq == nil || reportReq.GetInvocationId() != "unit" || len(reportReq.GetFiles()) != 1 {
-		t.Fatalf("expected report upload with unit key, got %#v", reportReq)
+	if reportReq == nil || reportReq.GetInvocationId() != "unit-report" || len(reportReq.GetFiles()) != 1 {
+		t.Fatalf("expected report upload with unit-report key, got %#v", reportReq)
 	}
 }
 

--- a/pkg/cmd/tests/run_test.go
+++ b/pkg/cmd/tests/run_test.go
@@ -106,6 +106,72 @@ func TestRunUsesIndependentSplitAndReportKeys(t *testing.T) {
 	}
 }
 
+func TestRunUsesDefaultsForOmittedKeys(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		keyArgs    []string
+		wantSplit  string
+		wantReport string
+	}{
+		{
+			name:       "split key only",
+			keyArgs:    []string{"--split-key", "unit-history"},
+			wantSplit:  "unit-history",
+			wantReport: "test-action",
+		},
+		{
+			name:       "report key only",
+			keyArgs:    []string{"--key", "unit-report"},
+			wantSplit:  "test-action",
+			wantReport: "unit-report",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			resetTestHooks(t)
+			t.Setenv("GITHUB_ACTION", "test-action")
+			workspace := t.TempDir()
+			t.Chdir(workspace)
+			writeTempFileAt(t, workspace, "reports/junit.xml", "<testsuite/>")
+			resolveOIDCCredentialFunc = func(context.Context) (string, error) { return "oidc-token", nil }
+
+			var splitReq *testresultsv1.SplitTestsRequest
+			splitTestsFunc = func(_ context.Context, _ string, req *testresultsv1.SplitTestsRequest) (*testresultsv1.SplitTestsResponse, error) {
+				splitReq = req
+				return &testresultsv1.SplitTestsResponse{Candidates: []string{"a.test.ts"}, CandidatesWithTimings: 1}, nil
+			}
+			runShellCommandFunc = func(_ context.Context, _ string, _ []string, _ io.Writer, _ io.Writer) (int, error) {
+				writeRunReport(t, workspace)
+				return 0, nil
+			}
+
+			var reportReq *testresultsv1.ReportTestResultsRequest
+			reportTestResultsFunc = func(_ context.Context, _ string, req *testresultsv1.ReportTestResultsRequest) (*testresultsv1.ReportTestResultsResponse, error) {
+				reportReq = req
+				return &testresultsv1.ReportTestResultsResponse{FilesProcessed: 1}, nil
+			}
+
+			args := []string{
+				"run",
+				"--index", "0",
+				"--total", "2",
+				"--command", "test-command",
+				"--report-path", "reports/junit.xml",
+			}
+			args = append(args, tt.keyArgs...)
+			_, _, err := executeCommandWithInputOutput("a.test.ts\n", args...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if splitReq == nil || splitReq.GetSplitKey() != tt.wantSplit {
+				t.Fatalf("expected split key %q, got %#v", tt.wantSplit, splitReq)
+			}
+			if reportReq == nil || reportReq.GetInvocationId() != tt.wantReport {
+				t.Fatalf("expected report key %q, got %#v", tt.wantReport, reportReq)
+			}
+		})
+	}
+}
+
 func TestRunWithoutShardFlagsRunsAllCandidatesWithoutSplitting(t *testing.T) {
 	resetTestHooks(t)
 	workspace := t.TempDir()

--- a/pkg/cmd/tests/run_test.go
+++ b/pkg/cmd/tests/run_test.go
@@ -125,6 +125,11 @@ func TestRunUsesDefaultsForOmittedKeys(t *testing.T) {
 			wantSplit:  "test-action",
 			wantReport: "unit-report",
 		},
+		{
+			name:       "no keys",
+			wantSplit:  "test-action",
+			wantReport: "test-action",
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			resetTestHooks(t)


### PR DESCRIPTION
## Summary

Test workflows can now reuse timing history independently from report upload idempotency. `depot tests run --split-key` selects the split history, while `--key` identifies the report upload.

| Input | Purpose |
| --- | --- |
| `--split-key` | Stable identity for timing-based shard selection |
| `--key` | Report invocation identity for idempotent uploads |

Existing workflows that used `--key` to select split history should move that value to `--split-key`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking CLI contract for existing `depot tests run` workflows that relied on `--key` for split history; behavior is otherwise localized to flag wiring with solid test coverage.
> 
> **Overview**
> **`depot tests run` now uses two independent keys** instead of routing a single `--key` to both timing splits and report uploads.
> 
> A new **`--split-key`** flag drives historical timing / shard selection (`SplitTestsRequest.split_key`). **`--key`** is limited to the report upload invocation id (`ReportTestResultsRequest.invocation_id`). Each flag still defaults to `GITHUB_ACTION` (or the same fallback) when omitted, so omitting both keeps prior “one default for everything” behavior; setting only one flag leaves the other on that default.
> 
> **Migration:** workflows that passed `--key` mainly to pick split history should move that value to **`--split-key`**.
> 
> Tests assert independent keys when both are set and add cases for split-only, report-only, and neither flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit beb30c511a4511111e2a3bf562b73aae809b4bff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->