### PR TITLE
feat(tests): add command-based candidate sources

### DIFF
--- a/pkg/cmd/tests/candidates.go
+++ b/pkg/cmd/tests/candidates.go
@@ -2,12 +2,21 @@ package tests
 
 import (
 	"bufio"
+	"bytes"
+	"context"
+	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"strings"
 )
 
-func loadCandidates(r io.Reader, candidatesFile string) ([]string, error) {
+var runCandidatesCommandFunc = runCandidatesCommand
+
+func loadCandidates(ctx context.Context, r io.Reader, candidatesFile, candidatesCommand string, stderr io.Writer) ([]string, error) {
+	if candidatesFile != "" && candidatesCommand != "" {
+		return nil, fmt.Errorf("--candidates-file and --candidates-command are mutually exclusive")
+	}
 	if candidatesFile != "" {
 		file, err := os.Open(candidatesFile)
 		if err != nil {
@@ -16,8 +25,24 @@ func loadCandidates(r io.Reader, candidatesFile string) ([]string, error) {
 		defer file.Close()
 		return readCandidates(file)
 	}
+	if candidatesCommand != "" {
+		var stdout bytes.Buffer
+		if err := runCandidatesCommandFunc(ctx, candidatesCommand, &stdout, stderr); err != nil {
+			return nil, fmt.Errorf("candidate command failed: %w", err)
+		}
+		return readCandidates(&stdout)
+	}
 
 	return readCandidates(r)
+}
+
+func runCandidatesCommand(ctx context.Context, command string, stdout, stderr io.Writer) error {
+	shell, args := shellCommand(command)
+	subCmd := exec.Command(shell, args...)
+	configureShellCommand(subCmd)
+	subCmd.Stdout = stdout
+	subCmd.Stderr = stderr
+	return runCancellableShellCommand(ctx, subCmd)
 }
 
 func readCandidates(r io.Reader) ([]string, error) {

--- a/pkg/cmd/tests/candidates_test.go
+++ b/pkg/cmd/tests/candidates_test.go
@@ -1,14 +1,18 @@
 package tests
 
 import (
+	"context"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
 
 func TestLoadCandidatesReadsFromStdin(t *testing.T) {
-	candidates, err := loadCandidates(strings.NewReader(" a.test.ts \n\nb.test.ts\r\n"), "")
+	candidates, err := loadCandidates(context.Background(), strings.NewReader(" a.test.ts \n\nb.test.ts\r\n"), "", "", io.Discard)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,10 +48,10 @@ func equalStrings(left, right []string) bool {
 	return true
 }
 
-func TestLoadCandidatesFileTakesPrecedence(t *testing.T) {
+func TestLoadCandidatesReadsFile(t *testing.T) {
 	path := writeTempFile(t, "tests.txt", "from-file\n")
 
-	candidates, err := loadCandidates(strings.NewReader("from-stdin\n"), path)
+	candidates, err := loadCandidates(context.Background(), strings.NewReader(""), path, "", io.Discard)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,5 +59,65 @@ func TestLoadCandidatesFileTakesPrecedence(t *testing.T) {
 	want := []string{"from-file"}
 	if !equalStrings(candidates, want) {
 		t.Fatalf("expected candidates %v, got %v", want, candidates)
+	}
+}
+
+func TestLoadCandidatesReadsCommandStdout(t *testing.T) {
+	previous := runCandidatesCommandFunc
+	runCandidatesCommandFunc = func(_ context.Context, command string, stdout, stderr io.Writer) error {
+		if command != "discover-tests" {
+			t.Fatalf("expected command %q, got %q", "discover-tests", command)
+		}
+		_, _ = io.WriteString(stdout, " a.test.ts \n\nb.test.ts\r\n")
+		return nil
+	}
+	t.Cleanup(func() { runCandidatesCommandFunc = previous })
+
+	candidates, err := loadCandidates(context.Background(), strings.NewReader(""), "", "discover-tests", io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"a.test.ts", "b.test.ts"}; !equalStrings(candidates, want) {
+		t.Fatalf("expected candidates %v, got %v", want, candidates)
+	}
+}
+
+func TestLoadCandidatesDoesNotUseCommandOutputAfterFailure(t *testing.T) {
+	previous := runCandidatesCommandFunc
+	runCandidatesCommandFunc = func(_ context.Context, _ string, stdout, stderr io.Writer) error {
+		_, _ = io.WriteString(stdout, "partial.test.ts\n")
+		_, _ = io.WriteString(stderr, "discovery failed\n")
+		return errors.New("exit status 1")
+	}
+	t.Cleanup(func() { runCandidatesCommandFunc = previous })
+
+	var stderr strings.Builder
+	candidates, err := loadCandidates(context.Background(), strings.NewReader(""), "", "discover-tests", &stderr)
+	if err == nil || !strings.Contains(err.Error(), "candidate command failed") {
+		t.Fatalf("expected candidate command failure, got candidates %v and error %v", candidates, err)
+	}
+	if candidates != nil {
+		t.Fatalf("expected no partial candidates, got %v", candidates)
+	}
+	if stderr.String() != "discovery failed\n" {
+		t.Fatalf("expected command stderr, got %q", stderr.String())
+	}
+}
+
+func TestRunCandidatesCommandForwardsStderr(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX shell utilities")
+	}
+
+	var stdout, stderr strings.Builder
+	err := runCandidatesCommand(context.Background(), "printf 'a.test.ts\\n'; printf 'discovery diagnostic\\n' >&2", &stdout, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stdout.String() != "a.test.ts\n" {
+		t.Fatalf("expected command stdout, got %q", stdout.String())
+	}
+	if stderr.String() != "discovery diagnostic\n" {
+		t.Fatalf("expected command stderr, got %q", stderr.String())
 	}
 }

--- a/pkg/cmd/tests/run.go
+++ b/pkg/cmd/tests/run.go
@@ -20,15 +20,16 @@ import (
 var runShellCommandFunc = runShellCommand
 
 type runOptions struct {
-	candidateType  string
-	timingsType    string
-	index          int
-	total          int
-	splitKey       string
-	command        string
-	reportPaths    []string
-	candidatesFile string
-	key            string
+	candidateType     string
+	timingsType       string
+	index             int
+	total             int
+	splitKey          string
+	command           string
+	reportPaths       []string
+	candidatesFile    string
+	candidatesCommand string
+	key               string
 }
 
 func newCmdTestsRun() *cobra.Command {
@@ -40,15 +41,19 @@ func newCmdTestsRun() *cobra.Command {
 		SilenceUsage: true,
 		Long: `Run a test command against the candidates assigned to this shard and upload JUnit XML reports.
 
-Candidates are optional when not splitting. When provided, they are newline-delimited runnable units read from stdin or
---candidates-file. Pass --index and --total to split candidates across shards; candidates are required when splitting.
+Candidates are optional when not splitting. When provided, they are newline-delimited runnable units read from stdin,
+--candidates-file, or --candidates-command. Provide at most one source. Pass --index and --total to split candidates
+across shards; candidates are required when splitting.
 Depot uses historical test timings to select a balanced shard. If no timings are available for filename candidates, Depot
 falls back to file-size splitting.`,
 		Example: `  # Run a timing-balanced shard from stdin candidates
   go list ./... | depot tests run --index 0 --total 4 --command "xargs go test -json | go-junit-report -out reports/junit.xml" --report-path reports/junit.xml
 
   # Run with an explicit candidates file
-  depot tests run --candidates-file tests.txt --index 0 --total 4 --command "xargs npm test -- --reporter junit --reporter-options output=reports/junit.xml" --report-path "reports/*.xml"`,
+  depot tests run --candidates-file tests.txt --index 0 --total 4 --command "xargs npm test -- --reporter junit --reporter-options output=reports/junit.xml" --report-path "reports/*.xml"
+
+  # Discover candidates with a command
+  depot tests run --candidates-command "go list ./..." --index 0 --total 4 --command "xargs go test -json | go-junit-report -out reports/junit.xml" --report-path reports/junit.xml`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runTestsRun(cmd, opts)
@@ -64,6 +69,7 @@ falls back to file-size splitting.`,
 	flags.StringVar(&opts.command, "command", "", "Shell command that receives selected candidates on stdin (required)")
 	flags.StringArrayVar(&opts.reportPaths, "report-path", nil, "JUnit XML report path, directory, or glob (required, repeatable)")
 	flags.StringVar(&opts.candidatesFile, "candidates-file", "", "Path to newline-delimited runnable test candidates instead of stdin")
+	flags.StringVar(&opts.candidatesCommand, "candidates-command", "", "Shell command that prints newline-delimited runnable test candidates")
 	flags.StringVar(&opts.key, "key", "", "Report invocation key for idempotent uploads (defaults to GITHUB_ACTION or default)")
 
 	return cmd
@@ -86,13 +92,14 @@ func runTestsRun(cmd *cobra.Command, opts runOptions) error {
 	}
 
 	splitOpts := splitOptions{
-		candidateType:  opts.candidateType,
-		timingsType:    opts.timingsType,
-		index:          opts.index,
-		total:          opts.total,
-		candidatesFile: opts.candidatesFile,
-		key:            opts.splitKey,
-		output:         splitOutputText,
+		candidateType:     opts.candidateType,
+		timingsType:       opts.timingsType,
+		index:             opts.index,
+		total:             opts.total,
+		candidatesFile:    opts.candidatesFile,
+		candidatesCommand: opts.candidatesCommand,
+		key:               opts.splitKey,
+		output:            splitOutputText,
 	}
 	splitRequested := runSplitRequested(splitOpts)
 	mode, candidates, selectedCandidates, splitResponse, err := selectRunCandidates(cmd, splitOpts)
@@ -173,7 +180,7 @@ func selectRunCandidates(cmd *cobra.Command, opts splitOptions) (splitMode, []st
 		if err := validateExplicitSplitIdentityFlags(opts); err != nil {
 			return "", nil, nil, nil, err
 		}
-		candidates, err := loadOptionalCandidates(cmd, opts.candidatesFile)
+		candidates, err := loadOptionalCandidates(cmd, opts.candidatesFile, opts.candidatesCommand)
 		if err != nil {
 			return "", nil, nil, nil, err
 		}

--- a/pkg/cmd/tests/run_test.go
+++ b/pkg/cmd/tests/run_test.go
@@ -436,7 +436,7 @@ func TestRunReadsCandidatesFile(t *testing.T) {
 	}
 
 	_, _, err := executeCommandWithInputOutput(
-		"ignored.test.ts\n",
+		"",
 		"run",
 		"--candidates-file", candidatesPath,
 		"--command", "test-command",
@@ -447,6 +447,74 @@ func TestRunReadsCandidatesFile(t *testing.T) {
 	}
 	if !equalStrings(commandCandidates, []string{"a.test.ts", "b.test.ts"}) {
 		t.Fatalf("expected candidates file to drive command stdin, got %v", commandCandidates)
+	}
+}
+
+func TestRunReadsCandidatesCommand(t *testing.T) {
+	resetTestHooks(t)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeTempFileAt(t, workspace, "reports/junit.xml", "<testsuite/>")
+	runCandidatesCommandFunc = func(_ context.Context, command string, stdout, _ io.Writer) error {
+		if command != "discover-tests" {
+			t.Fatalf("expected candidate command %q, got %q", "discover-tests", command)
+		}
+		_, _ = io.WriteString(stdout, "a.test.ts\nb.test.ts\n")
+		return nil
+	}
+
+	var commandCandidates []string
+	runShellCommandFunc = func(_ context.Context, _ string, candidates []string, _ io.Writer, _ io.Writer) (int, error) {
+		commandCandidates = append([]string(nil), candidates...)
+		writeRunReport(t, workspace)
+		return 0, nil
+	}
+
+	_, _, err := executeCommandWithInputOutput(
+		"",
+		"run",
+		"--candidates-command", "discover-tests",
+		"--index", "0",
+		"--total", "1",
+		"--command", "test-command",
+		"--report-path", "reports/junit.xml",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !equalStrings(commandCandidates, []string{"a.test.ts", "b.test.ts"}) {
+		t.Fatalf("expected command candidates, got %v", commandCandidates)
+	}
+}
+
+func TestRunCandidatesCommandFailureDoesNotRunTestsOrUploadReports(t *testing.T) {
+	resetTestHooks(t)
+	runCandidatesCommandFunc = func(_ context.Context, _ string, stdout, stderr io.Writer) error {
+		_, _ = io.WriteString(stdout, "partial.test.ts\n")
+		_, _ = io.WriteString(stderr, "discovery failed\n")
+		return errors.New("exit status 1")
+	}
+	runShellCommandFunc = func(context.Context, string, []string, io.Writer, io.Writer) (int, error) {
+		t.Fatal("test command should not run after candidate command failure")
+		return 0, nil
+	}
+	reportTestResultsFunc = func(context.Context, string, *testresultsv1.ReportTestResultsRequest) (*testresultsv1.ReportTestResultsResponse, error) {
+		t.Fatal("report upload should not run after candidate command failure")
+		return nil, nil
+	}
+
+	_, stderr, err := executeCommandWithInputOutput(
+		"",
+		"run",
+		"--candidates-command", "discover-tests",
+		"--command", "test-command",
+		"--report-path", "reports/junit.xml",
+	)
+	if err == nil || !strings.Contains(err.Error(), "candidate command failed") {
+		t.Fatalf("expected candidate command failure, got %v", err)
+	}
+	if !strings.Contains(stderr, "discovery failed") {
+		t.Fatalf("expected candidate command stderr, got %q", stderr)
 	}
 }
 

--- a/pkg/cmd/tests/selection.go
+++ b/pkg/cmd/tests/selection.go
@@ -28,7 +28,7 @@ func selectTestCandidates(cmd *cobra.Command, opts splitOptions) (splitMode, []s
 	if err := validateExplicitSplitIdentityFlags(opts); err != nil {
 		return "", nil, nil, nil, err
 	}
-	candidates, err := loadRequiredCandidates(cmd, opts.candidatesFile)
+	candidates, err := loadRequiredCandidates(cmd, opts.candidatesFile, opts.candidatesCommand)
 	if err != nil {
 		return "", nil, nil, nil, err
 	}
@@ -56,22 +56,49 @@ func selectTestCandidates(cmd *cobra.Command, opts splitOptions) (splitMode, []s
 	return mode, candidates, selectedCandidates, splitResponse, nil
 }
 
-func loadRequiredCandidates(cmd *cobra.Command, candidatesFile string) ([]string, error) {
-	candidates, err := loadOptionalCandidates(cmd, candidatesFile)
+func loadRequiredCandidates(cmd *cobra.Command, candidatesFile, candidatesCommand string) ([]string, error) {
+	candidates, err := loadOptionalCandidates(cmd, candidatesFile, candidatesCommand)
 	if err != nil {
 		return nil, err
 	}
 	if len(candidates) == 0 {
-		return nil, fmt.Errorf("no candidates provided; pipe newline-delimited candidates to stdin or pass --candidates-file")
+		return nil, fmt.Errorf("no candidates provided; pipe newline-delimited candidates to stdin or pass --candidates-file or --candidates-command")
 	}
 	return candidates, nil
 }
 
-func loadOptionalCandidates(cmd *cobra.Command, candidatesFile string) ([]string, error) {
-	if stdin, ok := cmd.InOrStdin().(*os.File); candidatesFile == "" && ok && stdin == os.Stdin && isStdinTerminalFunc() {
-		return nil, nil
+func loadOptionalCandidates(cmd *cobra.Command, candidatesFile, candidatesCommand string) ([]string, error) {
+	if candidatesFile != "" && candidatesCommand != "" {
+		return nil, fmt.Errorf("--candidates-file and --candidates-command are mutually exclusive")
 	}
-	candidates, err := loadCandidates(cmd.InOrStdin(), candidatesFile)
+
+	stdin := cmd.InOrStdin()
+	stdinIsTerminal := false
+	if file, ok := stdin.(*os.File); ok && file == os.Stdin {
+		stdinIsTerminal = isStdinTerminalFunc()
+	}
+	if stdinIsTerminal {
+		if candidatesFile == "" && candidatesCommand == "" {
+			return nil, nil
+		}
+		candidates, err := loadCandidates(cmd.Context(), stdin, candidatesFile, candidatesCommand, cmd.ErrOrStderr())
+		if err != nil {
+			return nil, fmt.Errorf("failed to load candidates: %w", err)
+		}
+		return candidates, nil
+	}
+
+	stdinCandidates, err := readCandidates(stdin)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load candidates: %w", err)
+	}
+	if len(stdinCandidates) > 0 && (candidatesFile != "" || candidatesCommand != "") {
+		return nil, fmt.Errorf("stdin, --candidates-file, and --candidates-command are mutually exclusive")
+	}
+	if candidatesFile == "" && candidatesCommand == "" {
+		return stdinCandidates, nil
+	}
+	candidates, err := loadCandidates(cmd.Context(), stdin, candidatesFile, candidatesCommand, cmd.ErrOrStderr())
 	if err != nil {
 		return nil, fmt.Errorf("failed to load candidates: %w", err)
 	}

--- a/pkg/cmd/tests/split.go
+++ b/pkg/cmd/tests/split.go
@@ -25,13 +25,14 @@ type splitOutput struct {
 }
 
 type splitOptions struct {
-	candidateType  string
-	timingsType    string
-	index          int
-	total          int
-	candidatesFile string
-	key            string
-	output         string
+	candidateType     string
+	timingsType       string
+	index             int
+	total             int
+	candidatesFile    string
+	candidatesCommand string
+	key               string
+	output            string
 }
 
 func newCmdTestsSplit() *cobra.Command {
@@ -43,14 +44,17 @@ func newCmdTestsSplit() *cobra.Command {
 		SilenceUsage: true,
 		Long: `Print the candidates assigned to this shard without running tests or uploading reports.
 
-Candidates are newline-delimited runnable units read from stdin or --candidates-file. By default, Depot uses historical test
-timings to select a balanced shard. If no timings are available for filename candidates, Depot falls back to file-size
-splitting.`,
+Candidates are newline-delimited runnable units read from stdin, --candidates-file, or --candidates-command. Provide at
+most one source. By default, Depot uses historical test timings to select a balanced shard. If no timings are available for
+filename candidates, Depot falls back to file-size splitting.`,
 		Example: `  # Print a timing-balanced shard from stdin candidates
   go list ./... | depot tests split --index 0 --total 4 --candidate-type classname
 
   # Print a shard from an explicit candidates file
-  depot tests split --candidates-file tests.txt --index 0 --total 4 --candidate-type filename`,
+  depot tests split --candidates-file tests.txt --index 0 --total 4 --candidate-type filename
+
+  # Discover candidates with a command
+  depot tests split --candidates-command "go list ./..." --index 0 --total 4 --candidate-type classname`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runTestsSplit(cmd, opts)
@@ -64,6 +68,7 @@ splitting.`,
 	flags.IntVar(&opts.total, "total", 0, "Total number of shards")
 	flags.StringVar(&opts.key, "key", "", "Test key")
 	flags.StringVar(&opts.candidatesFile, "candidates-file", "", "Path to newline-delimited runnable test candidates instead of stdin")
+	flags.StringVar(&opts.candidatesCommand, "candidates-command", "", "Shell command that prints newline-delimited runnable test candidates")
 	flags.StringVar(&opts.output, "output", splitOutputText, "Output format (text, json)")
 
 	return cmd

--- a/pkg/cmd/tests/split_test.go
+++ b/pkg/cmd/tests/split_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -431,7 +432,7 @@ func TestSplitReadsCandidatesFile(t *testing.T) {
 	}
 
 	stdout, _, err := executeCommandWithInputOutput(
-		"ignored.test.ts\n",
+		"",
 		"split",
 		"--candidates-file", candidatesPath,
 		"--index", "0",
@@ -442,6 +443,131 @@ func TestSplitReadsCandidatesFile(t *testing.T) {
 	}
 	if stdout != "a.test.ts\nb.test.ts\n" {
 		t.Fatalf("expected candidates file to be used, got %q", stdout)
+	}
+}
+
+func TestSplitReadsCandidatesCommand(t *testing.T) {
+	resetTestHooks(t)
+	runCandidatesCommandFunc = func(_ context.Context, command string, stdout, _ io.Writer) error {
+		if command != "discover-tests" {
+			t.Fatalf("expected candidate command %q, got %q", "discover-tests", command)
+		}
+		_, _ = io.WriteString(stdout, "a.test.ts\nb.test.ts\n")
+		return nil
+	}
+	resolveOIDCCredentialFunc = func(context.Context) (string, error) {
+		t.Fatal("single-shard split should not need OIDC")
+		return "", nil
+	}
+
+	stdout, _, err := executeCommandWithInputOutput(
+		"",
+		"split",
+		"--candidates-command", "discover-tests",
+		"--index", "0",
+		"--total", "1",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stdout != "a.test.ts\nb.test.ts\n" {
+		t.Fatalf("expected candidates command output, got %q", stdout)
+	}
+}
+
+func TestSplitRejectsPipedCandidatesWithCandidatesCommand(t *testing.T) {
+	resetTestHooks(t)
+	runCandidatesCommandFunc = func(context.Context, string, io.Writer, io.Writer) error {
+		t.Fatal("candidate command should not run for ambiguous sources")
+		return nil
+	}
+	resolveOIDCCredentialFunc = func(context.Context) (string, error) {
+		t.Fatal("ambiguous sources should not need OIDC")
+		return "", nil
+	}
+
+	_, _, err := executeCommandWithInputOutput(
+		"piped.test.ts\n",
+		"split",
+		"--candidates-command", "discover-tests",
+		"--index", "0",
+		"--total", "1",
+	)
+	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("expected source conflict, got %v", err)
+	}
+}
+
+func TestSplitRejectsAmbiguousCandidateSources(t *testing.T) {
+	candidatesPath := writeTempFile(t, "candidates.txt", "from-file.test.ts\n")
+	tests := []struct {
+		name  string
+		input string
+		args  []string
+	}{
+		{
+			name:  "stdin and file",
+			input: "from-stdin.test.ts\n",
+			args:  []string{"split", "--candidates-file", candidatesPath, "--index", "0", "--total", "1"},
+		},
+		{
+			name: "file and command",
+			args: []string{
+				"split", "--candidates-file", candidatesPath, "--candidates-command", "discover-tests", "--index", "0", "--total", "1",
+			},
+		},
+		{
+			name:  "stdin file and command",
+			input: "from-stdin.test.ts\n",
+			args: []string{
+				"split", "--candidates-file", candidatesPath, "--candidates-command", "discover-tests", "--index", "0", "--total", "1",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetTestHooks(t)
+			runCandidatesCommandFunc = func(context.Context, string, io.Writer, io.Writer) error {
+				t.Fatal("candidate command should not run for ambiguous sources")
+				return nil
+			}
+			resolveOIDCCredentialFunc = func(context.Context) (string, error) {
+				t.Fatal("ambiguous sources should not need OIDC")
+				return "", nil
+			}
+
+			_, _, err := executeCommandWithInputOutput(tt.input, tt.args...)
+			if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+				t.Fatalf("expected source conflict, got %v", err)
+			}
+		})
+	}
+}
+
+func TestSplitCandidatesCommandFailureDoesNotUseOIDCOrAPI(t *testing.T) {
+	resetTestHooks(t)
+	runCandidatesCommandFunc = func(context.Context, string, io.Writer, io.Writer) error {
+		return errors.New("exit status 1")
+	}
+	resolveOIDCCredentialFunc = func(context.Context) (string, error) {
+		t.Fatal("candidate command failure should not need OIDC")
+		return "", nil
+	}
+	splitTestsFunc = func(context.Context, string, *testresultsv1.SplitTestsRequest) (*testresultsv1.SplitTestsResponse, error) {
+		t.Fatal("candidate command failure should not call SplitTests")
+		return nil, nil
+	}
+
+	_, _, err := executeCommandWithInputOutput(
+		"",
+		"split",
+		"--candidates-command", "discover-tests",
+		"--index", "0",
+		"--total", "2",
+	)
+	if err == nil || !strings.Contains(err.Error(), "candidate command failed") {
+		t.Fatalf("expected candidate command failure, got %v", err)
 	}
 }
 
@@ -457,7 +583,7 @@ func TestSplitCandidatesFileFailureDoesNotUseStdinOrAPI(t *testing.T) {
 	}
 
 	stdout, _, err := executeCommandWithInputOutput(
-		"ignored.test.ts\n",
+		"",
 		"split",
 		"--candidates-file", "missing-candidates.txt",
 		"--index", "0",

--- a/pkg/cmd/tests/tests_test.go
+++ b/pkg/cmd/tests/tests_test.go
@@ -525,6 +525,7 @@ func resetTestHooks(t *testing.T) {
 	runShellCommandFunc = func(context.Context, string, []string, io.Writer, io.Writer) (int, error) {
 		return 0, nil
 	}
+	runCandidatesCommandFunc = runCandidatesCommand
 	isTerminalFunc = func() bool {
 		return true
 	}
@@ -543,6 +544,7 @@ func resetTestHooks(t *testing.T) {
 		splitTestsFunc = apiSplitTests
 		resolveOIDCCredentialFunc = testsResolveOIDCCredential
 		runShellCommandFunc = testsRunShellCommand
+		runCandidatesCommandFunc = testsRunCandidatesCommand
 		isTerminalFunc = helpersIsTerminal
 		isStdinTerminalFunc = helpersIsStdinTerminal
 		oidcDebugWriter = defaultOIDCDebugWriter
@@ -571,6 +573,7 @@ var (
 	apiSplitTests              = splitTestsFunc
 	testsResolveOIDCCredential = resolveOIDCCredentialFunc
 	testsRunShellCommand       = runShellCommandFunc
+	testsRunCandidatesCommand  = runCandidatesCommandFunc
 	helpersIsTerminal          = isTerminalFunc
 	helpersIsStdinTerminal     = isStdinTerminalFunc
 	defaultOIDCDebugWriter     = oidcDebugWriter


### PR DESCRIPTION
## Summary

`depot tests split` and `depot tests run` can now discover newline-delimited candidates with `--candidates-command`, eliminating the need to pipe or materialize a candidate file.

The CLI rejects ambiguous stdin, file, and command source combinations before command execution or timing lookup. Candidate-command stderr remains visible as diagnostics, and failed discovery never starts tests or uploads reports.

## What changed

- Added `--candidates-command` to both test commands and their help text.
- Reused the platform-aware shell execution path to load command stdout as candidates.
- Preserved optional empty candidates for unsharded `tests run`.
- Added coverage for command output, failures, every source collision, and command stdout/stderr separation.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only input plumbing with clear validation and extensive tests; no auth or server contract changes beyond existing split/run flows.
> 
> **Overview**
> Adds **`--candidates-command`** to `depot tests split` and `depot tests run` so newline-delimited candidates can come from a shell discovery command (e.g. `go list ./...`) instead of stdin or `--candidates-file`.
> 
> Candidate loading now runs that command through the same **platform shell path** as the test command, parses stdout, and **forwards stderr** for CI diagnostics. **stdin, file, and command sources are mutually exclusive** (validated before split/OIDC or test execution). A failed discovery returns an error with **no partial candidates**; `tests run` will not run the test command or upload reports, and `tests split` will not call OIDC/`SplitTests`.
> 
> Help text and error messages mention the new flag; optional empty candidates for unsharded `tests run` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c0f49eb549005ea3579f5c01be94343b3df7cbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->