### PR TITLE
fix(tests): scope default split keys by GitHub job

### DIFF
--- a/pkg/cmd/tests/run.go
+++ b/pkg/cmd/tests/run.go
@@ -65,7 +65,7 @@ falls back to file-size splitting.`,
 	flags.StringVar(&opts.timingsType, "timings-type", "", "JUnit timing identity (filename, classname, testname)")
 	flags.IntVar(&opts.index, "index", -1, "Zero-based shard index; pass with --total to split")
 	flags.IntVar(&opts.total, "total", 0, "Total number of shards; pass with --index to split")
-	flags.StringVar(&opts.splitKey, "split-key", "", "Stable test suite key for split timings (defaults to GITHUB_JOB:GITHUB_ACTION or default; set when running multiple suites)")
+	flags.StringVar(&opts.splitKey, "split-key", "", "Stable test suite key for split timings (defaults to the GitHub job/action identity or default; set when running multiple suites)")
 	flags.StringVar(&opts.command, "command", "", "Shell command that receives selected candidates on stdin (required)")
 	flags.StringArrayVar(&opts.reportPaths, "report-path", nil, "JUnit XML report path, directory, or glob (required, repeatable)")
 	flags.StringVar(&opts.candidatesFile, "candidates-file", "", "Path to newline-delimited runnable test candidates instead of stdin")

--- a/pkg/cmd/tests/run.go
+++ b/pkg/cmd/tests/run.go
@@ -65,7 +65,7 @@ falls back to file-size splitting.`,
 	flags.StringVar(&opts.timingsType, "timings-type", "", "JUnit timing identity (filename, classname, testname)")
 	flags.IntVar(&opts.index, "index", -1, "Zero-based shard index; pass with --total to split")
 	flags.IntVar(&opts.total, "total", 0, "Total number of shards; pass with --index to split")
-	flags.StringVar(&opts.splitKey, "split-key", "", "Stable test suite key for split timings (defaults to GITHUB_ACTION or default; set when running multiple suites)")
+	flags.StringVar(&opts.splitKey, "split-key", "", "Stable test suite key for split timings (defaults to GITHUB_JOB:GITHUB_ACTION or default; set when running multiple suites)")
 	flags.StringVar(&opts.command, "command", "", "Shell command that receives selected candidates on stdin (required)")
 	flags.StringArrayVar(&opts.reportPaths, "report-path", nil, "JUnit XML report path, directory, or glob (required, repeatable)")
 	flags.StringVar(&opts.candidatesFile, "candidates-file", "", "Path to newline-delimited runnable test candidates instead of stdin")

--- a/pkg/cmd/tests/run_test.go
+++ b/pkg/cmd/tests/run_test.go
@@ -122,17 +122,18 @@ func TestRunUsesDefaultsForOmittedKeys(t *testing.T) {
 		{
 			name:       "report key only",
 			keyArgs:    []string{"--key", "unit-report"},
-			wantSplit:  "test-action",
+			wantSplit:  "test-job:test-action",
 			wantReport: "unit-report",
 		},
 		{
 			name:       "no keys",
-			wantSplit:  "test-action",
+			wantSplit:  "test-job:test-action",
 			wantReport: "test-action",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			resetTestHooks(t)
+			t.Setenv("GITHUB_JOB", "test-job")
 			t.Setenv("GITHUB_ACTION", "test-action")
 			workspace := t.TempDir()
 			t.Chdir(workspace)

--- a/pkg/cmd/tests/selection.go
+++ b/pkg/cmd/tests/selection.go
@@ -183,6 +183,12 @@ func splitKey(key string) string {
 	if job != "" && action != "" {
 		return job + ":" + action
 	}
+	if job != "" {
+		return job
+	}
+	if action != "" {
+		return action
+	}
 	return "default"
 }
 

--- a/pkg/cmd/tests/selection.go
+++ b/pkg/cmd/tests/selection.go
@@ -156,7 +156,7 @@ func splitCandidatesByTimings(ctx context.Context, candidates []string, opts spl
 		TimingIdentity:    timingIdentity,
 		ShardIndex:        uint32(opts.index),
 		ShardTotal:        uint32(opts.total),
-		SplitKey:          testKey(opts.key),
+		SplitKey:          splitKey(opts.key),
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to split tests by timings: %w", err)
@@ -170,6 +170,18 @@ func testKey(key string) string {
 	}
 	if action := strings.TrimSpace(os.Getenv("GITHUB_ACTION")); action != "" {
 		return action
+	}
+	return "default"
+}
+
+func splitKey(key string) string {
+	if strings.TrimSpace(key) != "" {
+		return strings.TrimSpace(key)
+	}
+	job := strings.TrimSpace(os.Getenv("GITHUB_JOB"))
+	action := strings.TrimSpace(os.Getenv("GITHUB_ACTION"))
+	if job != "" && action != "" {
+		return job + ":" + action
 	}
 	return "default"
 }

--- a/pkg/cmd/tests/split_test.go
+++ b/pkg/cmd/tests/split_test.go
@@ -760,11 +760,15 @@ func TestSplitUsesDefaultKey(t *testing.T) {
 		{
 			name:      "action without job",
 			action:    "go-test",
-			wantSplit: "default",
+			wantSplit: "go-test",
 		},
 		{
 			name:      "job without action",
 			job:       "unit",
+			wantSplit: "unit",
+		},
+		{
+			name:      "no GitHub identity",
 			wantSplit: "default",
 		},
 		{

--- a/pkg/cmd/tests/split_test.go
+++ b/pkg/cmd/tests/split_test.go
@@ -743,34 +743,72 @@ func TestSplitReportsOIDCAndAPIErrors(t *testing.T) {
 	}
 }
 
-func TestSplitUsesGitHubActionAsDefaultKey(t *testing.T) {
-	resetTestHooks(t)
-	t.Setenv("GITHUB_ACTION", " go-test ")
-	resolveOIDCCredentialFunc = func(context.Context) (string, error) { return "oidc-token", nil }
-
-	var splitReq *testresultsv1.SplitTestsRequest
-	splitTestsFunc = func(_ context.Context, _ string, req *testresultsv1.SplitTestsRequest) (*testresultsv1.SplitTestsResponse, error) {
-		splitReq = req
-		return &testresultsv1.SplitTestsResponse{
-			Candidates:            []string{"a.test.ts"},
-			CandidatesRequested:   1,
-			CandidatesSelected:    1,
-			CandidatesWithTimings: 1,
-		}, nil
+func TestSplitUsesDefaultKey(t *testing.T) {
+	tests := []struct {
+		name      string
+		job       string
+		action    string
+		keyArgs   []string
+		wantSplit string
+	}{
+		{
+			name:      "GitHub job and action",
+			job:       " unit ",
+			action:    " go-test ",
+			wantSplit: "unit:go-test",
+		},
+		{
+			name:      "action without job",
+			action:    "go-test",
+			wantSplit: "default",
+		},
+		{
+			name:      "job without action",
+			job:       "unit",
+			wantSplit: "default",
+		},
+		{
+			name:      "explicit key",
+			job:       "unit",
+			action:    "go-test",
+			keyArgs:   []string{"--key", " unit-history "},
+			wantSplit: "unit-history",
+		},
 	}
 
-	_, _, err := executeCommandWithInputOutput(
-		"a.test.ts\n",
-		"split",
-		"--candidate-type", "filename",
-		"--index", "0",
-		"--total", "2",
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if splitReq.GetSplitKey() != "go-test" {
-		t.Fatalf("expected GITHUB_ACTION split key, got %q", splitReq.GetSplitKey())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetTestHooks(t)
+			t.Setenv("GITHUB_JOB", tt.job)
+			t.Setenv("GITHUB_ACTION", tt.action)
+			resolveOIDCCredentialFunc = func(context.Context) (string, error) { return "oidc-token", nil }
+
+			var splitReq *testresultsv1.SplitTestsRequest
+			splitTestsFunc = func(_ context.Context, _ string, req *testresultsv1.SplitTestsRequest) (*testresultsv1.SplitTestsResponse, error) {
+				splitReq = req
+				return &testresultsv1.SplitTestsResponse{
+					Candidates:            []string{"a.test.ts"},
+					CandidatesRequested:   1,
+					CandidatesSelected:    1,
+					CandidatesWithTimings: 1,
+				}, nil
+			}
+
+			args := []string{
+				"split",
+				"--candidate-type", "filename",
+				"--index", "0",
+				"--total", "2",
+			}
+			args = append(args, tt.keyArgs...)
+			_, _, err := executeCommandWithInputOutput("a.test.ts\n", args...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if splitReq.GetSplitKey() != tt.wantSplit {
+				t.Fatalf("expected split key %q, got %q", tt.wantSplit, splitReq.GetSplitKey())
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Test split timing history is now scoped to the GitHub workflow job as well as the action, so distinct jobs no longer share implicit timing data.

When no split key is supplied, the CLI prefers `GITHUB_JOB:GITHUB_ACTION` and gracefully falls back to either available value, then `default`. Explicit split keys and report-upload keys keep their existing behavior.
