### PR TITLE
docs(tests): clarify report key behavior

### DIFF
--- a/pkg/cmd/tests/run.go
+++ b/pkg/cmd/tests/run.go
@@ -70,7 +70,7 @@ falls back to file-size splitting.`,
 	flags.StringArrayVar(&opts.reportPaths, "report-path", nil, "JUnit XML report path, directory, or glob (required, repeatable)")
 	flags.StringVar(&opts.candidatesFile, "candidates-file", "", "Path to newline-delimited runnable test candidates instead of stdin")
 	flags.StringVar(&opts.candidatesCommand, "candidates-command", "", "Shell command that prints newline-delimited runnable test candidates")
-	flags.StringVar(&opts.key, "key", "", "Report invocation key for idempotent uploads (defaults to GITHUB_ACTION or default)")
+	flags.StringVar(&opts.key, "key", "", "Report invocation key (defaults to GITHUB_ACTION or default; set a distinct value when the same job reports more than once; does not affect split timings)")
 
 	return cmd
 }


### PR DESCRIPTION
## Summary
- clarify that --key identifies report uploads, not split timings
- explain when to use a distinct value for multiple report uploads from one job

## Verification
- gofmt -d pkg/cmd/tests/run.go
- go test ./...

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a CLI flag description; no runtime behavior changes.
> 
> **Overview**
> Updates the **`--key`** flag help text on **`depot tests run`** so it matches how the command actually behaves.
> 
> The description now calls it a **report invocation key** (still defaulting to `GITHUB_ACTION` or a default), tells users to set a **distinct value when one job uploads reports more than once**, and explicitly states that **`--key` does not affect split timings** (those use **`--split-key`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d8a0a5b66726a0c9e9425ea664c5d5bb052a0af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->