### PR TITLE
feat(tests): rename run key flag

### DIFF
--- a/pkg/cmd/tests/report_cmd.go
+++ b/pkg/cmd/tests/report_cmd.go
@@ -49,7 +49,7 @@ func newCmdTestsReport() *cobra.Command {
 
 	flags := cmd.Flags()
 	flags.StringArrayVar(&opts.reportPaths, "report-path", nil, "JUnit XML report path, directory, or glob; repeatable")
-	flags.StringVar(&opts.key, "key", "", "Test key")
+	flags.StringVar(&opts.key, "key", "", "Report invocation key for distinguishing between multiple reports uploads")
 	flags.StringVar(&opts.output, "output", reportOutputText, "Output format (text, json)")
 
 	return cmd

--- a/pkg/cmd/tests/run.go
+++ b/pkg/cmd/tests/run.go
@@ -29,7 +29,7 @@ type runOptions struct {
 	reportPaths       []string
 	candidatesFile    string
 	candidatesCommand string
-	key               string
+	reportKey         string
 }
 
 func newCmdTestsRun() *cobra.Command {
@@ -70,7 +70,7 @@ falls back to file-size splitting.`,
 	flags.StringArrayVar(&opts.reportPaths, "report-path", nil, "JUnit XML report path, directory, or glob (required, repeatable)")
 	flags.StringVar(&opts.candidatesFile, "candidates-file", "", "Path to newline-delimited runnable test candidates instead of stdin")
 	flags.StringVar(&opts.candidatesCommand, "candidates-command", "", "Shell command that prints newline-delimited runnable test candidates")
-	flags.StringVar(&opts.key, "key", "", "Report invocation key for idempotent uploads (defaults to GITHUB_ACTION or default)")
+	flags.StringVar(&opts.reportKey, "report-key", "", "Report invocation key for distinguishing between multiple reports uploads")
 
 	return cmd
 }
@@ -137,7 +137,7 @@ func runTestsRun(cmd *cobra.Command, opts runOptions) error {
 	if err := ctx.Err(); err != nil && exitCode == 0 {
 		return cancellationErrorOr(err)
 	}
-	reportErr := uploadAndSummarizeTestReports(cmd, reportPaths, opts.key, reportBaseline)
+	reportErr := uploadAndSummarizeTestReports(cmd, reportPaths, opts.reportKey, reportBaseline)
 	if reportErr != nil && errors.Is(reportErr, context.Canceled) && exitCode == 0 {
 		return cancellationErrorOr(reportErr)
 	}

--- a/pkg/cmd/tests/run_test.go
+++ b/pkg/cmd/tests/run_test.go
@@ -67,7 +67,7 @@ func TestRunUsesIndependentSplitAndReportKeys(t *testing.T) {
 		"--candidate-type", "filename",
 		"--timings-type", "testname",
 		"--split-key", "unit-history",
-		"--key", "unit-report",
+		"--report-key", "unit-report",
 		"--index", "1",
 		"--total", "2",
 		"--command", "test-command",
@@ -121,7 +121,7 @@ func TestRunUsesDefaultsForOmittedKeys(t *testing.T) {
 		},
 		{
 			name:       "report key only",
-			keyArgs:    []string{"--key", "unit-report"},
+			keyArgs:    []string{"--report-key", "unit-report"},
 			wantSplit:  "test-job:test-action",
 			wantReport: "unit-report",
 		},
@@ -261,6 +261,22 @@ func TestRunMatrixSingleShardPreservesUnsplitBehavior(t *testing.T) {
 	}
 	if !strings.Contains(stderr, "Depot is running against a single shard.") {
 		t.Fatalf("expected single-shard summary, got %q", stderr)
+	}
+}
+
+func TestRunExposesReportKeyOnly(t *testing.T) {
+	cmd := newCmdTestsRun()
+	if cmd.Flags().Lookup("report-key") == nil {
+		t.Fatal("expected --report-key flag")
+	}
+	if cmd.Flags().Lookup("key") != nil {
+		t.Fatal("did not expect --key flag")
+	}
+
+	cmd.SetArgs([]string{"--key", "unit-report"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "unknown flag: --key") {
+		t.Fatalf("expected --key to be rejected, got %v", err)
 	}
 }
 

--- a/pkg/cmd/tests/run_test.go
+++ b/pkg/cmd/tests/run_test.go
@@ -264,22 +264,6 @@ func TestRunMatrixSingleShardPreservesUnsplitBehavior(t *testing.T) {
 	}
 }
 
-func TestRunExposesReportKeyOnly(t *testing.T) {
-	cmd := newCmdTestsRun()
-	if cmd.Flags().Lookup("report-key") == nil {
-		t.Fatal("expected --report-key flag")
-	}
-	if cmd.Flags().Lookup("key") != nil {
-		t.Fatal("did not expect --key flag")
-	}
-
-	cmd.SetArgs([]string{"--key", "unit-report"})
-	err := cmd.Execute()
-	if err == nil || !strings.Contains(err.Error(), "unknown flag: --key") {
-		t.Fatalf("expected --key to be rejected, got %v", err)
-	}
-}
-
 func TestRunWithoutShardFlagsRunsAllCandidatesWithoutSplitting(t *testing.T) {
 	resetTestHooks(t)
 	workspace := t.TempDir()


### PR DESCRIPTION
## Summary
- rename `depot tests run --key` to `--report-key`
- keep `--split-key` independent and preserve `depot tests report --key`
- clarify report-key descriptions and reject the legacy run flag



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking CLI rename for `depot tests run` will fail workflows still passing `--key`; scope is limited to flag naming and docs, not upload or split logic.
> 
> **Overview**
> Renames the report invocation flag on **`depot tests run`** from **`--key`** to **`--report-key`**, with the internal option field renamed from `key` to `reportKey`. Upload behavior is unchanged: the value still flows into report upload as the invocation id, separate from **`--split-key`**.
> 
> **`depot tests report`** keeps **`--key`**; both commands now share the same help wording: the key is for distinguishing multiple report uploads in one CI run. Tests for `run` were updated to pass **`--report-key`** instead of **`--key`**.
> 
> **Breaking:** CI or scripts that still use `depot tests run --key` must switch to **`--report-key`**; there is no legacy alias in this change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 060583fcc6d427511bc072deb007e4278ba3bbe2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->