### PR TITLE
feat(browse): open Depot web destinations

### DIFF
--- a/pkg/api/auth.go
+++ b/pkg/api/auth.go
@@ -13,9 +13,9 @@ import (
 	cliv1beta1 "github.com/depot/cli/pkg/proto/depot/cli/v1beta1"
 )
 
-// openURL opens the specified URL in the user's default browser.
+// OpenURL opens the specified URL in the user's default browser.
 // It handles different operating systems appropriately.
-func openURL(url string) error {
+func OpenURL(url string) error {
 	var cmd string
 	var args []string
 
@@ -61,7 +61,7 @@ func AuthorizeDevice(ctx context.Context) (*cliv1beta1.FinishLoginResponse, erro
 	} else if openBrowser {
 		// User chose to open browser
 		fmt.Printf("Opening your browser...\n")
-		if err := openURL(response.Msg.ApproveUrl); err != nil {
+		if err := OpenURL(response.Msg.ApproveUrl); err != nil {
 			fmt.Printf("Could not open browser: %v\n", err)
 		}
 	}

--- a/pkg/api/auth.go
+++ b/pkg/api/auth.go
@@ -16,13 +16,21 @@ import (
 // OpenURL opens the specified URL in the user's default browser.
 // It handles different operating systems appropriately.
 func OpenURL(url string) error {
+	cmd, args, err := browserCommand(runtime.GOOS, url)
+	if err != nil {
+		return err
+	}
+	return exec.Command(cmd, args...).Start()
+}
+
+func browserCommand(goos, url string) (string, []string, error) {
 	var cmd string
 	var args []string
 
-	switch runtime.GOOS {
+	switch goos {
 	case "windows":
-		cmd = "cmd"
-		args = []string{"/c", "start", url}
+		cmd = "rundll32"
+		args = []string{"url.dll,FileProtocolHandler", url}
 	case "darwin":
 		cmd = "open"
 		args = []string{url}
@@ -30,10 +38,9 @@ func OpenURL(url string) error {
 		cmd = "xdg-open"
 		args = []string{url}
 	default:
-		return fmt.Errorf("unsupported platform")
+		return "", nil, fmt.Errorf("unsupported platform")
 	}
-
-	return exec.Command(cmd, args...).Start()
+	return cmd, args, nil
 }
 
 func AuthorizeDevice(ctx context.Context) (*cliv1beta1.FinishLoginResponse, error) {

--- a/pkg/api/auth_test.go
+++ b/pkg/api/auth_test.go
@@ -1,0 +1,23 @@
+package api
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBrowserCommandWindowsPreservesURLArgument(t *testing.T) {
+	t.Parallel()
+
+	destination := "https://depot.dev/orgs/org-123/usage?section=ci&range=month"
+	cmd, args, err := browserCommand("windows", destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cmd != "rundll32" {
+		t.Fatalf("command = %q, want rundll32", cmd)
+	}
+	wantArgs := []string{"url.dll,FileProtocolHandler", destination}
+	if !reflect.DeepEqual(args, wantArgs) {
+		t.Fatalf("args = %#v, want %#v", args, wantArgs)
+	}
+}

--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -195,11 +195,15 @@ func resolveDestination(ctx context.Context, location, orgID string, lookupBuild
 		if lookupBareID == nil {
 			return "", fmt.Errorf("entity lookup is unavailable")
 		}
-		matches, err := lookupBareID(ctx, path, orgID)
+		id, err := url.PathUnescape(path)
 		if err != nil {
-			return "", fmt.Errorf("failed to look up %s: %w", path, err)
+			return "", fmt.Errorf("invalid path segment %q: %w", path, err)
 		}
-		return selectEntityDestination(path, matches, parsed.RawQuery, parsed.EscapedFragment())
+		matches, err := lookupBareID(ctx, id, orgID)
+		if err != nil {
+			return "", fmt.Errorf("failed to look up %s: %w", id, err)
+		}
+		return selectEntityDestination(id, matches, parsed.RawQuery, parsed.EscapedFragment())
 	}
 
 	prefix := depotWebURL + "/orgs/" + url.PathEscape(orgID) + "/"

--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -33,6 +33,15 @@ type ciJobSummaryLookup func(context.Context, string, string, *civ1.GetJobSummar
 
 type ciJobMetricsLookup func(context.Context, string, string, string) (*civ1.GetJobMetricsResponse, error)
 
+type entityLookupDependencies struct {
+	resolveProjectToken func(context.Context) (string, error)
+	resolveOrgToken     func(context.Context) (string, error)
+	getBuild            func(context.Context, string, string) (*cliv1.GetBuildResponse, error)
+	getWorkflow         func(context.Context, string, string, string) (*civ1.GetWorkflowResponse, error)
+	getJobSummary       ciJobSummaryLookup
+	getJobMetrics       ciJobMetricsLookup
+}
+
 type dependencies struct {
 	currentOrg     func() string
 	lookupBuildURL buildURLLookup
@@ -241,6 +250,7 @@ func validateRelativePath(path string) error {
 }
 
 func buildShorthandID(path string) (string, bool) {
+	path = strings.TrimSuffix(path, "/")
 	parts := strings.Split(path, "/")
 	if len(parts) != 2 || parts[0] != "builds" || parts[1] == "" {
 		return "", false
@@ -303,17 +313,33 @@ func lookupBuildURL(ctx context.Context, buildID string) (string, error) {
 }
 
 func lookupEntity(ctx context.Context, id, orgID string) ([]entityDestination, error) {
+	return lookupEntityWithDependencies(ctx, id, orgID, entityLookupDependencies{
+		resolveProjectToken: func(ctx context.Context) (string, error) {
+			return helpers.ResolveProjectAuth(ctx, "")
+		},
+		resolveOrgToken: func(ctx context.Context) (string, error) {
+			return helpers.ResolveOrgAuth(ctx, "")
+		},
+		getBuild: func(ctx context.Context, token, id string) (*cliv1.GetBuildResponse, error) {
+			response, err := api.NewBuildClient().GetBuild(
+				ctx,
+				api.WithAuthentication(connect.NewRequest(&cliv1.GetBuildRequest{BuildId: id}), token),
+			)
+			if err != nil {
+				return nil, err
+			}
+			return response.Msg, nil
+		},
+		getWorkflow:   api.CIGetWorkflow,
+		getJobSummary: api.CIGetJobSummary,
+		getJobMetrics: api.CIGetJobMetrics,
+	})
+}
+
+func lookupEntityWithDependencies(ctx context.Context, id, orgID string, deps entityLookupDependencies) ([]entityDestination, error) {
 	if isDecimalID(id) {
 		path := "github-actions/jobs/" + url.PathEscape(id)
 		return []entityDestination{{kind: "GitHub Actions job", path: path, url: orgURL(orgID, path)}}, nil
-	}
-
-	token, err := helpers.ResolveProjectAuth(ctx, "")
-	if err != nil {
-		return nil, err
-	}
-	if token == "" {
-		return nil, fmt.Errorf("missing API token, please run `depot login`")
 	}
 
 	type lookupResult struct {
@@ -324,27 +350,35 @@ func lookupEntity(ctx context.Context, id, orgID string) ([]entityDestination, e
 	var wg sync.WaitGroup
 	wg.Add(3)
 
+	projectToken, projectTokenErr := resolveEntityLookupToken(ctx, "build", deps.resolveProjectToken)
+	orgToken, orgTokenErr := resolveEntityLookupToken(ctx, "Depot CI", deps.resolveOrgToken)
+
 	go func() {
 		defer wg.Done()
-		response, err := api.NewBuildClient().GetBuild(
-			ctx,
-			api.WithAuthentication(connect.NewRequest(&cliv1.GetBuildRequest{BuildId: id}), token),
-		)
+		if projectTokenErr != nil {
+			results <- lookupResult{err: projectTokenErr}
+			return
+		}
+		response, err := deps.getBuild(ctx, projectToken, id)
 		if err != nil {
 			results <- lookupResult{err: entityLookupError("build", err)}
 			return
 		}
-		if response.Msg.GetBuildUrl() == "" {
+		if response.GetBuildUrl() == "" {
 			results <- lookupResult{err: fmt.Errorf("build lookup returned an empty URL")}
 			return
 		}
 		path := "builds/" + url.PathEscape(id)
-		results <- lookupResult{destination: &entityDestination{kind: "build", path: path, url: response.Msg.GetBuildUrl()}}
+		results <- lookupResult{destination: &entityDestination{kind: "build", path: path, url: response.GetBuildUrl()}}
 	}()
 
 	go func() {
 		defer wg.Done()
-		response, err := api.CIGetWorkflow(ctx, token, orgID, id)
+		if orgTokenErr != nil {
+			results <- lookupResult{err: orgTokenErr}
+			return
+		}
+		response, err := deps.getWorkflow(ctx, orgToken, orgID, id)
 		if err != nil {
 			results <- lookupResult{err: entityLookupError("Depot CI workflow", err)}
 			return
@@ -359,7 +393,11 @@ func lookupEntity(ctx context.Context, id, orgID string) ([]entityDestination, e
 
 	go func() {
 		defer wg.Done()
-		destination, err := lookupCIJob(ctx, token, orgID, id, api.CIGetJobSummary, api.CIGetJobMetrics)
+		if orgTokenErr != nil {
+			results <- lookupResult{err: orgTokenErr}
+			return
+		}
+		destination, err := lookupCIJob(ctx, orgToken, orgID, id, deps.getJobSummary, deps.getJobMetrics)
 		results <- lookupResult{destination: destination, err: err}
 	}()
 
@@ -377,6 +415,17 @@ func lookupEntity(ctx context.Context, id, orgID string) ([]entityDestination, e
 		}
 	}
 	return finishEntityLookup(matches, lookupErrors)
+}
+
+func resolveEntityLookupToken(ctx context.Context, kind string, resolve func(context.Context) (string, error)) (string, error) {
+	token, err := resolve(ctx)
+	if err != nil {
+		return "", fmt.Errorf("%s authentication failed: %w", kind, err)
+	}
+	if token == "" {
+		return "", fmt.Errorf("%s authentication failed: missing API token, please run `depot login`", kind)
+	}
+	return token, nil
 }
 
 func finishEntityLookup(matches []entityDestination, lookupErrors []string) ([]entityDestination, error) {

--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -94,21 +94,14 @@ GitHub Actions job ID.`,
   depot browse github-actions
 
   # Open a GitHub Actions job
-  # Find run IDs with: gh run list --json databaseId
-  # Find job IDs with: gh run view <run-id> --json jobs
+  # Find job IDs with: depot browse github-actions
   depot browse github-actions/jobs/<github-job-id>
 
   # Open the organization homepage
   depot browse
 
-  # Open the registry
-  depot browse registry
-
   # Open organization usage for a specific month
   depot browse 'usage/2026/07?section=github-actions'
-
-  # Open a complete Depot URL unchanged
-  depot browse 'https://depot.dev/orgs/<org-id>/usage/2026/07?section=github-actions'
 
   # Look up a build, Depot CI workflow/job, or GitHub Actions job by ID
   depot browse <id>

--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -173,6 +173,9 @@ func resolveDestination(ctx context.Context, location, orgID string, lookupBuild
 		}
 		return addQueryAndFragment(canonical, parsed.RawQuery, parsed.EscapedFragment())
 	}
+	if orgID == "" && path == "" {
+		return addQueryAndFragment(depotWebURL, parsed.RawQuery, parsed.EscapedFragment())
+	}
 	if orgID == "" {
 		return "", fmt.Errorf("no organization selected; run `depot org switch` or use --org")
 	}

--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -29,6 +29,10 @@ type entityDestination struct {
 
 type entityLookup func(context.Context, string, string) ([]entityDestination, error)
 
+type ciJobSummaryLookup func(context.Context, string, string, *civ1.GetJobSummaryRequest) (*civ1.GetJobSummaryResponse, error)
+
+type ciJobMetricsLookup func(context.Context, string, string, string) (*civ1.GetJobMetricsResponse, error)
+
 type dependencies struct {
 	currentOrg     func() string
 	lookupBuildURL buildURLLookup
@@ -359,17 +363,8 @@ func lookupEntity(ctx context.Context, id, orgID string) ([]entityDestination, e
 
 	go func() {
 		defer wg.Done()
-		response, err := api.CIGetJobSummary(ctx, token, orgID, &civ1.GetJobSummaryRequest{JobId: id})
-		if err != nil {
-			results <- lookupResult{err: entityLookupError("Depot CI job", err)}
-			return
-		}
-		if response.GetWorkflowId() == "" || response.GetJobId() == "" {
-			results <- lookupResult{err: fmt.Errorf("Depot CI job lookup returned incomplete routing information")}
-			return
-		}
-		path := "workflows/" + url.PathEscape(response.GetWorkflowId()) + "/jobs/" + url.PathEscape(response.GetJobId())
-		results <- lookupResult{destination: &entityDestination{kind: "Depot CI job", path: path, url: orgURL(orgID, path)}}
+		destination, err := lookupCIJob(ctx, token, orgID, id, api.CIGetJobSummary, api.CIGetJobMetrics)
+		results <- lookupResult{destination: destination, err: err}
 	}()
 
 	wg.Wait()
@@ -385,11 +380,48 @@ func lookupEntity(ctx context.Context, id, orgID string) ([]entityDestination, e
 			lookupErrors = append(lookupErrors, result.err.Error())
 		}
 	}
+	return finishEntityLookup(matches, lookupErrors)
+}
+
+func finishEntityLookup(matches []entityDestination, lookupErrors []string) ([]entityDestination, error) {
+	if len(matches) > 0 {
+		return matches, nil
+	}
 	if len(lookupErrors) > 0 {
 		sort.Strings(lookupErrors)
 		return nil, fmt.Errorf("%s", strings.Join(lookupErrors, "; "))
 	}
-	return matches, nil
+	return nil, nil
+}
+
+func lookupCIJob(
+	ctx context.Context,
+	token, orgID, jobID string,
+	getSummary ciJobSummaryLookup,
+	getMetrics ciJobMetricsLookup,
+) (*entityDestination, error) {
+	response, err := getSummary(ctx, token, orgID, &civ1.GetJobSummaryRequest{JobId: jobID})
+	if err != nil {
+		return nil, entityLookupError("Depot CI job", err)
+	}
+	if response.GetJobId() == "" {
+		return nil, fmt.Errorf("Depot CI job lookup returned incomplete routing information")
+	}
+
+	workflowID := response.GetWorkflowId()
+	if workflowID == "" {
+		metrics, err := getMetrics(ctx, token, orgID, response.GetJobId())
+		if err != nil {
+			return nil, fmt.Errorf("Depot CI job lookup could not resolve its workflow: %w", err)
+		}
+		workflowID = metrics.GetWorkflow().GetWorkflowId()
+	}
+	if workflowID == "" {
+		return nil, fmt.Errorf("Depot CI job lookup returned incomplete routing information")
+	}
+
+	path := "workflows/" + url.PathEscape(workflowID) + "/jobs/" + url.PathEscape(response.GetJobId())
+	return &entityDestination{kind: "Depot CI job", path: path, url: orgURL(orgID, path)}, nil
 }
 
 func isDecimalID(id string) bool {

--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"sort"
 	"strings"
+	"sync"
 
 	"connectrpc.com/connect"
 	"github.com/depot/cli/pkg/api"
 	"github.com/depot/cli/pkg/config"
 	"github.com/depot/cli/pkg/helpers"
+	civ1 "github.com/depot/cli/pkg/proto/depot/ci/v1"
 	cliv1 "github.com/depot/cli/pkg/proto/depot/cli/v1"
 	"github.com/spf13/cobra"
 )
@@ -18,9 +21,18 @@ const depotWebURL = "https://depot.dev"
 
 type buildURLLookup func(context.Context, string) (string, error)
 
+type entityDestination struct {
+	kind string
+	path string
+	url  string
+}
+
+type entityLookup func(context.Context, string, string) ([]entityDestination, error)
+
 type dependencies struct {
 	currentOrg     func() string
 	lookupBuildURL buildURLLookup
+	lookupEntity   entityLookup
 	openURL        func(string) error
 }
 
@@ -28,6 +40,7 @@ func NewCmdBrowse() *cobra.Command {
 	return newCmdBrowse(dependencies{
 		currentOrg:     config.GetCurrentOrganization,
 		lookupBuildURL: lookupBuildURL,
+		lookupEntity:   lookupEntity,
 		openURL:        api.OpenURL,
 	})
 }
@@ -52,13 +65,19 @@ If the intended product is unclear, ask the user which destination they want.
 
 Relative paths are opened within the current Depot organization. Complete
 https://depot.dev URLs are opened unchanged. The builds/<build-id> shorthand
-looks up the build and opens its canonical project build page.`,
+looks up the build and opens its canonical project build page. An unrecognized
+single-segment path is looked up as a build, Depot CI workflow or job, or
+GitHub Actions job ID.`,
 		Example: `  # Open Depot CI
   depot browse workflows
 
   # Open a Depot CI workflow
   # Find workflow IDs with: depot ci workflow list --output json
   depot browse workflows/<workflow-id>
+
+  # Open a Depot CI job
+  # Find job IDs with: depot ci workflow show <workflow-id> --output json
+  depot browse workflows/<workflow-id>/jobs/<job-id>
 
   # Open Depot Container Builds
   depot browse builds
@@ -87,6 +106,9 @@ looks up the build and opens its canonical project build page.`,
   # Open a complete Depot URL unchanged
   depot browse 'https://depot.dev/orgs/<org-id>/usage/2026/07?section=github-actions'
 
+  # Look up a build, Depot CI workflow/job, or GitHub Actions job by ID
+  depot browse <id>
+
   # Print the resolved URL without opening a browser
   depot browse workflows --no-browser`,
 		Args: cobra.MaximumNArgs(1),
@@ -101,7 +123,7 @@ looks up the build and opens its canonical project build page.`,
 				selectedOrgID = deps.currentOrg()
 			}
 
-			destination, err := resolveDestination(cmd.Context(), location, selectedOrgID, deps.lookupBuildURL)
+			destination, err := resolveDestination(cmd.Context(), location, selectedOrgID, deps.lookupBuildURL, deps.lookupEntity)
 			if err != nil {
 				return err
 			}
@@ -126,7 +148,7 @@ looks up the build and opens its canonical project build page.`,
 	return cmd
 }
 
-func resolveDestination(ctx context.Context, location, orgID string, lookup buildURLLookup) (string, error) {
+func resolveDestination(ctx context.Context, location, orgID string, lookupBuild buildURLLookup, lookupBareID entityLookup) (string, error) {
 	location = strings.TrimSpace(location)
 	parsed, err := url.Parse(location)
 	if err != nil {
@@ -151,18 +173,57 @@ func resolveDestination(ctx context.Context, location, orgID string, lookup buil
 	if path == "builds" {
 		path = "projects"
 	} else if buildID, ok := buildShorthandID(path); ok {
-		if lookup == nil {
+		if lookupBuild == nil {
 			return "", fmt.Errorf("build lookup is unavailable")
 		}
-		canonical, err := lookup(ctx, buildID)
+		canonical, err := lookupBuild(ctx, buildID)
 		if err != nil {
 			return "", fmt.Errorf("failed to look up build %s: %w", buildID, err)
 		}
 		return addQueryAndFragment(canonical, parsed.RawQuery, parsed.EscapedFragment())
+	} else if isBareID(path) && !isKnownOrgPath(path) {
+		if lookupBareID == nil {
+			return "", fmt.Errorf("entity lookup is unavailable")
+		}
+		matches, err := lookupBareID(ctx, path, orgID)
+		if err != nil {
+			return "", fmt.Errorf("failed to look up %s: %w", path, err)
+		}
+		return selectEntityDestination(path, matches, parsed.RawQuery, parsed.EscapedFragment())
 	}
 
 	prefix := depotWebURL + "/orgs/" + url.PathEscape(orgID) + "/"
 	return prefix + relativeReference(path, parsed.RawQuery, parsed.EscapedFragment()), nil
+}
+
+func isBareID(path string) bool {
+	return path != "" && !strings.Contains(path, "/")
+}
+
+func isKnownOrgPath(path string) bool {
+	switch path {
+	case "audit-logs-portal", "builds", "cache", "claude", "code", "compute",
+		"dagger-projects", "github-actions", "home", "projects", "registry",
+		"registry-v2", "settings", "sso-portal", "test-results", "usage", "workflows":
+		return true
+	default:
+		return false
+	}
+}
+
+func selectEntityDestination(id string, matches []entityDestination, rawQuery, escapedFragment string) (string, error) {
+	if len(matches) == 0 {
+		return "", fmt.Errorf("could not find %s as a build, Depot CI workflow or job, or GitHub Actions job; use an explicit path if it is an app destination", id)
+	}
+	if len(matches) > 1 {
+		paths := make([]string, 0, len(matches))
+		for _, match := range matches {
+			paths = append(paths, fmt.Sprintf("%s (%s)", match.path, match.kind))
+		}
+		sort.Strings(paths)
+		return "", fmt.Errorf("%s is ambiguous; choose one of: %s", id, strings.Join(paths, ", "))
+	}
+	return addQueryAndFragment(matches[0].url, rawQuery, escapedFragment)
 }
 
 func validateRelativePath(path string) error {
@@ -204,7 +265,7 @@ func addQueryAndFragment(destination, rawQuery, escapedFragment string) (string,
 		return "", fmt.Errorf("invalid build URL: %w", err)
 	}
 	if parsed.Scheme != "https" || parsed.Host != "depot.dev" || parsed.User != nil {
-		return "", fmt.Errorf("build lookup returned a URL outside https://depot.dev")
+		return "", fmt.Errorf("lookup returned a URL outside https://depot.dev")
 	}
 	parsed.RawQuery = rawQuery
 	parsed.Fragment, err = url.PathUnescape(escapedFragment)
@@ -234,4 +295,117 @@ func lookupBuildURL(ctx context.Context, buildID string) (string, error) {
 		return "", fmt.Errorf("build lookup returned an empty URL")
 	}
 	return response.Msg.GetBuildUrl(), nil
+}
+
+func lookupEntity(ctx context.Context, id, orgID string) ([]entityDestination, error) {
+	if isDecimalID(id) {
+		path := "github-actions/jobs/" + url.PathEscape(id)
+		return []entityDestination{{kind: "GitHub Actions job", path: path, url: orgURL(orgID, path)}}, nil
+	}
+
+	token, err := helpers.ResolveProjectAuth(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+	if token == "" {
+		return nil, fmt.Errorf("missing API token, please run `depot login`")
+	}
+
+	type lookupResult struct {
+		destination *entityDestination
+		err         error
+	}
+	results := make(chan lookupResult, 3)
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	go func() {
+		defer wg.Done()
+		response, err := api.NewBuildClient().GetBuild(
+			ctx,
+			api.WithAuthentication(connect.NewRequest(&cliv1.GetBuildRequest{BuildId: id}), token),
+		)
+		if err != nil {
+			results <- lookupResult{err: entityLookupError("build", err)}
+			return
+		}
+		if response.Msg.GetBuildUrl() == "" {
+			results <- lookupResult{err: fmt.Errorf("build lookup returned an empty URL")}
+			return
+		}
+		path := "builds/" + url.PathEscape(id)
+		results <- lookupResult{destination: &entityDestination{kind: "build", path: path, url: response.Msg.GetBuildUrl()}}
+	}()
+
+	go func() {
+		defer wg.Done()
+		response, err := api.CIGetWorkflow(ctx, token, orgID, id)
+		if err != nil {
+			results <- lookupResult{err: entityLookupError("Depot CI workflow", err)}
+			return
+		}
+		if response.GetWorkflowId() == "" {
+			results <- lookupResult{err: fmt.Errorf("Depot CI workflow lookup returned incomplete routing information")}
+			return
+		}
+		path := "workflows/" + url.PathEscape(response.GetWorkflowId())
+		results <- lookupResult{destination: &entityDestination{kind: "Depot CI workflow", path: path, url: orgURL(orgID, path)}}
+	}()
+
+	go func() {
+		defer wg.Done()
+		response, err := api.CIGetJobSummary(ctx, token, orgID, &civ1.GetJobSummaryRequest{JobId: id})
+		if err != nil {
+			results <- lookupResult{err: entityLookupError("Depot CI job", err)}
+			return
+		}
+		if response.GetWorkflowId() == "" || response.GetJobId() == "" {
+			results <- lookupResult{err: fmt.Errorf("Depot CI job lookup returned incomplete routing information")}
+			return
+		}
+		path := "workflows/" + url.PathEscape(response.GetWorkflowId()) + "/jobs/" + url.PathEscape(response.GetJobId())
+		results <- lookupResult{destination: &entityDestination{kind: "Depot CI job", path: path, url: orgURL(orgID, path)}}
+	}()
+
+	wg.Wait()
+	close(results)
+
+	var matches []entityDestination
+	var lookupErrors []string
+	for result := range results {
+		if result.destination != nil {
+			matches = append(matches, *result.destination)
+		}
+		if result.err != nil {
+			lookupErrors = append(lookupErrors, result.err.Error())
+		}
+	}
+	if len(lookupErrors) > 0 {
+		sort.Strings(lookupErrors)
+		return nil, fmt.Errorf("%s", strings.Join(lookupErrors, "; "))
+	}
+	return matches, nil
+}
+
+func isDecimalID(id string) bool {
+	if id == "" {
+		return false
+	}
+	for _, char := range id {
+		if char < '0' || char > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func entityLookupError(kind string, err error) error {
+	if code := connect.CodeOf(err); code == connect.CodeNotFound || code == connect.CodeInvalidArgument {
+		return nil
+	}
+	return fmt.Errorf("%s lookup failed: %w", kind, err)
+}
+
+func orgURL(orgID, path string) string {
+	return depotWebURL + "/orgs/" + url.PathEscape(orgID) + "/" + path
 }

--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -1,0 +1,237 @@
+package browse
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"connectrpc.com/connect"
+	"github.com/depot/cli/pkg/api"
+	"github.com/depot/cli/pkg/config"
+	"github.com/depot/cli/pkg/helpers"
+	cliv1 "github.com/depot/cli/pkg/proto/depot/cli/v1"
+	"github.com/spf13/cobra"
+)
+
+const depotWebURL = "https://depot.dev"
+
+type buildURLLookup func(context.Context, string) (string, error)
+
+type dependencies struct {
+	currentOrg     func() string
+	lookupBuildURL buildURLLookup
+	openURL        func(string) error
+}
+
+func NewCmdBrowse() *cobra.Command {
+	return newCmdBrowse(dependencies{
+		currentOrg:     config.GetCurrentOrganization,
+		lookupBuildURL: lookupBuildURL,
+		openURL:        api.OpenURL,
+	})
+}
+
+func newCmdBrowse(deps dependencies) *cobra.Command {
+	var orgID string
+	var noBrowser bool
+
+	cmd := &cobra.Command{
+		Use:   "browse [path | URL]",
+		Short: "Open Depot in your web browser",
+		Long: `Open Depot in your web browser
+
+Depot has multiple products. Common destinations are:
+
+  workflows       Depot CI
+  builds          Depot Container Builds (alias for projects)
+  github-actions  Depot GitHub Action Runners
+  <no path>       Organization homepage
+
+If the intended product is unclear, ask the user which destination they want.
+
+Relative paths are opened within the current Depot organization. Complete
+https://depot.dev URLs are opened unchanged. The builds/<build-id> shorthand
+looks up the build and opens its canonical project build page.`,
+		Example: `  # Open Depot CI
+  depot browse workflows
+
+  # Open a Depot CI workflow
+  # Find workflow IDs with: depot ci workflow list --output json
+  depot browse workflows/<workflow-id>
+
+  # Open Depot Container Builds
+  depot browse builds
+
+  # Open a container build
+  # Find build IDs with: depot list builds --project <project-id> --output json
+  depot browse builds/<build-id>
+
+  # Open Depot GitHub Action Runners
+  depot browse github-actions
+
+  # Open a GitHub Actions job
+  # Find run IDs with: gh run list --json databaseId
+  # Find job IDs with: gh run view <run-id> --json jobs
+  depot browse github-actions/jobs/<github-job-id>
+
+  # Open the organization homepage
+  depot browse
+
+  # Open the registry
+  depot browse registry
+
+  # Open organization usage for a specific month
+  depot browse 'usage/2026/07?section=github-actions'
+
+  # Open a complete Depot URL unchanged
+  depot browse 'https://depot.dev/orgs/<org-id>/usage/2026/07?section=github-actions'
+
+  # Print the resolved URL without opening a browser
+  depot browse workflows --no-browser`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			location := ""
+			if len(args) == 1 {
+				location = args[0]
+			}
+
+			selectedOrgID := orgID
+			if selectedOrgID == "" && deps.currentOrg != nil {
+				selectedOrgID = deps.currentOrg()
+			}
+
+			destination, err := resolveDestination(cmd.Context(), location, selectedOrgID, deps.lookupBuildURL)
+			if err != nil {
+				return err
+			}
+
+			if noBrowser {
+				_, err := fmt.Fprintln(cmd.OutOrStdout(), destination)
+				return err
+			}
+			if deps.openURL == nil {
+				return fmt.Errorf("browser opener is unavailable")
+			}
+			if err := deps.openURL(destination); err != nil {
+				return fmt.Errorf("failed to open %s: %w", destination, err)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVarP(&noBrowser, "no-browser", "n", false, "Print the destination URL instead of opening it")
+	cmd.Flags().StringVar(&orgID, "org", "", "Depot organization ID (defaults to the current organization)")
+
+	return cmd
+}
+
+func resolveDestination(ctx context.Context, location, orgID string, lookup buildURLLookup) (string, error) {
+	location = strings.TrimSpace(location)
+	parsed, err := url.Parse(location)
+	if err != nil {
+		return "", fmt.Errorf("invalid browse destination %q: %w", location, err)
+	}
+
+	if parsed.IsAbs() || parsed.Host != "" {
+		if parsed.Scheme != "https" || parsed.Host != "depot.dev" || parsed.User != nil {
+			return "", fmt.Errorf("only https://depot.dev URLs can be opened as complete URLs")
+		}
+		return parsed.String(), nil
+	}
+
+	path := strings.TrimPrefix(parsed.EscapedPath(), "/")
+	if err := validateRelativePath(path); err != nil {
+		return "", err
+	}
+	if orgID == "" {
+		return "", fmt.Errorf("no organization selected; run `depot org switch` or use --org")
+	}
+
+	if path == "builds" {
+		path = "projects"
+	} else if buildID, ok := buildShorthandID(path); ok {
+		if lookup == nil {
+			return "", fmt.Errorf("build lookup is unavailable")
+		}
+		canonical, err := lookup(ctx, buildID)
+		if err != nil {
+			return "", fmt.Errorf("failed to look up build %s: %w", buildID, err)
+		}
+		return addQueryAndFragment(canonical, parsed.RawQuery, parsed.EscapedFragment())
+	}
+
+	prefix := depotWebURL + "/orgs/" + url.PathEscape(orgID) + "/"
+	return prefix + relativeReference(path, parsed.RawQuery, parsed.EscapedFragment()), nil
+}
+
+func validateRelativePath(path string) error {
+	for _, segment := range strings.Split(path, "/") {
+		decoded, err := url.PathUnescape(segment)
+		if err != nil {
+			return fmt.Errorf("invalid path segment %q: %w", segment, err)
+		}
+		if decoded == "." || decoded == ".." {
+			return fmt.Errorf("organization-relative paths must not contain . or .. segments")
+		}
+	}
+	return nil
+}
+
+func buildShorthandID(path string) (string, bool) {
+	parts := strings.Split(path, "/")
+	if len(parts) != 2 || parts[0] != "builds" || parts[1] == "" {
+		return "", false
+	}
+	buildID, err := url.PathUnescape(parts[1])
+	return buildID, err == nil && buildID != ""
+}
+
+func relativeReference(path, rawQuery, escapedFragment string) string {
+	reference := path
+	if rawQuery != "" {
+		reference += "?" + rawQuery
+	}
+	if escapedFragment != "" {
+		reference += "#" + escapedFragment
+	}
+	return reference
+}
+
+func addQueryAndFragment(destination, rawQuery, escapedFragment string) (string, error) {
+	parsed, err := url.Parse(destination)
+	if err != nil {
+		return "", fmt.Errorf("invalid build URL: %w", err)
+	}
+	if parsed.Scheme != "https" || parsed.Host != "depot.dev" || parsed.User != nil {
+		return "", fmt.Errorf("build lookup returned a URL outside https://depot.dev")
+	}
+	parsed.RawQuery = rawQuery
+	parsed.Fragment, err = url.PathUnescape(escapedFragment)
+	if err != nil {
+		return "", fmt.Errorf("invalid URL fragment: %w", err)
+	}
+	return parsed.String(), nil
+}
+
+func lookupBuildURL(ctx context.Context, buildID string) (string, error) {
+	token, err := helpers.ResolveProjectAuth(ctx, "")
+	if err != nil {
+		return "", err
+	}
+	if token == "" {
+		return "", fmt.Errorf("missing API token, please run `depot login`")
+	}
+
+	response, err := api.NewBuildClient().GetBuild(
+		ctx,
+		api.WithAuthentication(connect.NewRequest(&cliv1.GetBuildRequest{BuildId: buildID}), token),
+	)
+	if err != nil {
+		return "", err
+	}
+	if response.Msg.GetBuildUrl() == "" {
+		return "", fmt.Errorf("build lookup returned an empty URL")
+	}
+	return response.Msg.GetBuildUrl(), nil
+}

--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -156,7 +156,7 @@ func resolveDestination(ctx context.Context, location, orgID string, lookupBuild
 	}
 
 	if parsed.IsAbs() || parsed.Host != "" {
-		if parsed.Scheme != "https" || parsed.Host != "depot.dev" || parsed.User != nil {
+		if !isDepotURL(parsed) {
 			return "", fmt.Errorf("only https://depot.dev URLs can be opened as complete URLs")
 		}
 		return parsed.String(), nil
@@ -166,13 +166,7 @@ func resolveDestination(ctx context.Context, location, orgID string, lookupBuild
 	if err := validateRelativePath(path); err != nil {
 		return "", err
 	}
-	if orgID == "" {
-		return "", fmt.Errorf("no organization selected; run `depot org switch` or use --org")
-	}
-
-	if path == "builds" {
-		path = "projects"
-	} else if buildID, ok := buildShorthandID(path); ok {
+	if buildID, ok := buildShorthandID(path); ok {
 		if lookupBuild == nil {
 			return "", fmt.Errorf("build lookup is unavailable")
 		}
@@ -181,6 +175,13 @@ func resolveDestination(ctx context.Context, location, orgID string, lookupBuild
 			return "", fmt.Errorf("failed to look up build %s: %w", buildID, err)
 		}
 		return addQueryAndFragment(canonical, parsed.RawQuery, parsed.EscapedFragment())
+	}
+	if orgID == "" {
+		return "", fmt.Errorf("no organization selected; run `depot org switch` or use --org")
+	}
+
+	if path == "builds" || path == "builds/" {
+		path = "projects"
 	} else if isBareID(path) && !isKnownOrgPath(path) {
 		if lookupBareID == nil {
 			return "", fmt.Errorf("entity lookup is unavailable")
@@ -264,7 +265,7 @@ func addQueryAndFragment(destination, rawQuery, escapedFragment string) (string,
 	if err != nil {
 		return "", fmt.Errorf("invalid build URL: %w", err)
 	}
-	if parsed.Scheme != "https" || parsed.Host != "depot.dev" || parsed.User != nil {
+	if !isDepotURL(parsed) {
 		return "", fmt.Errorf("lookup returned a URL outside https://depot.dev")
 	}
 	parsed.RawQuery = rawQuery
@@ -273,6 +274,10 @@ func addQueryAndFragment(destination, rawQuery, escapedFragment string) (string,
 		return "", fmt.Errorf("invalid URL fragment: %w", err)
 	}
 	return parsed.String(), nil
+}
+
+func isDepotURL(parsed *url.URL) bool {
+	return parsed.Scheme == "https" && strings.EqualFold(parsed.Hostname(), "depot.dev") && parsed.Port() == "" && parsed.User == nil
 }
 
 func lookupBuildURL(ctx context.Context, buildID string) (string, error) {

--- a/pkg/cmd/browse/browse_test.go
+++ b/pkg/cmd/browse/browse_test.go
@@ -1,0 +1,227 @@
+package browse
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestResolveDestination(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		location string
+		orgID    string
+		want     string
+	}{
+		{name: "organization homepage", orgID: "org-123", want: "https://depot.dev/orgs/org-123/"},
+		{name: "Depot CI", location: "workflows", orgID: "org-123", want: "https://depot.dev/orgs/org-123/workflows"},
+		{name: "container builds alias", location: "builds", orgID: "org-123", want: "https://depot.dev/orgs/org-123/projects"},
+		{name: "GitHub Actions job", location: "github-actions/jobs/87413161724", orgID: "org-123", want: "https://depot.dev/orgs/org-123/github-actions/jobs/87413161724"},
+		{name: "encoded registry repository", location: "registry/repositories/depot%2Fsnapshots%2Fe2e-base/manifests", orgID: "org-123", want: "https://depot.dev/orgs/org-123/registry/repositories/depot%2Fsnapshots%2Fe2e-base/manifests"},
+		{name: "query and fragment", location: "usage/2026/07?section=github-actions#details", orgID: "org-123", want: "https://depot.dev/orgs/org-123/usage/2026/07?section=github-actions#details"},
+		{name: "complete Depot URL", location: "https://depot.dev/orgs/another-org/workflows?status=failed", want: "https://depot.dev/orgs/another-org/workflows?status=failed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := resolveDestination(context.Background(), tt.location, tt.orgID, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Fatalf("resolveDestination() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveDestinationBuildShorthand(t *testing.T) {
+	t.Parallel()
+
+	var gotBuildID string
+	lookup := func(_ context.Context, buildID string) (string, error) {
+		gotBuildID = buildID
+		return "https://depot.dev/orgs/org-123/projects/project-123/builds/build-123", nil
+	}
+
+	got, err := resolveDestination(context.Background(), "builds/build-123?tab=logs#step", "org-123", lookup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotBuildID != "build-123" {
+		t.Fatalf("lookup build ID = %q, want build-123", gotBuildID)
+	}
+	want := "https://depot.dev/orgs/org-123/projects/project-123/builds/build-123?tab=logs#step"
+	if got != want {
+		t.Fatalf("resolveDestination() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveDestinationRejectsUnsafeBuildURL(t *testing.T) {
+	t.Parallel()
+
+	lookup := func(context.Context, string) (string, error) {
+		return "https://example.com/phishing", nil
+	}
+
+	_, err := resolveDestination(context.Background(), "builds/build-123", "org-123", lookup)
+	if err == nil || !strings.Contains(err.Error(), "outside https://depot.dev") {
+		t.Fatalf("error = %v, want unsafe build URL error", err)
+	}
+}
+
+func TestResolveDestinationRejectsUnsafeOrIncompleteInput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		location string
+		orgID    string
+		wantErr  string
+	}{
+		{name: "external URL", location: "https://example.com/path", wantErr: "only https://depot.dev URLs"},
+		{name: "HTTP Depot URL", location: "http://depot.dev/orgs/org-123", wantErr: "only https://depot.dev URLs"},
+		{name: "protocol relative URL", location: "//example.com/path", orgID: "org-123", wantErr: "only https://depot.dev URLs"},
+		{name: "parent traversal", location: "../settings", orgID: "org-123", wantErr: "must not contain . or .. segments"},
+		{name: "missing organization", location: "workflows", wantErr: "no organization selected"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := resolveDestination(context.Background(), tt.location, tt.orgID, nil)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestBrowseNoBrowserPrintsResolvedURL(t *testing.T) {
+	t.Parallel()
+
+	var opened string
+	cmd := newCmdBrowse(dependencies{
+		currentOrg: func() string { return "org-123" },
+		openURL: func(destination string) error {
+			opened = destination
+			return nil
+		},
+	})
+	cmd.SetArgs([]string{"workflows", "--no-browser"})
+
+	var stdout strings.Builder
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if opened != "" {
+		t.Fatalf("opened %q with --no-browser", opened)
+	}
+	if got, want := stdout.String(), "https://depot.dev/orgs/org-123/workflows\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+}
+
+func TestBrowseOpensResolvedURL(t *testing.T) {
+	t.Parallel()
+
+	var opened string
+	cmd := newCmdBrowse(dependencies{
+		currentOrg: func() string { return "org-123" },
+		openURL: func(destination string) error {
+			opened = destination
+			return nil
+		},
+	})
+	cmd.SetArgs([]string{"builds"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := opened, "https://depot.dev/orgs/org-123/projects"; got != want {
+		t.Fatalf("opened = %q, want %q", got, want)
+	}
+}
+
+func TestBrowseOrgFlagOverridesCurrentOrganization(t *testing.T) {
+	t.Parallel()
+
+	var opened string
+	cmd := newCmdBrowse(dependencies{
+		currentOrg: func() string { return "configured-org" },
+		openURL: func(destination string) error {
+			opened = destination
+			return nil
+		},
+	})
+	cmd.SetArgs([]string{"workflows", "--org", "requested-org"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := opened, "https://depot.dev/orgs/requested-org/workflows"; got != want {
+		t.Fatalf("opened = %q, want %q", got, want)
+	}
+}
+
+func TestBrowseReportsOpenFailure(t *testing.T) {
+	t.Parallel()
+
+	cmd := newCmdBrowse(dependencies{
+		currentOrg: func() string { return "org-123" },
+		openURL:    func(string) error { return errors.New("boom") },
+	})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"workflows"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "failed to open") {
+		t.Fatalf("error = %v, want open failure", err)
+	}
+}
+
+func TestBrowseHelpHighlightsProductsAndDiscoveryCommands(t *testing.T) {
+	t.Parallel()
+
+	cmd := newCmdBrowse(dependencies{})
+	help := cmd.Long + "\n" + cmd.Example
+
+	ordered := []string{
+		"workflows       Depot CI",
+		"builds          Depot Container Builds (alias for projects)",
+		"github-actions  Depot GitHub Action Runners",
+		"<no path>       Organization homepage",
+	}
+	last := -1
+	for _, want := range ordered {
+		index := strings.Index(help, want)
+		if index == -1 {
+			t.Fatalf("help missing %q:\n%s", want, help)
+		}
+		if index < last {
+			t.Fatalf("help does not preserve product priority near %q:\n%s", want, help)
+		}
+		last = index
+	}
+
+	for _, want := range []string{
+		"If the intended product is unclear, ask the user which destination they want.",
+		"depot ci workflow list --output json",
+		"depot list builds --project <project-id> --output json",
+		"gh run view <run-id> --json jobs",
+	} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("help missing %q:\n%s", want, help)
+		}
+	}
+}

--- a/pkg/cmd/browse/browse_test.go
+++ b/pkg/cmd/browse/browse_test.go
@@ -19,10 +19,12 @@ func TestResolveDestination(t *testing.T) {
 		{name: "organization homepage", orgID: "org-123", want: "https://depot.dev/orgs/org-123/"},
 		{name: "Depot CI", location: "workflows", orgID: "org-123", want: "https://depot.dev/orgs/org-123/workflows"},
 		{name: "container builds alias", location: "builds", orgID: "org-123", want: "https://depot.dev/orgs/org-123/projects"},
+		{name: "container builds alias with trailing slash", location: "builds/", orgID: "org-123", want: "https://depot.dev/orgs/org-123/projects"},
 		{name: "GitHub Actions job", location: "github-actions/jobs/87413161724", orgID: "org-123", want: "https://depot.dev/orgs/org-123/github-actions/jobs/87413161724"},
 		{name: "encoded registry repository", location: "registry/repositories/depot%2Fsnapshots%2Fe2e-base/manifests", orgID: "org-123", want: "https://depot.dev/orgs/org-123/registry/repositories/depot%2Fsnapshots%2Fe2e-base/manifests"},
 		{name: "query and fragment", location: "usage/2026/07?section=github-actions#details", orgID: "org-123", want: "https://depot.dev/orgs/org-123/usage/2026/07?section=github-actions#details"},
 		{name: "complete Depot URL", location: "https://depot.dev/orgs/another-org/workflows?status=failed", want: "https://depot.dev/orgs/another-org/workflows?status=failed"},
+		{name: "complete Depot URL with mixed-case host", location: "https://Depot.Dev/orgs/another-org/workflows", want: "https://Depot.Dev/orgs/another-org/workflows"},
 	}
 
 	for _, tt := range tests {
@@ -37,6 +39,22 @@ func TestResolveDestination(t *testing.T) {
 				t.Fatalf("resolveDestination() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestResolveDestinationBuildShorthandDoesNotRequireOrganization(t *testing.T) {
+	t.Parallel()
+
+	lookup := func(context.Context, string) (string, error) {
+		return "https://depot.dev/orgs/org-123/projects/project-123/builds/build-123", nil
+	}
+
+	got, err := resolveDestination(context.Background(), "builds/build-123", "", lookup, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "https://depot.dev/orgs/org-123/projects/project-123/builds/build-123"; got != want {
+		t.Fatalf("resolveDestination() = %q, want %q", got, want)
 	}
 }
 

--- a/pkg/cmd/browse/browse_test.go
+++ b/pkg/cmd/browse/browse_test.go
@@ -29,7 +29,7 @@ func TestResolveDestination(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := resolveDestination(context.Background(), tt.location, tt.orgID, nil)
+			got, err := resolveDestination(context.Background(), tt.location, tt.orgID, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -49,7 +49,7 @@ func TestResolveDestinationBuildShorthand(t *testing.T) {
 		return "https://depot.dev/orgs/org-123/projects/project-123/builds/build-123", nil
 	}
 
-	got, err := resolveDestination(context.Background(), "builds/build-123?tab=logs#step", "org-123", lookup)
+	got, err := resolveDestination(context.Background(), "builds/build-123?tab=logs#step", "org-123", lookup, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +69,7 @@ func TestResolveDestinationRejectsUnsafeBuildURL(t *testing.T) {
 		return "https://example.com/phishing", nil
 	}
 
-	_, err := resolveDestination(context.Background(), "builds/build-123", "org-123", lookup)
+	_, err := resolveDestination(context.Background(), "builds/build-123", "org-123", lookup, nil)
 	if err == nil || !strings.Contains(err.Error(), "outside https://depot.dev") {
 		t.Fatalf("error = %v, want unsafe build URL error", err)
 	}
@@ -95,11 +95,92 @@ func TestResolveDestinationRejectsUnsafeOrIncompleteInput(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := resolveDestination(context.Background(), tt.location, tt.orgID, nil)
+			_, err := resolveDestination(context.Background(), tt.location, tt.orgID, nil, nil)
 			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 				t.Fatalf("error = %v, want containing %q", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestResolveDestinationLooksUpBareID(t *testing.T) {
+	t.Parallel()
+
+	lookup := func(_ context.Context, id, orgID string) ([]entityDestination, error) {
+		if id != "workflow-123" || orgID != "org-123" {
+			t.Fatalf("lookup(%q, %q), want workflow-123, org-123", id, orgID)
+		}
+		return []entityDestination{{
+			kind: "Depot CI workflow",
+			path: "workflows/workflow-123",
+			url:  "https://depot.dev/orgs/org-123/workflows/workflow-123",
+		}}, nil
+	}
+
+	got, err := resolveDestination(context.Background(), "workflow-123?view=graph#failed", "org-123", nil, lookup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "https://depot.dev/orgs/org-123/workflows/workflow-123?view=graph#failed"; got != want {
+		t.Fatalf("resolveDestination() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveDestinationDoesNotLookUpKnownPath(t *testing.T) {
+	t.Parallel()
+
+	lookup := func(context.Context, string, string) ([]entityDestination, error) {
+		t.Fatal("lookup called for known app path")
+		return nil, nil
+	}
+
+	got, err := resolveDestination(context.Background(), "registry", "org-123", nil, lookup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "https://depot.dev/orgs/org-123/registry"; got != want {
+		t.Fatalf("resolveDestination() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveDestinationRejectsAmbiguousBareID(t *testing.T) {
+	t.Parallel()
+
+	lookup := func(context.Context, string, string) ([]entityDestination, error) {
+		return []entityDestination{
+			{kind: "build", path: "builds/shared-id", url: "https://depot.dev/orgs/org-123/projects/project-1/builds/shared-id"},
+			{kind: "Depot CI workflow", path: "workflows/shared-id", url: "https://depot.dev/orgs/org-123/workflows/shared-id"},
+		}, nil
+	}
+
+	_, err := resolveDestination(context.Background(), "shared-id", "org-123", nil, lookup)
+	if err == nil || !strings.Contains(err.Error(), "shared-id is ambiguous") || !strings.Contains(err.Error(), "builds/shared-id") || !strings.Contains(err.Error(), "workflows/shared-id") {
+		t.Fatalf("error = %v, want ambiguity with explicit paths", err)
+	}
+}
+
+func TestResolveDestinationReportsUnknownBareID(t *testing.T) {
+	t.Parallel()
+
+	lookup := func(context.Context, string, string) ([]entityDestination, error) { return nil, nil }
+	_, err := resolveDestination(context.Background(), "missing-id", "org-123", nil, lookup)
+	if err == nil || !strings.Contains(err.Error(), "could not find missing-id") || !strings.Contains(err.Error(), "use an explicit path") {
+		t.Fatalf("error = %v, want not-found guidance", err)
+	}
+}
+
+func TestLookupEntityRecognizesGitHubActionsJobID(t *testing.T) {
+	t.Parallel()
+
+	matches, err := lookupEntity(context.Background(), "87413161724", "org-123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("matches = %v, want one", matches)
+	}
+	if got, want := matches[0].url, "https://depot.dev/orgs/org-123/github-actions/jobs/87413161724"; got != want {
+		t.Fatalf("URL = %q, want %q", got, want)
 	}
 }
 
@@ -216,9 +297,12 @@ func TestBrowseHelpHighlightsProductsAndDiscoveryCommands(t *testing.T) {
 
 	for _, want := range []string{
 		"If the intended product is unclear, ask the user which destination they want.",
+		"single-segment path is looked up as a build, Depot CI workflow or job",
 		"depot ci workflow list --output json",
+		"depot ci workflow show <workflow-id> --output json",
 		"depot list builds --project <project-id> --output json",
 		"gh run view <run-id> --json jobs",
+		"depot browse <id>",
 	} {
 		if !strings.Contains(help, want) {
 			t.Fatalf("help missing %q:\n%s", want, help)

--- a/pkg/cmd/browse/browse_test.go
+++ b/pkg/cmd/browse/browse_test.go
@@ -19,6 +19,7 @@ func TestResolveDestination(t *testing.T) {
 		want     string
 	}{
 		{name: "organization homepage", orgID: "org-123", want: "https://depot.dev/orgs/org-123/"},
+		{name: "Depot homepage without organization", want: "https://depot.dev"},
 		{name: "Depot CI", location: "workflows", orgID: "org-123", want: "https://depot.dev/orgs/org-123/workflows"},
 		{name: "container builds alias", location: "builds", orgID: "org-123", want: "https://depot.dev/orgs/org-123/projects"},
 		{name: "container builds alias with trailing slash", location: "builds/", orgID: "org-123", want: "https://depot.dev/orgs/org-123/projects"},
@@ -288,6 +289,26 @@ func TestBrowseOpensResolvedURL(t *testing.T) {
 		t.Fatal(err)
 	}
 	if got, want := opened, "https://depot.dev/orgs/org-123/projects"; got != want {
+		t.Fatalf("opened = %q, want %q", got, want)
+	}
+}
+
+func TestBrowseWithoutOrganizationOpensDepotHomepage(t *testing.T) {
+	t.Parallel()
+
+	var opened string
+	cmd := newCmdBrowse(dependencies{
+		currentOrg: func() string { return "" },
+		openURL: func(destination string) error {
+			opened = destination
+			return nil
+		},
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := opened, "https://depot.dev"; got != want {
 		t.Fatalf("opened = %q, want %q", got, want)
 	}
 }

--- a/pkg/cmd/browse/browse_test.go
+++ b/pkg/cmd/browse/browse_test.go
@@ -360,7 +360,7 @@ func TestBrowseHelpHighlightsProductsAndDiscoveryCommands(t *testing.T) {
 		"depot ci workflow list --output json",
 		"depot ci workflow show <workflow-id> --output json",
 		"depot list builds --project <project-id> --output json",
-		"gh run view <run-id> --json jobs",
+		"Find job IDs with: depot browse github-actions",
 		"depot browse <id>",
 	} {
 		if !strings.Contains(help, want) {

--- a/pkg/cmd/browse/browse_test.go
+++ b/pkg/cmd/browse/browse_test.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 	"testing"
 
+	"connectrpc.com/connect"
 	civ1 "github.com/depot/cli/pkg/proto/depot/ci/v1"
+	cliv1 "github.com/depot/cli/pkg/proto/depot/cli/v1"
 )
 
 func TestResolveDestination(t *testing.T) {
@@ -70,7 +72,7 @@ func TestResolveDestinationBuildShorthand(t *testing.T) {
 		return "https://depot.dev/orgs/org-123/projects/project-123/builds/build-123", nil
 	}
 
-	got, err := resolveDestination(context.Background(), "builds/build-123?tab=logs#step", "org-123", lookup, nil)
+	got, err := resolveDestination(context.Background(), "builds/build-123/?tab=logs#step", "org-123", lookup, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -231,16 +233,108 @@ func TestLookupCIJobRecoversWorkflowFromMetrics(t *testing.T) {
 	}
 }
 
-func TestFinishEntityLookupKeepsConfirmedMatches(t *testing.T) {
+func TestLookupEntityKeepsConfirmedMatchWhenSiblingLookupsFail(t *testing.T) {
 	t.Parallel()
 
-	matches := []entityDestination{{kind: "build", path: "builds/build-123", url: "https://depot.dev/build-123"}}
-	got, err := finishEntityLookup(matches, []string{"Depot CI workflow lookup failed: unavailable"})
+	buildTokens := make(chan string, 1)
+	workflowTokens := make(chan string, 1)
+	jobTokens := make(chan string, 1)
+	matches, err := lookupEntityWithDependencies(context.Background(), "build-123", "org-123", entityLookupDependencies{
+		resolveProjectToken: func(context.Context) (string, error) {
+			return "project-token", nil
+		},
+		resolveOrgToken: func(context.Context) (string, error) {
+			return "org-token", nil
+		},
+		getBuild: func(_ context.Context, token, _ string) (*cliv1.GetBuildResponse, error) {
+			buildTokens <- token
+			return &cliv1.GetBuildResponse{BuildUrl: "https://depot.dev/orgs/org-123/projects/project-123/builds/build-123"}, nil
+		},
+		getWorkflow: func(_ context.Context, token, _, _ string) (*civ1.GetWorkflowResponse, error) {
+			workflowTokens <- token
+			return nil, connect.NewError(connect.CodeUnavailable, errors.New("workflow service unavailable"))
+		},
+		getJobSummary: func(_ context.Context, token, _ string, _ *civ1.GetJobSummaryRequest) (*civ1.GetJobSummaryResponse, error) {
+			jobTokens <- token
+			return nil, connect.NewError(connect.CodePermissionDenied, errors.New("job lookup denied"))
+		},
+		getJobMetrics: func(context.Context, string, string, string) (*civ1.GetJobMetricsResponse, error) {
+			return nil, errors.New("unexpected job metrics lookup")
+		},
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(got) != 1 || got[0] != matches[0] {
-		t.Fatalf("matches = %v, want %v", got, matches)
+	want := entityDestination{
+		kind: "build",
+		path: "builds/build-123",
+		url:  "https://depot.dev/orgs/org-123/projects/project-123/builds/build-123",
+	}
+	if len(matches) != 1 || matches[0] != want {
+		t.Fatalf("matches = %v, want [%v]", matches, want)
+	}
+	if got := <-buildTokens; got != "project-token" {
+		t.Errorf("build token = %q, want project-token", got)
+	}
+	if got := <-workflowTokens; got != "org-token" {
+		t.Errorf("workflow token = %q, want org-token", got)
+	}
+	if got := <-jobTokens; got != "org-token" {
+		t.Errorf("job token = %q, want org-token", got)
+	}
+}
+
+func TestLookupEntityKeepsBuildMatchWhenOrgAuthenticationFails(t *testing.T) {
+	t.Parallel()
+
+	matches, err := lookupEntityWithDependencies(context.Background(), "build-123", "org-123", entityLookupDependencies{
+		resolveProjectToken: func(context.Context) (string, error) { return "project-token", nil },
+		resolveOrgToken:     func(context.Context) (string, error) { return "", errors.New("org auth unavailable") },
+		getBuild: func(context.Context, string, string) (*cliv1.GetBuildResponse, error) {
+			return &cliv1.GetBuildResponse{BuildUrl: "https://depot.dev/orgs/org-123/projects/project-123/builds/build-123"}, nil
+		},
+		getWorkflow: func(context.Context, string, string, string) (*civ1.GetWorkflowResponse, error) {
+			return nil, errors.New("unexpected workflow lookup")
+		},
+		getJobSummary: func(context.Context, string, string, *civ1.GetJobSummaryRequest) (*civ1.GetJobSummaryResponse, error) {
+			return nil, errors.New("unexpected job lookup")
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 || matches[0].kind != "build" {
+		t.Fatalf("matches = %v, want one build", matches)
+	}
+}
+
+func TestLookupEntityKeepsWorkflowMatchWhenProjectAuthenticationFails(t *testing.T) {
+	t.Parallel()
+
+	matches, err := lookupEntityWithDependencies(context.Background(), "workflow-123", "org-123", entityLookupDependencies{
+		resolveProjectToken: func(context.Context) (string, error) { return "", errors.New("project auth unavailable") },
+		resolveOrgToken:     func(context.Context) (string, error) { return "org-token", nil },
+		getBuild: func(context.Context, string, string) (*cliv1.GetBuildResponse, error) {
+			return nil, errors.New("unexpected build lookup")
+		},
+		getWorkflow: func(_ context.Context, token, _, _ string) (*civ1.GetWorkflowResponse, error) {
+			if token != "org-token" {
+				return nil, errors.New("workflow received wrong token")
+			}
+			return &civ1.GetWorkflowResponse{WorkflowId: "workflow-123"}, nil
+		},
+		getJobSummary: func(context.Context, string, string, *civ1.GetJobSummaryRequest) (*civ1.GetJobSummaryResponse, error) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("job not found"))
+		},
+		getJobMetrics: func(context.Context, string, string, string) (*civ1.GetJobMetricsResponse, error) {
+			return nil, errors.New("unexpected job metrics lookup")
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 || matches[0].kind != "Depot CI workflow" {
+		t.Fatalf("matches = %v, want one Depot CI workflow", matches)
 	}
 }
 

--- a/pkg/cmd/browse/browse_test.go
+++ b/pkg/cmd/browse/browse_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	civ1 "github.com/depot/cli/pkg/proto/depot/ci/v1"
 )
 
 func TestResolveDestination(t *testing.T) {
@@ -199,6 +201,45 @@ func TestLookupEntityRecognizesGitHubActionsJobID(t *testing.T) {
 	}
 	if got, want := matches[0].url, "https://depot.dev/orgs/org-123/github-actions/jobs/87413161724"; got != want {
 		t.Fatalf("URL = %q, want %q", got, want)
+	}
+}
+
+func TestLookupCIJobRecoversWorkflowFromMetrics(t *testing.T) {
+	t.Parallel()
+
+	destination, err := lookupCIJob(
+		context.Background(),
+		"token-123",
+		"org-123",
+		"job-123",
+		func(context.Context, string, string, *civ1.GetJobSummaryRequest) (*civ1.GetJobSummaryResponse, error) {
+			return &civ1.GetJobSummaryResponse{JobId: "job-123", JobStatus: "queued", EmptyReason: "no_attempt"}, nil
+		},
+		func(context.Context, string, string, string) (*civ1.GetJobMetricsResponse, error) {
+			return &civ1.GetJobMetricsResponse{
+				Workflow: &civ1.CIMetricsWorkflowContext{WorkflowId: "workflow-123"},
+				Job:      &civ1.CIMetricsJobContext{JobId: "job-123"},
+			}, nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := destination.url, "https://depot.dev/orgs/org-123/workflows/workflow-123/jobs/job-123"; got != want {
+		t.Fatalf("URL = %q, want %q", got, want)
+	}
+}
+
+func TestFinishEntityLookupKeepsConfirmedMatches(t *testing.T) {
+	t.Parallel()
+
+	matches := []entityDestination{{kind: "build", path: "builds/build-123", url: "https://depot.dev/build-123"}}
+	got, err := finishEntityLookup(matches, []string{"Depot CI workflow lookup failed: unavailable"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0] != matches[0] {
+		t.Fatalf("matches = %v, want %v", got, matches)
 	}
 }
 

--- a/pkg/cmd/browse/browse_test.go
+++ b/pkg/cmd/browse/browse_test.go
@@ -126,7 +126,7 @@ func TestResolveDestinationRejectsUnsafeOrIncompleteInput(t *testing.T) {
 	}
 }
 
-func TestResolveDestinationLooksUpBareID(t *testing.T) {
+func TestResolveDestinationDecodesBareIDForLookup(t *testing.T) {
 	t.Parallel()
 
 	lookup := func(_ context.Context, id, orgID string) ([]entityDestination, error) {
@@ -140,7 +140,7 @@ func TestResolveDestinationLooksUpBareID(t *testing.T) {
 		}}, nil
 	}
 
-	got, err := resolveDestination(context.Background(), "workflow-123?view=graph#failed", "org-123", nil, lookup)
+	got, err := resolveDestination(context.Background(), "workflow%2D123?view=graph#failed", "org-123", nil, lookup)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -7,6 +7,7 @@ import (
 
 	bakeCmd "github.com/depot/cli/pkg/cmd/bake"
 	"github.com/depot/cli/pkg/cmd/blog"
+	browseCmd "github.com/depot/cli/pkg/cmd/browse"
 	buildCmd "github.com/depot/cli/pkg/cmd/build"
 	cacheCmd "github.com/depot/cli/pkg/cmd/cache"
 	cargoCmd "github.com/depot/cli/pkg/cmd/cargo"
@@ -65,6 +66,7 @@ func NewCmdRoot(version, buildDate string) *cobra.Command {
 	// Child commands
 	cmd.AddCommand(bakeCmd.NewCmdBake())
 	cmd.AddCommand(blog.NewCmdBlog())
+	cmd.AddCommand(browseCmd.NewCmdBrowse())
 	cmd.AddCommand(buildCmd.NewCmdBuild())
 	cmd.AddCommand(cacheCmd.NewCmdCache())
 	cmd.AddCommand(cargoCmd.NewCmdCargo())

--- a/pkg/cmd/root/root_test.go
+++ b/pkg/cmd/root/root_test.go
@@ -2,12 +2,16 @@ package root
 
 import "testing"
 
-func TestRootRegistersTestsCommand(t *testing.T) {
+func TestRootRegistersCommands(t *testing.T) {
 	cmd := NewCmdRoot("test-version", "test-date")
+	registered := map[string]bool{}
 	for _, child := range cmd.Commands() {
-		if child.Name() == "tests" {
-			return
+		registered[child.Name()] = true
+	}
+
+	for _, name := range []string{"browse", "tests"} {
+		if !registered[name] {
+			t.Errorf("expected root command to register %s command", name)
 		}
 	}
-	t.Fatal("expected root command to register tests command")
 }


### PR DESCRIPTION
This PR adds a very simple command to go from CLI to browser:

- `depot browse` -> https://depot.dev (unauthenticated)
- `depot browse` -> https://depot.dev/orgs/org-id
- `depot browse workflows` -> https://depot.dev/orgs/org-id/workflows
- `depot browse workflows/some-id` -> https://depot.dev/orgs/org-id/workflows/some-id
- `depot browse registry` -> https://depot.dev/orgs/org-id/registry
- `depot browse some-id` -> https://depot.dev/orgs/org-id/{workflows,projects/builds,github-actions}/some-id (whichever matches).

A bit gimmick, but might be useful when you've started with downloading the CLI through brew or have been using stripe projects, etc.

---

## Summary

Users and agents can now open any organization-scoped Depot destination from the CLI while relying on the app's existing information architecture. The help leads with Depot CI and Container Builds, then GitHub Action Runners, and includes commands for discovering workflow, build, and job IDs.

Container Builds get two conveniences: `builds` aliases to `projects`, and `builds/<build-id>` resolves the canonical project build URL through the API. Complete URLs and API-returned build URLs are constrained to `https://depot.dev`; `--no-browser` makes resolution inspectable and script-friendly.

An unrecognized single-segment path is treated as an entity ID. Numeric IDs open GitHub Actions jobs directly; other IDs are checked concurrently against builds, Depot CI workflows, and Depot CI jobs. A unique match opens its canonical page, while ambiguity fails with explicit paths rather than guessing.

Fixes DEP-5420.

## Validation

- `go test ./...`
- `golangci-lint run --timeout 5m --new-from-rev origin/main` — 0 issues
- Rendered `depot browse --help` and smoke-tested workflows, builds, a complete URL, and a bare GitHub Actions job ID with `--no-browser`

## Post-deploy monitoring & validation

This is a local CLI-only change with no server rollout. After release, watch CLI/support reports for systematic browser-open or build-lookup failures; revert the release change if generated Depot URLs do not resolve correctly.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New API-backed URL resolution and a shared Windows browser-launch change affect login and browse; mitigations include depot.dev-only URL checks and explicit ambiguity handling.
> 
> **Overview**
> Adds **`depot browse`** to resolve Depot web URLs and open them in the default browser (or print them with **`--no-browser`** / **`--org`**). Relative paths map under the current org; full URLs must be **`https://depot.dev`**; **`builds`** aliases to **`projects`**; **`builds/<id>`** resolves the canonical build page via the API.
> 
> Bare single-segment IDs trigger concurrent lookups (build, Depot CI workflow/job, numeric GitHub Actions job), with ambiguity and not-found errors instead of guessing. API-returned build URLs are restricted to **`depot.dev`**, and relative paths reject **`..`** segments.
> 
> **`OpenURL`** is exported from **`pkg/api`** with a testable **`browserCommand`** helper; **Windows** opening switches from **`cmd /c start`** to **`rundll32 url.dll,FileProtocolHandler`** (also used during device login). The root command registers **`browse`**; tests cover resolution, lookups, and registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d7034cf7b1bb2a4ba604fa6cd3248a7eac29784. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->