### PR TITLE
docker: fall back to floating driver image tags during release window

### DIFF
--- a/pkg/cmd/docker/docker.go
+++ b/pkg/cmd/docker/docker.go
@@ -178,7 +178,15 @@ func uninstallDepotPlugin(dir string) error {
 
 const depotCLIImageRepo = "public.ecr.aws/depot/cli:"
 
-// driverImageCandidates returns the buildkit driver image references to try, in
+// driverImageCandidate is one image reference to try for the buildkit driver.
+// mutable marks a floating tag (<major>.<minor>, <major>, latest) whose contents
+// can change over time; the exact X.Y.Z release tag is immutable.
+type driverImageCandidate struct {
+	ref     string
+	mutable bool
+}
+
+// driverImageCandidates returns the driver image references to try, in
 // preference order: the exact CLI version, then the floating <major>.<minor>
 // and <major> tags.
 //
@@ -189,49 +197,128 @@ const depotCLIImageRepo = "public.ecr.aws/depot/cli:"
 // Falling back to those keeps configure-docker working during that window.
 // See DEP-5314.
 //
-// Fallbacks are only offered for clean release versions; dev/prerelease builds
-// try the exact tag only, matching prior behavior.
-func driverImageCandidates(cliVersion string) []string {
-	candidates := []string{depotCLIImageRepo + cliVersion}
-
+// Floating fallbacks are only added for a clean release version (X.Y.Z, no
+// prerelease). For anything else (dev, prerelease, `latest`) the single exact
+// candidate is itself treated as mutable.
+func driverImageCandidates(cliVersion string) []driverImageCandidate {
 	v, err := goversion.NewVersion(cliVersion)
-	if err != nil || v.Prerelease() != "" {
+	cleanRelease := err == nil && v.Prerelease() == ""
+
+	exact := depotCLIImageRepo + cliVersion
+	candidates := []driverImageCandidate{{ref: exact, mutable: !cleanRelease}}
+	if !cleanRelease {
 		return candidates
 	}
 
 	seg := v.Segments()
-	if len(seg) >= 2 {
-		if mm := fmt.Sprintf("%s%d.%d", depotCLIImageRepo, seg[0], seg[1]); mm != candidates[0] {
-			candidates = append(candidates, mm)
-		}
-		if mj := fmt.Sprintf("%s%d", depotCLIImageRepo, seg[0]); mj != candidates[0] {
-			candidates = append(candidates, mj)
-		}
+	if mm := fmt.Sprintf("%s%d.%d", depotCLIImageRepo, seg[0], seg[1]); mm != exact {
+		candidates = append(candidates, driverImageCandidate{ref: mm, mutable: true})
+	}
+	if mj := fmt.Sprintf("%s%d", depotCLIImageRepo, seg[0]); mj != exact {
+		candidates = append(candidates, driverImageCandidate{ref: mj, mutable: true})
 	}
 	return candidates
 }
 
-// resolveDriverImage returns the first candidate image that can be pulled,
-// retrying each a few times to ride out transient registry errors before
-// falling through to the next.
-func resolveDriverImage(ctx context.Context, dockerCli command.Cli, candidates []string) (string, error) {
-	return selectDriverImage(candidates, func(image string) error {
+// resolveDriverImageForBuild resolves the driver image for the current CLI
+// build. It maps the dev version to `latest`, picks the best available candidate
+// (falling back to floating tags during the post-release publish window), warns
+// on fallback, and returns an immutable reference safe to persist and to reuse
+// by string comparison. Shared by configure-docker and UpdateDrivers so both
+// make the same decision.
+func resolveDriverImageForBuild(ctx context.Context, dockerCli command.Cli) (string, error) {
+	version := build.Version
+	if version == "0.0.0-dev" {
+		version = "latest"
+	}
+
+	candidates := driverImageCandidates(version)
+	ref, fellBack, err := resolveDriverImage(ctx, dockerCli, candidates)
+	if err != nil {
+		return "", err
+	}
+	if fellBack {
+		fmt.Fprintf(os.Stderr, "depot: driver image %s unavailable, falling back to %s\n", candidates[0].ref, ref)
+	}
+	return ref, nil
+}
+
+// resolveDriverImage returns an immutable reference for the first candidate that
+// can be pulled, retrying each a few times to ride out transient registry
+// errors before falling through to the next. A mutable tag is pinned to the
+// digest just pulled so a later move of the tag can't leave the persisted node
+// config or a reused driver container pointing at different contents. fellBack
+// reports whether a candidate other than the exact tag was used.
+func resolveDriverImage(ctx context.Context, dockerCli command.Cli, candidates []driverImageCandidate) (ref string, fellBack bool, err error) {
+	chosen, err := selectDriverImage(candidates, func(c driverImageCandidate) error {
+		// A mutable tag's local copy may be stale, so force a registry pull to
+		// fetch the current image before we pin it.
 		return retry.Retry(func() error {
-			return DownloadImage(ctx, dockerCli, image)
+			return downloadImage(ctx, dockerCli, c.ref, c.mutable)
 		}, 3)
 	})
+	if err != nil {
+		return "", false, err
+	}
+
+	fellBack = chosen.ref != candidates[0].ref
+	if !chosen.mutable {
+		return chosen.ref, fellBack, nil
+	}
+	if pinned, perr := pinnedImageRef(ctx, dockerCli, chosen.ref); perr == nil {
+		return pinned, fellBack, nil
+	}
+	// If the digest can't be read, the tag is still usable; accept the small
+	// staleness risk rather than failing the resolve.
+	return chosen.ref, fellBack, nil
 }
 
 // selectDriverImage returns the first candidate for which pull succeeds, trying
 // them in order, or the last error if every candidate fails.
-func selectDriverImage(candidates []string, pull func(image string) error) (string, error) {
+func selectDriverImage(candidates []driverImageCandidate, pull func(driverImageCandidate) error) (driverImageCandidate, error) {
 	var err error
-	for _, image := range candidates {
-		if err = pull(image); err == nil {
-			return image, nil
+	for _, c := range candidates {
+		if err = pull(c); err == nil {
+			return c, nil
 		}
 	}
-	return "", err
+	return driverImageCandidate{}, err
+}
+
+// pinnedImageRef returns imageName rewritten to its immutable repo@sha256 digest
+// form, using the digest of the locally present image.
+func pinnedImageRef(ctx context.Context, dockerCli command.Cli, imageName string) (string, error) {
+	inspect, _, err := dockerCli.Client().ImageInspectWithRaw(ctx, imageName)
+	if err != nil {
+		return "", err
+	}
+
+	// Split off the tag to get the bare repo (a registry port colon, if any,
+	// sorts before the last path separator, so only the tag colon matches here).
+	repo := imageName
+	if i := strings.LastIndex(imageName, ":"); i > strings.LastIndex(imageName, "/") {
+		repo = imageName[:i]
+	}
+	for _, rd := range inspect.RepoDigests {
+		if strings.HasPrefix(rd, repo+"@") {
+			return rd, nil
+		}
+	}
+	return "", fmt.Errorf("no repo digest found for %s", imageName)
+}
+
+// hasDepotDriverNode reports whether any node group already uses a depot driver
+// image, i.e. whether there is anything for UpdateDrivers to update.
+func hasDepotDriverNode(nodeGroups []*store.NodeGroup) bool {
+	for _, nodeGroup := range nodeGroups {
+		for _, node := range nodeGroup.Nodes {
+			image := node.DriverOpts["image"]
+			if strings.HasPrefix(image, "ghcr.io/depot/cli") || strings.HasPrefix(image, "public.ecr.aws/depot/cli") {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func runConfigureBuildx(ctx context.Context, dockerCli command.Cli, project, token string) error {
@@ -252,13 +339,9 @@ func runConfigureBuildx(ctx context.Context, dockerCli command.Cli, project, tok
 	// Resolve the driver image before opening the store transaction, so the
 	// registry pulls (and release-window fallback retries) don't run while the
 	// cross-process store lock is held (DEP-5314).
-	version := build.Version
-	image, err := resolveDriverImage(ctx, dockerCli, driverImageCandidates(version))
+	image, err := resolveDriverImageForBuild(ctx, dockerCli)
 	if err != nil {
-		return fmt.Errorf("unable create driver container: %w", err)
-	}
-	if want := depotCLIImageRepo + version; image != want {
-		fmt.Fprintf(os.Stderr, "depot: driver image %s unavailable, falling back to %s\n", want, image)
+		return fmt.Errorf("unable to create driver container: %w", err)
 	}
 
 	configStore, err := store.New(confutil.ConfigDir(dockerCli))
@@ -414,36 +497,49 @@ func StopDepotNodes(ctx context.Context, client dockerclient.APIClient, nodes []
 }
 
 func UpdateDrivers(ctx context.Context, dockerCli command.Cli) error {
-	// Resolve the target driver image before tearing down the existing drivers,
-	// so a failed resolve (e.g. all candidate tags unreachable) leaves the
-	// working drivers in place rather than deleting them (DEP-5314).
-	version := build.Version
-	if version == "0.0.0-dev" {
-		version = "latest"
+	// Check whether there is anything to update before doing any registry work.
+	// This runs in a background goroutine on every build, so a machine with no
+	// depot driver nodes must not pull the driver image. Read the store, then
+	// release the lock before the (network) resolve below so it isn't held
+	// during pulls (DEP-5314).
+	txn, release, err := storeutil.GetStore(dockerCli)
+	if err != nil {
+		return fmt.Errorf("unable to get docker store: %w", err)
 	}
-	resolvedImage, err := resolveDriverImage(ctx, dockerCli, driverImageCandidates(version))
+	nodeGroups, err := txn.List()
+	if err != nil {
+		release()
+		return fmt.Errorf("unable to list node groups: %w", err)
+	}
+	hasDepot := hasDepotDriverNode(nodeGroups)
+	release()
+	if !hasDepot {
+		return nil
+	}
+
+	// Resolve the driver image before tearing down the existing drivers, so a
+	// failed resolve leaves the working drivers in place rather than deleting
+	// them (DEP-5314).
+	resolvedImage, err := resolveDriverImageForBuild(ctx, dockerCli)
 	if err != nil {
 		return fmt.Errorf("unable to resolve driver image: %w", err)
-	}
-	if want := depotCLIImageRepo + version; resolvedImage != want {
-		fmt.Fprintf(os.Stderr, "depot: driver image %s unavailable, falling back to %s\n", want, resolvedImage)
 	}
 
 	nodes, err := ListDepotNodes(ctx, dockerCli.Client())
 	if err != nil {
 		return err
 	}
-	err = StopDepotNodes(ctx, dockerCli.Client(), nodes)
-	if err != nil {
+	if err := StopDepotNodes(ctx, dockerCli.Client(), nodes); err != nil {
 		return err
 	}
-	txn, release, err := storeutil.GetStore(dockerCli)
+
+	txn, release, err = storeutil.GetStore(dockerCli)
 	if err != nil {
 		return fmt.Errorf("unable to get docker store: %w", err)
 	}
 	defer release()
 
-	nodeGroups, err := txn.List()
+	nodeGroups, err = txn.List()
 	if err != nil {
 		return fmt.Errorf("unable to list node groups: %w", err)
 	}
@@ -519,13 +615,24 @@ func Bootstrap(ctx context.Context, dockerCli command.Cli, imageName, projectNam
 }
 
 func DownloadImage(ctx context.Context, dockerCli command.Cli, imageName string) error {
+	return downloadImage(ctx, dockerCli, imageName, false)
+}
+
+// downloadImage pulls imageName. When forcePull is false, an image already
+// present locally is accepted without contacting the registry. When true, the
+// registry is always consulted, so a mutable/floating tag (e.g. <major>.<minor>)
+// is refreshed to its current digest instead of trusting a possibly stale local
+// copy.
+func downloadImage(ctx context.Context, dockerCli command.Cli, imageName string, forcePull bool) error {
 	client := dockerCli.Client()
 
-	images, err := client.ImageList(ctx, dockertypes.ImageListOptions{
-		Filters: filters.NewArgs(filters.Arg("reference", imageName)),
-	})
-	if err == nil && len(images) > 0 {
-		return nil
+	if !forcePull {
+		images, err := client.ImageList(ctx, dockertypes.ImageListOptions{
+			Filters: filters.NewArgs(filters.Arg("reference", imageName)),
+		})
+		if err == nil && len(images) > 0 {
+			return nil
+		}
 	}
 
 	ra, err := imagetools.RegistryAuthForRef(imageName, dockerCli.ConfigFile())

--- a/pkg/cmd/docker/docker.go
+++ b/pkg/cmd/docker/docker.go
@@ -249,6 +249,18 @@ func runConfigureBuildx(ctx context.Context, dockerCli command.Cli, project, tok
 		return errors.Errorf("unknown project ID (run `depot init` or use --project or $DEPOT_PROJECT_ID)")
 	}
 
+	// Resolve the driver image before opening the store transaction, so the
+	// registry pulls (and release-window fallback retries) don't run while the
+	// cross-process store lock is held (DEP-5314).
+	version := build.Version
+	image, err := resolveDriverImage(ctx, dockerCli, driverImageCandidates(version))
+	if err != nil {
+		return fmt.Errorf("unable create driver container: %w", err)
+	}
+	if want := depotCLIImageRepo + version; image != want {
+		fmt.Fprintf(os.Stderr, "depot: driver image %s unavailable, falling back to %s\n", want, image)
+	}
+
 	configStore, err := store.New(confutil.ConfigDir(dockerCli))
 	if err != nil {
 		return fmt.Errorf("unable to create docker configuration store: %w", err)
@@ -265,16 +277,6 @@ func runConfigureBuildx(ctx context.Context, dockerCli command.Cli, project, tok
 	endpoint, err := dockerutil.GetCurrentEndpoint(dockerCli)
 	if err != nil {
 		return fmt.Errorf("unable to get current docker endpoint: %w", err)
-	}
-
-	version := build.Version
-
-	image, err := resolveDriverImage(ctx, dockerCli, driverImageCandidates(version))
-	if err != nil {
-		return fmt.Errorf("unable create driver container: %w", err)
-	}
-	if want := depotCLIImageRepo + version; image != want {
-		fmt.Fprintf(os.Stderr, "depot: driver image %s unavailable, falling back to %s\n", want, image)
 	}
 
 	nodeName := "depot_" + projectName

--- a/pkg/cmd/docker/docker.go
+++ b/pkg/cmd/docker/docker.go
@@ -28,6 +28,7 @@ import (
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
 	dockerclient "github.com/docker/docker/client"
+	goversion "github.com/hashicorp/go-version"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -175,6 +176,57 @@ func uninstallDepotPlugin(dir string) error {
 	return nil
 }
 
+const depotCLIImageRepo = "public.ecr.aws/depot/cli:"
+
+// driverImageCandidates returns the buildkit driver image references to try, in
+// preference order: the exact CLI version, then the floating <major>.<minor>
+// and <major> tags.
+//
+// The exact-version image (public.ecr.aws/depot/cli:<version>) is published by a
+// separate, slower pipeline than the one that makes a release resolvable as
+// `latest`, so for up to ~an hour after a release the exact tag can 404 while
+// the floating tags still point at the previous, driver-compatible patch.
+// Falling back to those keeps configure-docker working during that window.
+// See DEP-5314.
+//
+// Fallbacks are only offered for clean release versions; dev/prerelease builds
+// try the exact tag only, matching prior behavior.
+func driverImageCandidates(cliVersion string) []string {
+	candidates := []string{depotCLIImageRepo + cliVersion}
+
+	v, err := goversion.NewVersion(cliVersion)
+	if err != nil || v.Prerelease() != "" {
+		return candidates
+	}
+
+	seg := v.Segments()
+	if len(seg) >= 2 {
+		if mm := fmt.Sprintf("%s%d.%d", depotCLIImageRepo, seg[0], seg[1]); mm != candidates[0] {
+			candidates = append(candidates, mm)
+		}
+		if mj := fmt.Sprintf("%s%d", depotCLIImageRepo, seg[0]); mj != candidates[0] {
+			candidates = append(candidates, mj)
+		}
+	}
+	return candidates
+}
+
+// resolveDriverImage returns the first candidate image that can be pulled,
+// retrying each a few times to ride out transient registry errors before
+// falling through to the next.
+func resolveDriverImage(ctx context.Context, dockerCli command.Cli, candidates []string) (string, error) {
+	var err error
+	for _, image := range candidates {
+		err = retry.Retry(func() error {
+			return DownloadImage(ctx, dockerCli, image)
+		}, 3)
+		if err == nil {
+			return image, nil
+		}
+	}
+	return "", err
+}
+
 func runConfigureBuildx(ctx context.Context, dockerCli command.Cli, project, token string) error {
 	var err error
 	token, err = helpers.ResolveProjectAuth(ctx, token)
@@ -210,7 +262,13 @@ func runConfigureBuildx(ctx context.Context, dockerCli command.Cli, project, tok
 
 	version := build.Version
 
-	image := "public.ecr.aws/depot/cli:" + version
+	image, err := resolveDriverImage(ctx, dockerCli, driverImageCandidates(version))
+	if err != nil {
+		return fmt.Errorf("unable create driver container: %w", err)
+	}
+	if want := depotCLIImageRepo + version; image != want {
+		fmt.Fprintf(os.Stderr, "depot: driver image %s is not published yet, falling back to %s\n", want, image)
+	}
 
 	nodeName := "depot_" + projectName
 	ng := &store.NodeGroup{
@@ -372,18 +430,29 @@ func UpdateDrivers(ctx context.Context, dockerCli command.Cli) error {
 		version = "latest"
 	}
 
+	// Resolve the target driver image once, falling back to floating tags when
+	// the exact version image isn't published yet (DEP-5314). If none resolve,
+	// leave the existing drivers untouched rather than pinning an unavailable tag.
+	resolvedImage, err := resolveDriverImage(ctx, dockerCli, driverImageCandidates(version))
+	if err != nil {
+		return fmt.Errorf("unable to resolve driver image: %w", err)
+	}
+	if want := depotCLIImageRepo + version; resolvedImage != want {
+		fmt.Fprintf(os.Stderr, "depot: driver image %s is not published yet, falling back to %s\n", want, resolvedImage)
+	}
+
 	for _, nodeGroup := range nodeGroups {
 		var save bool
 		for i, node := range nodeGroup.Nodes {
 			image := node.DriverOpts["image"]
 			if strings.HasPrefix(image, "ghcr.io/depot/cli") || strings.HasPrefix(image, "public.ecr.aws/depot/cli") {
-				nodeGroup.Nodes[i].DriverOpts["image"] = "public.ecr.aws/depot/cli:" + version
+				nodeGroup.Nodes[i].DriverOpts["image"] = resolvedImage
 				save = true
 
 				projectName := node.DriverOpts["env.DEPOT_PROJECT_ID"]
 				token := node.DriverOpts["env.DEPOT_TOKEN"]
 				platform := node.DriverOpts["env.DEPOT_PLATFORM"]
-				_ = Bootstrap(ctx, dockerCli, "public.ecr.aws/depot/cli:"+version, projectName, token, platform)
+				_ = Bootstrap(ctx, dockerCli, resolvedImage, projectName, token, platform)
 			}
 
 		}

--- a/pkg/cmd/docker/docker.go
+++ b/pkg/cmd/docker/docker.go
@@ -215,12 +215,19 @@ func driverImageCandidates(cliVersion string) []string {
 // retrying each a few times to ride out transient registry errors before
 // falling through to the next.
 func resolveDriverImage(ctx context.Context, dockerCli command.Cli, candidates []string) (string, error) {
-	var err error
-	for _, image := range candidates {
-		err = retry.Retry(func() error {
+	return selectDriverImage(candidates, func(image string) error {
+		return retry.Retry(func() error {
 			return DownloadImage(ctx, dockerCli, image)
 		}, 3)
-		if err == nil {
+	})
+}
+
+// selectDriverImage returns the first candidate for which pull succeeds, trying
+// them in order, or the last error if every candidate fails.
+func selectDriverImage(candidates []string, pull func(image string) error) (string, error) {
+	var err error
+	for _, image := range candidates {
+		if err = pull(image); err == nil {
 			return image, nil
 		}
 	}
@@ -267,7 +274,7 @@ func runConfigureBuildx(ctx context.Context, dockerCli command.Cli, project, tok
 		return fmt.Errorf("unable create driver container: %w", err)
 	}
 	if want := depotCLIImageRepo + version; image != want {
-		fmt.Fprintf(os.Stderr, "depot: driver image %s is not published yet, falling back to %s\n", want, image)
+		fmt.Fprintf(os.Stderr, "depot: driver image %s unavailable, falling back to %s\n", want, image)
 	}
 
 	nodeName := "depot_" + projectName
@@ -405,6 +412,21 @@ func StopDepotNodes(ctx context.Context, client dockerclient.APIClient, nodes []
 }
 
 func UpdateDrivers(ctx context.Context, dockerCli command.Cli) error {
+	// Resolve the target driver image before tearing down the existing drivers,
+	// so a failed resolve (e.g. all candidate tags unreachable) leaves the
+	// working drivers in place rather than deleting them (DEP-5314).
+	version := build.Version
+	if version == "0.0.0-dev" {
+		version = "latest"
+	}
+	resolvedImage, err := resolveDriverImage(ctx, dockerCli, driverImageCandidates(version))
+	if err != nil {
+		return fmt.Errorf("unable to resolve driver image: %w", err)
+	}
+	if want := depotCLIImageRepo + version; resolvedImage != want {
+		fmt.Fprintf(os.Stderr, "depot: driver image %s unavailable, falling back to %s\n", want, resolvedImage)
+	}
+
 	nodes, err := ListDepotNodes(ctx, dockerCli.Client())
 	if err != nil {
 		return err
@@ -422,23 +444,6 @@ func UpdateDrivers(ctx context.Context, dockerCli command.Cli) error {
 	nodeGroups, err := txn.List()
 	if err != nil {
 		return fmt.Errorf("unable to list node groups: %w", err)
-	}
-
-	// Update to the current build's version.
-	version := build.Version
-	if version == "0.0.0-dev" {
-		version = "latest"
-	}
-
-	// Resolve the target driver image once, falling back to floating tags when
-	// the exact version image isn't published yet (DEP-5314). If none resolve,
-	// leave the existing drivers untouched rather than pinning an unavailable tag.
-	resolvedImage, err := resolveDriverImage(ctx, dockerCli, driverImageCandidates(version))
-	if err != nil {
-		return fmt.Errorf("unable to resolve driver image: %w", err)
-	}
-	if want := depotCLIImageRepo + version; resolvedImage != want {
-		fmt.Fprintf(os.Stderr, "depot: driver image %s is not published yet, falling back to %s\n", want, resolvedImage)
 	}
 
 	for _, nodeGroup := range nodeGroups {

--- a/pkg/cmd/docker/docker_test.go
+++ b/pkg/cmd/docker/docker_test.go
@@ -12,32 +12,44 @@ func TestDriverImageCandidates(t *testing.T) {
 	tests := []struct {
 		name    string
 		version string
-		want    []string
+		want    []driverImageCandidate
 	}{
 		{
 			name:    "patch release falls back to major.minor and major",
 			version: "2.101.69",
-			want:    []string{repo + "2.101.69", repo + "2.101", repo + "2"},
+			want: []driverImageCandidate{
+				{ref: repo + "2.101.69", mutable: false},
+				{ref: repo + "2.101", mutable: true},
+				{ref: repo + "2", mutable: true},
+			},
 		},
 		{
 			name:    "zero patch still yields distinct floating tags",
 			version: "2.101.0",
-			want:    []string{repo + "2.101.0", repo + "2.101", repo + "2"},
+			want: []driverImageCandidate{
+				{ref: repo + "2.101.0", mutable: false},
+				{ref: repo + "2.101", mutable: true},
+				{ref: repo + "2", mutable: true},
+			},
 		},
 		{
 			name:    "major.minor.0 with zero minor",
 			version: "3.0.0",
-			want:    []string{repo + "3.0.0", repo + "3.0", repo + "3"},
+			want: []driverImageCandidate{
+				{ref: repo + "3.0.0", mutable: false},
+				{ref: repo + "3.0", mutable: true},
+				{ref: repo + "3", mutable: true},
+			},
 		},
 		{
-			name:    "prerelease build tries exact tag only",
+			name:    "prerelease build is a single mutable exact tag, no fallbacks",
 			version: "0.0.0-dev",
-			want:    []string{repo + "0.0.0-dev"},
+			want:    []driverImageCandidate{{ref: repo + "0.0.0-dev", mutable: true}},
 		},
 		{
-			name:    "non-semver tries exact tag only",
+			name:    "non-semver (latest) is a single mutable exact tag, no fallbacks",
 			version: "latest",
-			want:    []string{repo + "latest"},
+			want:    []driverImageCandidate{{ref: repo + "latest", mutable: true}},
 		},
 	}
 
@@ -45,37 +57,41 @@ func TestDriverImageCandidates(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := driverImageCandidates(tt.version)
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("driverImageCandidates(%q) = %v, want %v", tt.version, got, tt.want)
+				t.Errorf("driverImageCandidates(%q) = %+v, want %+v", tt.version, got, tt.want)
 			}
 		})
 	}
 }
 
 func TestSelectDriverImage(t *testing.T) {
-	candidates := []string{"repo:1.2.3", "repo:1.2", "repo:1"}
+	candidates := []driverImageCandidate{
+		{ref: "repo:1.2.3", mutable: false},
+		{ref: "repo:1.2", mutable: true},
+		{ref: "repo:1", mutable: true},
+	}
 
 	t.Run("returns exact when it pulls, without trying fallbacks", func(t *testing.T) {
 		var tried []string
-		got, err := selectDriverImage(candidates, func(image string) error {
-			tried = append(tried, image)
+		got, err := selectDriverImage(candidates, func(c driverImageCandidate) error {
+			tried = append(tried, c.ref)
 			return nil
 		})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if got != "repo:1.2.3" {
-			t.Errorf("got %q, want repo:1.2.3", got)
+		if got != candidates[0] {
+			t.Errorf("got %+v, want %+v", got, candidates[0])
 		}
 		if !reflect.DeepEqual(tried, []string{"repo:1.2.3"}) {
 			t.Errorf("tried %v, want only the exact tag", tried)
 		}
 	})
 
-	t.Run("falls back in order to the first candidate that pulls", func(t *testing.T) {
+	t.Run("falls back in order to the first candidate that pulls, carrying its mutable flag", func(t *testing.T) {
 		var tried []string
-		got, err := selectDriverImage(candidates, func(image string) error {
-			tried = append(tried, image)
-			if image == "repo:1.2.3" {
+		got, err := selectDriverImage(candidates, func(c driverImageCandidate) error {
+			tried = append(tried, c.ref)
+			if c.ref == "repo:1.2.3" {
 				return errors.New("not found")
 			}
 			return nil
@@ -83,8 +99,11 @@ func TestSelectDriverImage(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if got != "repo:1.2" {
-			t.Errorf("got %q, want repo:1.2", got)
+		if got != candidates[1] {
+			t.Errorf("got %+v, want %+v (the mutable major.minor tag)", got, candidates[1])
+		}
+		if !got.mutable {
+			t.Errorf("expected chosen fallback to be marked mutable so the caller pins it to a digest")
 		}
 		if !reflect.DeepEqual(tried, []string{"repo:1.2.3", "repo:1.2"}) {
 			t.Errorf("tried %v, want exact then major.minor", tried)
@@ -93,14 +112,14 @@ func TestSelectDriverImage(t *testing.T) {
 
 	t.Run("returns the last error when every candidate fails", func(t *testing.T) {
 		wantErr := errors.New("major failed")
-		got, err := selectDriverImage(candidates, func(image string) error {
-			if image == "repo:1" {
+		got, err := selectDriverImage(candidates, func(c driverImageCandidate) error {
+			if c.ref == "repo:1" {
 				return wantErr
 			}
 			return errors.New("not found")
 		})
-		if got != "" {
-			t.Errorf("got %q, want empty", got)
+		if got != (driverImageCandidate{}) {
+			t.Errorf("got %+v, want zero value", got)
 		}
 		if !errors.Is(err, wantErr) {
 			t.Errorf("got err %v, want last error %v", err, wantErr)

--- a/pkg/cmd/docker/docker_test.go
+++ b/pkg/cmd/docker/docker_test.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 )
@@ -48,4 +49,61 @@ func TestDriverImageCandidates(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSelectDriverImage(t *testing.T) {
+	candidates := []string{"repo:1.2.3", "repo:1.2", "repo:1"}
+
+	t.Run("returns exact when it pulls, without trying fallbacks", func(t *testing.T) {
+		var tried []string
+		got, err := selectDriverImage(candidates, func(image string) error {
+			tried = append(tried, image)
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "repo:1.2.3" {
+			t.Errorf("got %q, want repo:1.2.3", got)
+		}
+		if !reflect.DeepEqual(tried, []string{"repo:1.2.3"}) {
+			t.Errorf("tried %v, want only the exact tag", tried)
+		}
+	})
+
+	t.Run("falls back in order to the first candidate that pulls", func(t *testing.T) {
+		var tried []string
+		got, err := selectDriverImage(candidates, func(image string) error {
+			tried = append(tried, image)
+			if image == "repo:1.2.3" {
+				return errors.New("not found")
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "repo:1.2" {
+			t.Errorf("got %q, want repo:1.2", got)
+		}
+		if !reflect.DeepEqual(tried, []string{"repo:1.2.3", "repo:1.2"}) {
+			t.Errorf("tried %v, want exact then major.minor", tried)
+		}
+	})
+
+	t.Run("returns the last error when every candidate fails", func(t *testing.T) {
+		wantErr := errors.New("major failed")
+		got, err := selectDriverImage(candidates, func(image string) error {
+			if image == "repo:1" {
+				return wantErr
+			}
+			return errors.New("not found")
+		})
+		if got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+		if !errors.Is(err, wantErr) {
+			t.Errorf("got err %v, want last error %v", err, wantErr)
+		}
+	})
 }

--- a/pkg/cmd/docker/docker_test.go
+++ b/pkg/cmd/docker/docker_test.go
@@ -1,0 +1,51 @@
+package docker
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDriverImageCandidates(t *testing.T) {
+	repo := "public.ecr.aws/depot/cli:"
+
+	tests := []struct {
+		name    string
+		version string
+		want    []string
+	}{
+		{
+			name:    "patch release falls back to major.minor and major",
+			version: "2.101.69",
+			want:    []string{repo + "2.101.69", repo + "2.101", repo + "2"},
+		},
+		{
+			name:    "zero patch still yields distinct floating tags",
+			version: "2.101.0",
+			want:    []string{repo + "2.101.0", repo + "2.101", repo + "2"},
+		},
+		{
+			name:    "major.minor.0 with zero minor",
+			version: "3.0.0",
+			want:    []string{repo + "3.0.0", repo + "3.0", repo + "3"},
+		},
+		{
+			name:    "prerelease build tries exact tag only",
+			version: "0.0.0-dev",
+			want:    []string{repo + "0.0.0-dev"},
+		},
+		{
+			name:    "non-semver tries exact tag only",
+			version: "latest",
+			want:    []string{repo + "latest"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := driverImageCandidates(tt.version)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("driverImageCandidates(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

When a new CLI version is released, `latest` starts resolving to it before the matching `public.ecr.aws/depot/cli:<version>` image finishes publishing (a separate, slower pipeline — ~53 min gap observed for v2.101.69). During that window `depot configure-docker` fails, because the buildkit driver container is pinned to the exact `build.Version`:

```
Error: could not configure buildx: unable create driver container: unable to download image:
failed to resolve reference "public.ecr.aws/depot/cli:2.101.69": not found
```

Affects any workflow using `depot/use-action`/`setup-action` with `version: latest` (or unpinned) that hits `configure-docker`/buildx during the window. Reported by bastionplatforms (T-9503).

## Fix

Fall back through floating tags that still point at the previous, driver-compatible patch during the window: exact `<version>` → `<major>.<minor>` → `<major>`. The `package` job already publishes all three.

- `driverImageCandidates` builds the ordered list as `{ref, mutable}` entries — the exact `X.Y.Z` tag is immutable; floating tags are mutable. Semver-guarded: dev/prerelease/`latest` yield a single (mutable) exact candidate, no fallbacks.
- `resolveDriverImageForBuild` is the shared entry point for both call sites. It force-pulls mutable tags (bypassing the local-image cache so a stale cached floating tag isn't trusted) and **pins a winning floating tag to its `@sha256` digest**, so the persisted node-group config and the container (reused by image-string compare) can't later point at a moved tag. Warns on stderr only when it actually falls back.
- `runConfigureBuildx` resolves before opening the buildx store lock.
- `UpdateDrivers` (best-effort on every `depot build`) skips all registry work when there's no depot driver node, resolves **before** tearing down the running driver, and doesn't hold the store lock during pulls.

## Testing

- `TestDriverImageCandidates` — asserts both the ordered candidate list and the `mutable` flags: clean release (3 candidates), zero-patch, zero-minor, prerelease and non-semver/`latest` (single mutable exact, no fallbacks).
- `TestSelectDriverImage` — the fallback logic the PR exists for: exact wins without trying fallbacks; falls back in order and carries the chosen tag's `mutable` flag through so the caller digest-pins it; returns the last error when every candidate fails. (`selectDriverImage` was extracted as a seam specifically so this is testable without a Docker daemon.)
- `go build` / `go vet` / `gofmt` / `go mod tidy` all clean.
- **Not unit-tested:** the digest-pin (`pinnedImageRef`) and `forcePull` registry paths need a live Docker daemon + registry, and the real ECR 404 window can't be reproduced without an actual release gap. These were exercised by reasoning + the Cursor review rather than automated tests.

Closes DEP-5314

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes buildkit driver image resolution and UpdateDrivers teardown order on every build with Depot drivers; mistakes could break configure-docker or leave drivers inconsistent, but behavior is guarded and covered by new unit tests.
> 
> **Overview**
> Fixes **`depot configure-docker`** and background driver updates failing when the exact `public.ecr.aws/depot/cli:<version>` image is not yet published (~hour after a release) while `latest` already points at the new CLI.
> 
> Driver image selection now tries **exact version → `<major>.<minor>` → `<major>`** (semver releases only), with retries per tag. **`resolveDriverImageForBuild`** is shared by **`runConfigureBuildx`** and **`UpdateDrivers`**; both persist the same resolved ref (digest-pinned when a floating tag wins). **`UpdateDrivers`** skips registry work when no Depot driver nodes exist, resolves the image **before** stopping containers, and registry pulls run **outside** the buildx store lock.
> 
> **`downloadImage`** gains a **`forcePull`** path for mutable tags so fallbacks are not served from stale local caches. Stderr warns when a fallback is used. Unit tests cover candidate ordering and selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e994574b75e8cd016dd40af3491d8786fc4ee6c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
