### PR TITLE
release: publish container image before CLI binaries (DEP-5314)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,9 @@ jobs:
 
   package:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
+    # Release (tag) image builds are handled by release.yml so the image is
+    # published before the CLI binaries (DEP-5314); this job covers main/branch CI.
+    if: github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: read
       packages: write
@@ -156,7 +158,7 @@ jobs:
           registry-type: public
       - uses: depot/build-push-action@v1
         with:
-          push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
+          push: ${{ github.ref == 'refs/heads/main' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,62 @@ permissions:
   id-token: write
 
 jobs:
+  # Build and push the container image before the CLI binaries are released.
+  # `latest` only flips to a version once goreleaser uploads its binaries, and
+  # the release job now waits on this one, so the driver image is always present
+  # by the time `latest` points at the new version. If the image push fails, the
+  # release job is skipped and the release never completes (DEP-5314).
+  package:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev-')
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: depot/setup-action@v1
+      - uses: docker/metadata-action@v6
+        id: meta
+        with:
+          images: |
+            ghcr.io/depot/cli
+            public.ecr.aws/depot/cli
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+      - id: build-info
+        name: Set build information
+        run: |
+          echo "version=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}" >> $GITHUB_OUTPUT
+          echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+          echo "sentry-environment=release" >> $GITHUB_OUTPUT
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::375021575472:role/github-actions
+          aws-region: us-east-1
+      - uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+      - uses: depot/build-push-action@v1
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            LDFLAGS=-s -w -X github.com/depot/cli/internal/build.Version=${{ steps.build-info.outputs.version }} -X github.com/depot/cli/internal/build.Date=${{ steps.build-info.outputs.date }} -X github.com/depot/cli/internal/build.SentryEnvironment=${{ steps.build-info.outputs.sentry-environment }}
+
   release:
     runs-on: ubuntu-latest-16-cores
+    needs: package
     if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev-')
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Problem

`depot configure-docker` fails for ~an hour after each CLI release. When a release is published, the CLI binaries (goreleaser, `release.yml`) and the driver container image (`ci.yml` `package` job) build in parallel, and the image job is much slower (~53 min observed). `latest` starts resolving to the new version before its `public.ecr.aws/depot/cli:<version>` image exists, so the driver pin 404s. Reported by bastionplatforms (T-9503).

## Approach

Per discussion with Jacob, fix the ordering at the source instead of having the CLI fall back to a possibly-incompatible tag at runtime (the previous attempt, #544, now closed).

Key fact: `latest` only flips once the release has **binary assets** — `api/src/dl/github.ts` `getLatestRelease` falls back to the previous release while the newest one has no assets. goreleaser uploads those assets, so gating goreleaser on the image push means `latest` never points at a version whose image isn't published yet.

## Change

- `release.yml`: add a `package` job that builds+pushes the multi-arch image (ghcr + public ECR, semver tags), and make the `release` (goreleaser) job `needs: package`. If the image push fails, `release` is skipped and the release never completes.
- `ci.yml`: the `package` job no longer runs/pushes on tags (still covers main + branch CI); the release image push now lives in `release.yml`.

## Effect

- Normal release: image publishes → binaries publish → `latest` flips last, image guaranteed present.
- Image push fails: no binaries, `latest` stays on the previous version.
- No runtime fallback, no compatibility risk. Protects all CLI versions, including pinned ones.

## Testing

- `release.yml` passes `actionlint` clean; both files parse.
- The full release path can only be exercised by an actual release; worth a close look from someone who owns the release pipeline before merge.

Closes DEP-5314

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release ordering and where tag images are built; a misconfigured `needs` or `if` could block releases or skip image pushes until caught on a real tag.
> 
> **Overview**
> Fixes a post-release window where **`latest`** could point at a new CLI version before **`public.ecr.aws/depot/cli:<version>`** existed, breaking **`depot configure-docker`** until the slow CI image job finished.
> 
> **`release.yml`** gains a **`package`** job that builds and pushes the multi-arch image to GHCR and public ECR with semver tags, and the goreleaser **`release`** job now **`needs: package`**. If the image push fails, binaries are not published and the release does not complete.
> 
> **`ci.yml`** **`package`** is limited to non-PR, non-**`refs/tags/v`** events and only **`push`**es on **`main`** (tag pushes no longer build or push images there).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 514691afa77018441afaab5443a16c2c6a9d7b38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->