### PR TITLE
Add project get and update commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,53 @@ depot projects create --organization your-org-id --region us-west-2 --cache-stor
 | `cache-storage-policy` | Build cache to keep per architecture in GB (default: 50) |
 | `token`                | Depot API token                                          |
 
+#### `depot projects get`
+
+View a Depot project's details and configuration. Pass a project ID as an argument or with `--project-id`. If neither is provided, the command uses `DEPOT_PROJECT_ID` or the project configured in `depot.json`.
+
+**Example**
+
+```shell
+# View the project configured in the current directory
+depot projects get
+
+# View a specific project as JSON
+depot projects get your-project-id --output json
+```
+
+#### Flags for `projects get`
+
+| Name                | Description               |
+| ------------------- | ------------------------- |
+| `project-id` / `-p` | Depot project ID          |
+| `output` / `-o`     | Output format (`json`)    |
+| `token`             | Depot API token           |
+
+#### `depot projects update`
+
+Update a Depot project's name, region, or cache storage policy. Only values passed as flags are changed. Pass a project ID as an argument or with `--project-id`. If neither is provided, the command uses `DEPOT_PROJECT_ID` or the project configured in `depot.json`.
+
+**Example**
+
+```shell
+# Rename the project configured in the current directory
+depot projects update --name "New project name"
+
+# Update a specific project's region and cache storage policy
+depot projects update your-project-id --region eu-central-1 --cache-storage-policy 100
+```
+
+#### Flags for `projects update`
+
+| Name                   | Description                                    |
+| ---------------------- | ---------------------------------------------- |
+| `project-id` / `-p`    | Depot project ID                               |
+| `name`                 | Project name                                   |
+| `region`               | Build data storage region                      |
+| `cache-storage-policy` | Build cache to keep per architecture in GB     |
+| `output` / `-o`        | Output format (`json`)                         |
+| `token`                | Depot API token                                |
+
 #### `depot projects delete`
 
 Delete a Depot project. If no project ID is specified, the command will display an interactive list of projects to choose from.

--- a/pkg/cmd/projects/get.go
+++ b/pkg/cmd/projects/get.go
@@ -1,0 +1,69 @@
+package projects
+
+import (
+	"fmt"
+
+	corev1 "buf.build/gen/go/depot/api/protocolbuffers/go/depot/core/v1"
+	"connectrpc.com/connect"
+	"github.com/depot/cli/pkg/api"
+	"github.com/depot/cli/pkg/helpers"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdGet() *cobra.Command {
+	var (
+		projectID string
+		token     string
+		output    string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "get [<project-id>]",
+		Short: "Get project details",
+		Long: `Get the details and configuration of a Depot project.
+
+If no project ID is provided, the command uses DEPOT_PROJECT_ID or the project
+configured in depot.json in the current directory.`,
+		Example: `  # Get the project configured in the current directory
+  depot projects get
+
+  # Get a specific project as JSON
+  depot projects get <project-id> --output json`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateProjectOutput(output); err != nil {
+				return err
+			}
+
+			resolvedProjectID, err := resolveProjectID(args, projectID)
+			if err != nil {
+				return err
+			}
+
+			token, err := helpers.ResolveProjectAuth(cmd.Context(), token)
+			if err != nil {
+				return err
+			}
+			if token == "" {
+				return fmt.Errorf("missing API token, please run `depot login`")
+			}
+
+			request := connect.NewRequest(&corev1.GetProjectRequest{ProjectId: resolvedProjectID})
+			response, err := api.NewSDKProjectsClient().GetProject(
+				cmd.Context(),
+				api.WithAuthentication(request, token),
+			)
+			if err != nil {
+				return fmt.Errorf("failed to get project: %w", err)
+			}
+
+			return writeProjectOutput(cmd.OutOrStdout(), response.Msg.GetProject(), output)
+		},
+	}
+
+	cmd.Flags().StringVarP(&projectID, "project-id", "p", "", "Depot project ID")
+	cmd.Flags().StringVar(&token, "token", "", "Depot API token")
+	cmd.Flags().StringVarP(&output, "output", "o", "", "Output format (json)")
+
+	return cmd
+}

--- a/pkg/cmd/projects/output.go
+++ b/pkg/cmd/projects/output.go
@@ -1,0 +1,116 @@
+package projects
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"text/tabwriter"
+	"time"
+
+	corev1 "buf.build/gen/go/depot/api/protocolbuffers/go/depot/core/v1"
+	"github.com/depot/cli/pkg/helpers"
+)
+
+const bytesPerGigabyte int64 = 1024 * 1024 * 1024
+
+type projectOutput struct {
+	ProjectID      string              `json:"project_id"`
+	OrganizationID string              `json:"organization_id"`
+	Name           string              `json:"name"`
+	RegionID       string              `json:"region_id"`
+	CreatedAt      string              `json:"created_at,omitempty"`
+	CachePolicy    *corev1.CachePolicy `json:"cache_policy,omitempty"`
+}
+
+func newProjectOutput(project *corev1.Project) (*projectOutput, error) {
+	if project == nil {
+		return nil, fmt.Errorf("API returned no project")
+	}
+
+	var createdAt string
+	if project.GetCreatedAt() != nil {
+		createdAt = project.GetCreatedAt().AsTime().UTC().Format(time.RFC3339Nano)
+	}
+
+	return &projectOutput{
+		ProjectID:      project.GetProjectId(),
+		OrganizationID: project.GetOrganizationId(),
+		Name:           project.GetName(),
+		RegionID:       project.GetRegionId(),
+		CreatedAt:      createdAt,
+		CachePolicy:    project.GetCachePolicy(),
+	}, nil
+}
+
+func writeProjectOutput(w io.Writer, project *corev1.Project, output string) error {
+	view, err := newProjectOutput(project)
+	if err != nil {
+		return err
+	}
+
+	if output == "json" {
+		encoder := json.NewEncoder(w)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(view)
+	}
+
+	table := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(table, "Project ID:\t%s\n", view.ProjectID)
+	fmt.Fprintf(table, "Organization ID:\t%s\n", view.OrganizationID)
+	fmt.Fprintf(table, "Name:\t%s\n", view.Name)
+	fmt.Fprintf(table, "Region:\t%s\n", view.RegionID)
+	fmt.Fprintf(table, "Created:\t%s\n", valueOrDash(view.CreatedAt))
+	if view.CachePolicy != nil {
+		fmt.Fprintf(table, "Cache storage:\t%s\n", formatCacheStorage(view.CachePolicy.GetKeepBytes()))
+		fmt.Fprintf(table, "Cache retention:\t%s\n", formatCacheRetention(view.CachePolicy.GetKeepDays()))
+	}
+	return table.Flush()
+}
+
+func validateProjectOutput(output string) error {
+	switch output {
+	case "", "json":
+		return nil
+	default:
+		return fmt.Errorf("unsupported output %q (valid: json)", output)
+	}
+}
+
+func resolveProjectID(args []string, projectID string) (string, error) {
+	if len(args) > 0 {
+		if projectID != "" {
+			return "", fmt.Errorf("project ID must be specified as either an argument or --project-id, not both")
+		}
+		projectID = args[0]
+	}
+
+	projectID = helpers.ResolveProjectID(projectID)
+	if projectID == "" {
+		return "", fmt.Errorf("unknown project ID (run `depot init`, pass a project ID, use --project-id, or set $DEPOT_PROJECT_ID)")
+	}
+	return projectID, nil
+}
+
+func valueOrDash(value string) string {
+	if value == "" {
+		return "-"
+	}
+	return value
+}
+
+func formatCacheStorage(bytes int64) string {
+	if bytes == 0 {
+		return "No limit"
+	}
+	if bytes%bytesPerGigabyte == 0 {
+		return fmt.Sprintf("%d GB", bytes/bytesPerGigabyte)
+	}
+	return fmt.Sprintf("%d bytes", bytes)
+}
+
+func formatCacheRetention(days int32) string {
+	if days == 0 {
+		return "No limit"
+	}
+	return fmt.Sprintf("%d days", days)
+}

--- a/pkg/cmd/projects/projects.go
+++ b/pkg/cmd/projects/projects.go
@@ -16,6 +16,8 @@ func NewCmdProjects() *cobra.Command {
 	}
 
 	cmd.AddCommand(NewCmdCreate())
+	cmd.AddCommand(NewCmdGet())
+	cmd.AddCommand(NewCmdUpdate())
 	cmd.AddCommand(NewCmdDelete())
 	cmd.AddCommand(list.NewCmdProjects("list", "ls"))
 

--- a/pkg/cmd/projects/projects_test.go
+++ b/pkg/cmd/projects/projects_test.go
@@ -83,7 +83,15 @@ func TestGetProjectCallsAPIAndWritesJSON(t *testing.T) {
 }
 
 func TestUpdateProjectSendsOnlyChangedFields(t *testing.T) {
-	handler := &projectServiceRecorder{}
+	handler := &projectServiceRecorder{
+		project: &corev1.Project{
+			ProjectId: "project-123",
+			CachePolicy: &corev1.CachePolicy{
+				KeepBytes: 50 * bytesPerGigabyte,
+				KeepDays:  14,
+			},
+		},
+	}
 	setupProjectService(t, handler)
 
 	var stdout bytes.Buffer
@@ -119,6 +127,12 @@ func TestUpdateProjectSendsOnlyChangedFields(t *testing.T) {
 	}
 	if request.CachePolicy == nil || request.CachePolicy.GetKeepBytes() != 75*bytesPerGigabyte {
 		t.Fatalf("CachePolicy = %#v", request.CachePolicy)
+	}
+	if request.CachePolicy.GetKeepDays() != 14 {
+		t.Fatalf("CachePolicy.KeepDays = %d, want 14", request.CachePolicy.GetKeepDays())
+	}
+	if handler.getRequest == nil || handler.getRequest.GetProjectId() != "project-123" {
+		t.Fatalf("GetProject request = %#v, want project-123", handler.getRequest)
 	}
 	if handler.authorization != "Bearer token-123" {
 		t.Fatalf("Authorization = %q, want Bearer token-123", handler.authorization)

--- a/pkg/cmd/projects/projects_test.go
+++ b/pkg/cmd/projects/projects_test.go
@@ -1,0 +1,213 @@
+package projects
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"buf.build/gen/go/depot/api/connectrpc/go/depot/core/v1/corev1connect"
+	corev1 "buf.build/gen/go/depot/api/protocolbuffers/go/depot/core/v1"
+	"connectrpc.com/connect"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestProjectsCommandRegistration(t *testing.T) {
+	command := NewCmdProjects()
+	registered := make(map[string]bool)
+	for _, subcommand := range command.Commands() {
+		registered[subcommand.Name()] = true
+	}
+
+	for _, name := range []string{"create", "delete", "get", "list", "update"} {
+		if !registered[name] {
+			t.Errorf("subcommand %q not registered under `depot projects`", name)
+		}
+	}
+}
+
+func TestGetProjectCallsAPIAndWritesJSON(t *testing.T) {
+	handler := &projectServiceRecorder{
+		project: &corev1.Project{
+			ProjectId:      "project-123",
+			OrganizationId: "org-123",
+			Name:           "Example",
+			RegionId:       "eu-central-1",
+			CreatedAt:      timestamppb.New(time.Date(2026, time.July, 29, 12, 30, 0, 0, time.UTC)),
+			CachePolicy: &corev1.CachePolicy{
+				KeepBytes: 50 * bytesPerGigabyte,
+				KeepDays:  14,
+			},
+		},
+	}
+	setupProjectService(t, handler)
+
+	var stdout bytes.Buffer
+	command := NewCmdGet()
+	command.SetArgs([]string{"project-123", "--token", "token-123", "--output", "json"})
+	command.SetOut(&stdout)
+	command.SetErr(io.Discard)
+	command.SilenceUsage = true
+	command.SilenceErrors = true
+
+	if err := command.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if handler.getRequest == nil || handler.getRequest.GetProjectId() != "project-123" {
+		t.Fatalf("GetProject request = %#v, want project-123", handler.getRequest)
+	}
+	if handler.authorization != "Bearer token-123" {
+		t.Fatalf("Authorization = %q, want Bearer token-123", handler.authorization)
+	}
+
+	var output projectOutput
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, stdout.String())
+	}
+	if output.ProjectID != "project-123" || output.OrganizationID != "org-123" {
+		t.Fatalf("output = %#v", output)
+	}
+	if output.CreatedAt != "2026-07-29T12:30:00Z" {
+		t.Fatalf("created_at = %q", output.CreatedAt)
+	}
+	if output.CachePolicy == nil || output.CachePolicy.GetKeepDays() != 14 {
+		t.Fatalf("cache_policy = %#v", output.CachePolicy)
+	}
+}
+
+func TestUpdateProjectSendsOnlyChangedFields(t *testing.T) {
+	handler := &projectServiceRecorder{}
+	setupProjectService(t, handler)
+
+	var stdout bytes.Buffer
+	command := NewCmdUpdate()
+	command.SetArgs([]string{
+		"--project-id", "project-123",
+		"--name", "Renamed",
+		"--cache-storage-policy", "75",
+		"--token", "token-123",
+		"--output", "json",
+	})
+	command.SetOut(&stdout)
+	command.SetErr(io.Discard)
+	command.SilenceUsage = true
+	command.SilenceErrors = true
+
+	if err := command.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	request := handler.updateRequest
+	if request == nil {
+		t.Fatal("UpdateProject was not called")
+	}
+	if request.GetProjectId() != "project-123" {
+		t.Fatalf("ProjectId = %q", request.GetProjectId())
+	}
+	if request.Name == nil || request.GetName() != "Renamed" {
+		t.Fatalf("Name = %#v", request.Name)
+	}
+	if request.RegionId != nil {
+		t.Fatalf("RegionId = %#v, want nil", request.RegionId)
+	}
+	if request.CachePolicy == nil || request.CachePolicy.GetKeepBytes() != 75*bytesPerGigabyte {
+		t.Fatalf("CachePolicy = %#v", request.CachePolicy)
+	}
+	if handler.authorization != "Bearer token-123" {
+		t.Fatalf("Authorization = %q, want Bearer token-123", handler.authorization)
+	}
+
+	var output projectOutput
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, stdout.String())
+	}
+	if output.ProjectID != "project-123" || output.Name != "Renamed" {
+		t.Fatalf("output = %#v", output)
+	}
+}
+
+func TestUpdateProjectRequiresAChange(t *testing.T) {
+	command := NewCmdUpdate()
+	command.SetArgs([]string{"project-123"})
+	command.SetOut(io.Discard)
+	command.SetErr(io.Discard)
+	command.SilenceUsage = true
+	command.SilenceErrors = true
+
+	err := command.Execute()
+	if err == nil || !strings.Contains(err.Error(), "one of --name, --region, or --cache-storage-policy is required") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestProjectCommandsRejectArgumentAndProjectIDFlag(t *testing.T) {
+	command := NewCmdGet()
+	command.SetArgs([]string{"project-123", "--project-id", "project-456"})
+	command.SetOut(io.Discard)
+	command.SetErr(io.Discard)
+	command.SilenceUsage = true
+	command.SilenceErrors = true
+
+	err := command.Execute()
+	if err == nil || !strings.Contains(err.Error(), "either an argument or --project-id, not both") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestGetProjectRejectsUnsupportedOutputBeforeAuth(t *testing.T) {
+	command := NewCmdGet()
+	command.SetArgs([]string{"project-123", "--output", "yaml"})
+	command.SetOut(io.Discard)
+	command.SetErr(io.Discard)
+	command.SilenceUsage = true
+	command.SilenceErrors = true
+
+	err := command.Execute()
+	if err == nil || !strings.Contains(err.Error(), `unsupported output "yaml"`) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+type projectServiceRecorder struct {
+	corev1connect.UnimplementedProjectServiceHandler
+
+	project       *corev1.Project
+	getRequest    *corev1.GetProjectRequest
+	updateRequest *corev1.UpdateProjectRequest
+	authorization string
+}
+
+func (h *projectServiceRecorder) GetProject(_ context.Context, request *connect.Request[corev1.GetProjectRequest]) (*connect.Response[corev1.GetProjectResponse], error) {
+	h.getRequest = request.Msg
+	h.authorization = request.Header().Get("Authorization")
+	return connect.NewResponse(&corev1.GetProjectResponse{Project: h.project}), nil
+}
+
+func (h *projectServiceRecorder) UpdateProject(_ context.Context, request *connect.Request[corev1.UpdateProjectRequest]) (*connect.Response[corev1.UpdateProjectResponse], error) {
+	h.updateRequest = request.Msg
+	h.authorization = request.Header().Get("Authorization")
+	return connect.NewResponse(&corev1.UpdateProjectResponse{
+		Project: &corev1.Project{
+			ProjectId:   request.Msg.GetProjectId(),
+			Name:        request.Msg.GetName(),
+			RegionId:    request.Msg.GetRegionId(),
+			CachePolicy: request.Msg.GetCachePolicy(),
+		},
+	}), nil
+}
+
+func setupProjectService(t *testing.T, handler corev1connect.ProjectServiceHandler) {
+	t.Helper()
+
+	_, connectHandler := corev1connect.NewProjectServiceHandler(handler)
+	server := httptest.NewServer(h2c.NewHandler(connectHandler, &http2.Server{}))
+	t.Cleanup(server.Close)
+	t.Setenv("DEPOT_API_URL", server.URL)
+}

--- a/pkg/cmd/projects/update.go
+++ b/pkg/cmd/projects/update.go
@@ -1,0 +1,106 @@
+package projects
+
+import (
+	"fmt"
+	"math"
+
+	corev1 "buf.build/gen/go/depot/api/protocolbuffers/go/depot/core/v1"
+	"connectrpc.com/connect"
+	"github.com/depot/cli/pkg/api"
+	"github.com/depot/cli/pkg/helpers"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdUpdate() *cobra.Command {
+	var (
+		projectID     string
+		token         string
+		output        string
+		name          string
+		region        string
+		keepGigabytes int64
+	)
+
+	cmd := &cobra.Command{
+		Use:   "update [<project-id>]",
+		Short: "Update project details",
+		Long: `Update the name, region, or cache storage policy of a Depot project.
+
+Only values passed as flags are changed. If no project ID is provided, the
+command uses DEPOT_PROJECT_ID or the project configured in depot.json in the
+current directory.`,
+		Example: `  # Rename the project configured in the current directory
+  depot projects update --name "New project name"
+
+  # Update a specific project's region and print the result as JSON
+  depot projects update <project-id> --region eu-central-1 --output json`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateProjectOutput(output); err != nil {
+				return err
+			}
+
+			flags := cmd.Flags()
+			nameChanged := flags.Changed("name")
+			regionChanged := flags.Changed("region")
+			cachePolicyChanged := flags.Changed("cache-storage-policy")
+			if !nameChanged && !regionChanged && !cachePolicyChanged {
+				return fmt.Errorf("one of --name, --region, or --cache-storage-policy is required")
+			}
+			if cachePolicyChanged {
+				if keepGigabytes < 0 {
+					return fmt.Errorf("--cache-storage-policy cannot be negative")
+				}
+				if keepGigabytes > math.MaxInt64/bytesPerGigabyte {
+					return fmt.Errorf("--cache-storage-policy is too large")
+				}
+			}
+
+			resolvedProjectID, err := resolveProjectID(args, projectID)
+			if err != nil {
+				return err
+			}
+
+			token, err := helpers.ResolveProjectAuth(cmd.Context(), token)
+			if err != nil {
+				return err
+			}
+			if token == "" {
+				return fmt.Errorf("missing API token, please run `depot login`")
+			}
+
+			requestBody := &corev1.UpdateProjectRequest{ProjectId: resolvedProjectID}
+			if nameChanged {
+				requestBody.Name = &name
+			}
+			if regionChanged {
+				requestBody.RegionId = &region
+			}
+			if cachePolicyChanged {
+				requestBody.CachePolicy = &corev1.CachePolicy{
+					KeepBytes: keepGigabytes * bytesPerGigabyte,
+				}
+			}
+
+			request := connect.NewRequest(requestBody)
+			response, err := api.NewSDKProjectsClient().UpdateProject(
+				cmd.Context(),
+				api.WithAuthentication(request, token),
+			)
+			if err != nil {
+				return fmt.Errorf("failed to update project: %w", err)
+			}
+
+			return writeProjectOutput(cmd.OutOrStdout(), response.Msg.GetProject(), output)
+		},
+	}
+
+	cmd.Flags().StringVarP(&projectID, "project-id", "p", "", "Depot project ID")
+	cmd.Flags().StringVar(&name, "name", "", "Project name")
+	cmd.Flags().StringVar(&region, "region", "", "Build data storage region")
+	cmd.Flags().Int64Var(&keepGigabytes, "cache-storage-policy", 0, "Build cache to keep per architecture in GB")
+	cmd.Flags().StringVar(&token, "token", "", "Depot API token")
+	cmd.Flags().StringVarP(&output, "output", "o", "", "Output format (json)")
+
+	return cmd
+}

--- a/pkg/cmd/projects/update.go
+++ b/pkg/cmd/projects/update.go
@@ -69,6 +69,7 @@ current directory.`,
 				return fmt.Errorf("missing API token, please run `depot login`")
 			}
 
+			client := api.NewSDKProjectsClient()
 			requestBody := &corev1.UpdateProjectRequest{ProjectId: resolvedProjectID}
 			if nameChanged {
 				requestBody.Name = &name
@@ -77,13 +78,27 @@ current directory.`,
 				requestBody.RegionId = &region
 			}
 			if cachePolicyChanged {
+				getRequest := connect.NewRequest(&corev1.GetProjectRequest{ProjectId: resolvedProjectID})
+				getResponse, err := client.GetProject(
+					cmd.Context(),
+					api.WithAuthentication(getRequest, token),
+				)
+				if err != nil {
+					return fmt.Errorf("failed to get current project cache policy: %w", err)
+				}
+				currentProject := getResponse.Msg.GetProject()
+				if currentProject == nil {
+					return fmt.Errorf("API returned no project")
+				}
+
 				requestBody.CachePolicy = &corev1.CachePolicy{
 					KeepBytes: keepGigabytes * bytesPerGigabyte,
+					KeepDays:  currentProject.GetCachePolicy().GetKeepDays(),
 				}
 			}
 
 			request := connect.NewRequest(requestBody)
-			response, err := api.NewSDKProjectsClient().UpdateProject(
+			response, err := client.UpdateProject(
 				cmd.Context(),
 				api.WithAuthentication(request, token),
 			)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `depot projects get` with text and JSON output
- add partial `depot projects update` support for names, regions, and cache storage policies
- preserve cache retention when changing a project's cache storage limit
- resolve projects from arguments, flags, environment variables, or `depot.json`
- document the new commands and cover their API requests with tests

## Testing
- `go test -race ./pkg/cmd/projects`
- `go test ./...`
- `go vet ./...`
- `go build ./cmd/depot`
- `go mod tidy` (no diff)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DEP-5490](https://linear.app/depot/issue/DEP-5490/depot-cli-view-and-edit-project-details)

<div><a href="https://cursor.com/agents/bc-72ac6646-3ebb-4ff1-bb75-d7e67d282fab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-72ac6646-3ebb-4ff1-bb75-d7e67d282fab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

