### PR TITLE
Add cache policy keep days to project creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ Create a new Depot project. This command creates a new project in your Depot acc
 depot projects create
 
 # Create a project with custom settings
-depot projects create --organization your-org-id --region us-west-2 --cache-storage-policy 100 --cache-retention-days 14 your-project-name
+depot projects create --organization your-org-id --region us-west-2 --cache-storage-policy 100 --cache-policy-keep-days 14 your-project-name
 ```
 
 #### Flags for `projects create`
@@ -434,7 +434,7 @@ depot projects create --organization your-org-id --region us-west-2 --cache-stor
 | `organization` / `-o`    | Depot organization ID                                    |
 | `region`                 | Build data storage region (default: "us-east-1")         |
 | `cache-storage-policy`   | Build cache to keep per architecture in GB (default: 50) |
-| `cache-retention-days`   | Build cache retention in days (default: no limit)        |
+| `cache-policy-keep-days` | Build cache retention in days (default: no limit)        |
 | `token`                  | Depot API token                                          |
 
 #### `depot projects get`

--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ Create a new Depot project. This command creates a new project in your Depot acc
 depot projects create
 
 # Create a project with custom settings
-depot projects create --organization your-org-id --region us-west-2 --cache-storage-policy 100 --cache-retention-policy 14 your-project-name
+depot projects create --organization your-org-id --region us-west-2 --cache-storage-policy 100 --cache-retention-days 14 your-project-name
 ```
 
 #### Flags for `projects create`
@@ -434,7 +434,7 @@ depot projects create --organization your-org-id --region us-west-2 --cache-stor
 | `organization` / `-o`    | Depot organization ID                                    |
 | `region`                 | Build data storage region (default: "us-east-1")         |
 | `cache-storage-policy`   | Build cache to keep per architecture in GB (default: 50) |
-| `cache-retention-policy` | Build cache retention in days (default: no limit)        |
+| `cache-retention-days`   | Build cache retention in days (default: no limit)        |
 | `token`                  | Depot API token                                          |
 
 #### `depot projects get`

--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ Create a new Depot project. This command creates a new project in your Depot acc
 depot projects create
 
 # Create a project with custom settings
-depot projects create --organization your-org-id --region us-west-2 --cache-storage-policy 100 --cache-policy-keep-days 14 your-project-name
+depot projects create --organization your-org-id --region us-west-2 --cache-storage-policy 100 --cache-policy-keep-days 30 your-project-name
 ```
 
 #### Flags for `projects create`
@@ -434,7 +434,7 @@ depot projects create --organization your-org-id --region us-west-2 --cache-stor
 | `organization` / `-o`    | Depot organization ID                                    |
 | `region`                 | Build data storage region (default: "us-east-1")         |
 | `cache-storage-policy`   | Build cache to keep per architecture in GB (default: 50) |
-| `cache-policy-keep-days` | Build cache retention in days (default: no limit)        |
+| `cache-policy-keep-days` | Build cache retention in days (default: 14)              |
 | `token`                  | Depot API token                                          |
 
 #### `depot projects get`

--- a/README.md
+++ b/README.md
@@ -424,17 +424,18 @@ Create a new Depot project. This command creates a new project in your Depot acc
 depot projects create
 
 # Create a project with custom settings
-depot projects create --organization your-org-id --region us-west-2 --cache-storage-policy 100
+depot projects create --organization your-org-id --region us-west-2 --cache-storage-policy 100 --cache-retention-policy 14 your-project-name
 ```
 
 #### Flags for `projects create`
 
-| Name                   | Description                                              |
-| ---------------------- | -------------------------------------------------------- |
-| `organization` / `-o`  | Depot organization ID                                    |
-| `region`               | Build data storage region (default: "us-east-1")         |
-| `cache-storage-policy` | Build cache to keep per architecture in GB (default: 50) |
-| `token`                | Depot API token                                          |
+| Name                     | Description                                              |
+| ------------------------ | -------------------------------------------------------- |
+| `organization` / `-o`    | Depot organization ID                                    |
+| `region`                 | Build data storage region (default: "us-east-1")         |
+| `cache-storage-policy`   | Build cache to keep per architecture in GB (default: 50) |
+| `cache-retention-policy` | Build cache retention in days (default: no limit)        |
+| `token`                  | Depot API token                                          |
 
 #### `depot projects get`
 

--- a/pkg/cmd/projects/create.go
+++ b/pkg/cmd/projects/create.go
@@ -81,7 +81,7 @@ func NewCmdCreate() *cobra.Command {
 	flags.StringVarP(&orgID, "organization", "o", config.GetCurrentOrganization(), "Depot organization ID")
 	flags.StringVar(&region, "region", "us-east-1", "Build data will be stored in the chosen region")
 	flags.Int64Var(&keepGigabytes, "cache-storage-policy", 50, "Build cache to keep per architecture in GB")
-	flags.Int32Var(&cachePolicyKeepDays, "cache-policy-keep-days", 0, "Build cache retention in days (0 means no limit)")
+	flags.Int32Var(&cachePolicyKeepDays, "cache-policy-keep-days", 14, "Build cache retention in days (0 means no limit)")
 
 	return cmd
 }

--- a/pkg/cmd/projects/create.go
+++ b/pkg/cmd/projects/create.go
@@ -15,11 +15,11 @@ import (
 
 func NewCmdCreate() *cobra.Command {
 	var (
-		token              string
-		orgID              string
-		region             string
-		keepGigabytes      int64
-		cacheRetentionDays int32
+		token               string
+		orgID               string
+		region              string
+		keepGigabytes       int64
+		cachePolicyKeepDays int32
 	)
 
 	cmd := &cobra.Command{
@@ -34,8 +34,8 @@ func NewCmdCreate() *cobra.Command {
 			ctx := cmd.Context()
 			projectName := args[0]
 
-			if cacheRetentionDays < 0 {
-				return fmt.Errorf("--cache-retention-days cannot be negative")
+			if cachePolicyKeepDays < 0 {
+				return fmt.Errorf("--cache-policy-keep-days cannot be negative")
 			}
 
 			token, err := helpers.ResolveProjectAuth(ctx, token)
@@ -53,7 +53,7 @@ func NewCmdCreate() *cobra.Command {
 				RegionId: region,
 				CachePolicy: &corev1.CachePolicy{
 					KeepBytes: keepGigabytes * 1024 * 1024 * 1024,
-					KeepDays:  cacheRetentionDays,
+					KeepDays:  cachePolicyKeepDays,
 				},
 			}
 			if orgID != "" {
@@ -81,7 +81,7 @@ func NewCmdCreate() *cobra.Command {
 	flags.StringVarP(&orgID, "organization", "o", config.GetCurrentOrganization(), "Depot organization ID")
 	flags.StringVar(&region, "region", "us-east-1", "Build data will be stored in the chosen region")
 	flags.Int64Var(&keepGigabytes, "cache-storage-policy", 50, "Build cache to keep per architecture in GB")
-	flags.Int32Var(&cacheRetentionDays, "cache-retention-days", 0, "Build cache retention in days (0 means no limit)")
+	flags.Int32Var(&cachePolicyKeepDays, "cache-policy-keep-days", 0, "Build cache retention in days (0 means no limit)")
 
 	return cmd
 }

--- a/pkg/cmd/projects/create.go
+++ b/pkg/cmd/projects/create.go
@@ -35,7 +35,7 @@ func NewCmdCreate() *cobra.Command {
 			projectName := args[0]
 
 			if cacheRetentionDays < 0 {
-				return fmt.Errorf("--cache-retention-policy cannot be negative")
+				return fmt.Errorf("--cache-retention-days cannot be negative")
 			}
 
 			token, err := helpers.ResolveProjectAuth(ctx, token)
@@ -81,7 +81,7 @@ func NewCmdCreate() *cobra.Command {
 	flags.StringVarP(&orgID, "organization", "o", config.GetCurrentOrganization(), "Depot organization ID")
 	flags.StringVar(&region, "region", "us-east-1", "Build data will be stored in the chosen region")
 	flags.Int64Var(&keepGigabytes, "cache-storage-policy", 50, "Build cache to keep per architecture in GB")
-	flags.Int32Var(&cacheRetentionDays, "cache-retention-policy", 0, "Build cache retention in days (0 means no limit)")
+	flags.Int32Var(&cacheRetentionDays, "cache-retention-days", 0, "Build cache retention in days (0 means no limit)")
 
 	return cmd
 }

--- a/pkg/cmd/projects/create.go
+++ b/pkg/cmd/projects/create.go
@@ -15,10 +15,11 @@ import (
 
 func NewCmdCreate() *cobra.Command {
 	var (
-		token         string
-		orgID         string
-		region        string
-		keepGigabytes int64
+		token              string
+		orgID              string
+		region             string
+		keepGigabytes      int64
+		cacheRetentionDays int32
 	)
 
 	cmd := &cobra.Command{
@@ -32,6 +33,10 @@ func NewCmdCreate() *cobra.Command {
 			}
 			ctx := cmd.Context()
 			projectName := args[0]
+
+			if cacheRetentionDays < 0 {
+				return fmt.Errorf("--cache-retention-policy cannot be negative")
+			}
 
 			token, err := helpers.ResolveProjectAuth(ctx, token)
 			if err != nil {
@@ -48,6 +53,7 @@ func NewCmdCreate() *cobra.Command {
 				RegionId: region,
 				CachePolicy: &corev1.CachePolicy{
 					KeepBytes: keepGigabytes * 1024 * 1024 * 1024,
+					KeepDays:  cacheRetentionDays,
 				},
 			}
 			if orgID != "" {
@@ -63,7 +69,7 @@ func NewCmdCreate() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Printf("%s\n", buf)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s\n", buf)
 
 			return nil
 		},
@@ -75,6 +81,7 @@ func NewCmdCreate() *cobra.Command {
 	flags.StringVarP(&orgID, "organization", "o", config.GetCurrentOrganization(), "Depot organization ID")
 	flags.StringVar(&region, "region", "us-east-1", "Build data will be stored in the chosen region")
 	flags.Int64Var(&keepGigabytes, "cache-storage-policy", 50, "Build cache to keep per architecture in GB")
+	flags.Int32Var(&cacheRetentionDays, "cache-retention-policy", 0, "Build cache retention in days (0 means no limit)")
 
 	return cmd
 }

--- a/pkg/cmd/projects/projects_test.go
+++ b/pkg/cmd/projects/projects_test.go
@@ -32,7 +32,7 @@ func TestProjectsCommandRegistration(t *testing.T) {
 	}
 }
 
-func TestCreateProjectSendsCacheRetentionPolicy(t *testing.T) {
+func TestCreateProjectSendsCacheRetentionDays(t *testing.T) {
 	handler := &projectServiceRecorder{}
 	setupProjectService(t, handler)
 
@@ -43,7 +43,7 @@ func TestCreateProjectSendsCacheRetentionPolicy(t *testing.T) {
 		"--organization", "org-123",
 		"--region", "eu-central-1",
 		"--cache-storage-policy", "75",
-		"--cache-retention-policy", "14",
+		"--cache-retention-days", "14",
 		"--token", "token-123",
 	})
 	command.SetOut(&stdout)
@@ -76,16 +76,16 @@ func TestCreateProjectSendsCacheRetentionPolicy(t *testing.T) {
 	}
 }
 
-func TestCreateProjectRejectsNegativeCacheRetentionPolicy(t *testing.T) {
+func TestCreateProjectRejectsNegativeCacheRetentionDays(t *testing.T) {
 	command := NewCmdCreate()
-	command.SetArgs([]string{"Example", "--cache-retention-policy", "-1"})
+	command.SetArgs([]string{"Example", "--cache-retention-days", "-1"})
 	command.SetOut(io.Discard)
 	command.SetErr(io.Discard)
 	command.SilenceUsage = true
 	command.SilenceErrors = true
 
 	err := command.Execute()
-	if err == nil || !strings.Contains(err.Error(), "--cache-retention-policy cannot be negative") {
+	if err == nil || !strings.Contains(err.Error(), "--cache-retention-days cannot be negative") {
 		t.Fatalf("error = %v", err)
 	}
 }

--- a/pkg/cmd/projects/projects_test.go
+++ b/pkg/cmd/projects/projects_test.go
@@ -43,7 +43,7 @@ func TestCreateProjectSendsCachePolicyKeepDays(t *testing.T) {
 		"--organization", "org-123",
 		"--region", "eu-central-1",
 		"--cache-storage-policy", "75",
-		"--cache-policy-keep-days", "14",
+		"--cache-policy-keep-days", "30",
 		"--token", "token-123",
 	})
 	command.SetOut(&stdout)
@@ -68,11 +68,34 @@ func TestCreateProjectSendsCachePolicyKeepDays(t *testing.T) {
 	if request.GetCachePolicy().GetKeepBytes() != 75*bytesPerGigabyte {
 		t.Fatalf("CachePolicy.KeepBytes = %d, want %d", request.GetCachePolicy().GetKeepBytes(), 75*bytesPerGigabyte)
 	}
-	if request.GetCachePolicy().GetKeepDays() != 14 {
-		t.Fatalf("CachePolicy.KeepDays = %d, want 14", request.GetCachePolicy().GetKeepDays())
+	if request.GetCachePolicy().GetKeepDays() != 30 {
+		t.Fatalf("CachePolicy.KeepDays = %d, want 30", request.GetCachePolicy().GetKeepDays())
 	}
 	if handler.authorization != "Bearer token-123" {
 		t.Fatalf("Authorization = %q, want Bearer token-123", handler.authorization)
+	}
+}
+
+func TestCreateProjectDefaultsCachePolicyKeepDays(t *testing.T) {
+	handler := &projectServiceRecorder{}
+	setupProjectService(t, handler)
+
+	command := NewCmdCreate()
+	command.SetArgs([]string{"Example", "--token", "token-123"})
+	command.SetOut(io.Discard)
+	command.SetErr(io.Discard)
+	command.SilenceUsage = true
+	command.SilenceErrors = true
+
+	if err := command.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if handler.createRequest == nil {
+		t.Fatal("CreateProject was not called")
+	}
+	if got := handler.createRequest.GetCachePolicy().GetKeepDays(); got != 14 {
+		t.Fatalf("CachePolicy.KeepDays = %d, want 14", got)
 	}
 }
 

--- a/pkg/cmd/projects/projects_test.go
+++ b/pkg/cmd/projects/projects_test.go
@@ -32,7 +32,7 @@ func TestProjectsCommandRegistration(t *testing.T) {
 	}
 }
 
-func TestCreateProjectSendsCacheRetentionDays(t *testing.T) {
+func TestCreateProjectSendsCachePolicyKeepDays(t *testing.T) {
 	handler := &projectServiceRecorder{}
 	setupProjectService(t, handler)
 
@@ -43,7 +43,7 @@ func TestCreateProjectSendsCacheRetentionDays(t *testing.T) {
 		"--organization", "org-123",
 		"--region", "eu-central-1",
 		"--cache-storage-policy", "75",
-		"--cache-retention-days", "14",
+		"--cache-policy-keep-days", "14",
 		"--token", "token-123",
 	})
 	command.SetOut(&stdout)
@@ -76,16 +76,16 @@ func TestCreateProjectSendsCacheRetentionDays(t *testing.T) {
 	}
 }
 
-func TestCreateProjectRejectsNegativeCacheRetentionDays(t *testing.T) {
+func TestCreateProjectRejectsNegativeCachePolicyKeepDays(t *testing.T) {
 	command := NewCmdCreate()
-	command.SetArgs([]string{"Example", "--cache-retention-days", "-1"})
+	command.SetArgs([]string{"Example", "--cache-policy-keep-days", "-1"})
 	command.SetOut(io.Discard)
 	command.SetErr(io.Discard)
 	command.SilenceUsage = true
 	command.SilenceErrors = true
 
 	err := command.Execute()
-	if err == nil || !strings.Contains(err.Error(), "--cache-retention-days cannot be negative") {
+	if err == nil || !strings.Contains(err.Error(), "--cache-policy-keep-days cannot be negative") {
 		t.Fatalf("error = %v", err)
 	}
 }

--- a/pkg/cmd/projects/projects_test.go
+++ b/pkg/cmd/projects/projects_test.go
@@ -32,6 +32,64 @@ func TestProjectsCommandRegistration(t *testing.T) {
 	}
 }
 
+func TestCreateProjectSendsCacheRetentionPolicy(t *testing.T) {
+	handler := &projectServiceRecorder{}
+	setupProjectService(t, handler)
+
+	var stdout bytes.Buffer
+	command := NewCmdCreate()
+	command.SetArgs([]string{
+		"Example",
+		"--organization", "org-123",
+		"--region", "eu-central-1",
+		"--cache-storage-policy", "75",
+		"--cache-retention-policy", "14",
+		"--token", "token-123",
+	})
+	command.SetOut(&stdout)
+	command.SetErr(io.Discard)
+	command.SilenceUsage = true
+	command.SilenceErrors = true
+
+	if err := command.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	request := handler.createRequest
+	if request == nil {
+		t.Fatal("CreateProject was not called")
+	}
+	if request.GetName() != "Example" || request.GetOrganizationId() != "org-123" {
+		t.Fatalf("request = %#v", request)
+	}
+	if request.GetRegionId() != "eu-central-1" {
+		t.Fatalf("RegionId = %q, want eu-central-1", request.GetRegionId())
+	}
+	if request.GetCachePolicy().GetKeepBytes() != 75*bytesPerGigabyte {
+		t.Fatalf("CachePolicy.KeepBytes = %d, want %d", request.GetCachePolicy().GetKeepBytes(), 75*bytesPerGigabyte)
+	}
+	if request.GetCachePolicy().GetKeepDays() != 14 {
+		t.Fatalf("CachePolicy.KeepDays = %d, want 14", request.GetCachePolicy().GetKeepDays())
+	}
+	if handler.authorization != "Bearer token-123" {
+		t.Fatalf("Authorization = %q, want Bearer token-123", handler.authorization)
+	}
+}
+
+func TestCreateProjectRejectsNegativeCacheRetentionPolicy(t *testing.T) {
+	command := NewCmdCreate()
+	command.SetArgs([]string{"Example", "--cache-retention-policy", "-1"})
+	command.SetOut(io.Discard)
+	command.SetErr(io.Discard)
+	command.SilenceUsage = true
+	command.SilenceErrors = true
+
+	err := command.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--cache-retention-policy cannot be negative") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestGetProjectCallsAPIAndWritesJSON(t *testing.T) {
 	handler := &projectServiceRecorder{
 		project: &corev1.Project{
@@ -193,9 +251,24 @@ type projectServiceRecorder struct {
 	corev1connect.UnimplementedProjectServiceHandler
 
 	project       *corev1.Project
+	createRequest *corev1.CreateProjectRequest
 	getRequest    *corev1.GetProjectRequest
 	updateRequest *corev1.UpdateProjectRequest
 	authorization string
+}
+
+func (h *projectServiceRecorder) CreateProject(_ context.Context, request *connect.Request[corev1.CreateProjectRequest]) (*connect.Response[corev1.CreateProjectResponse], error) {
+	h.createRequest = request.Msg
+	h.authorization = request.Header().Get("Authorization")
+	return connect.NewResponse(&corev1.CreateProjectResponse{
+		Project: &corev1.Project{
+			ProjectId:      "project-123",
+			OrganizationId: request.Msg.GetOrganizationId(),
+			Name:           request.Msg.GetName(),
+			RegionId:       request.Msg.GetRegionId(),
+			CachePolicy:    request.Msg.GetCachePolicy(),
+		},
+	}), nil
 }
 
 func (h *projectServiceRecorder) GetProject(_ context.Context, request *connect.Request[corev1.GetProjectRequest]) (*connect.Response[corev1.GetProjectResponse], error) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `--cache-policy-keep-days` to `depot projects create`, matching the API's `CachePolicy.KeepDays` field
- send the configured retention in `CachePolicy.KeepDays`
- default retention to 14 days, reject negative values, and allow `0` for no limit

Resolves DEP-5626.

## Testing
- `go test ./pkg/cmd/projects`
- `go test ./...`
- `go fmt ./...`
- `go mod tidy`
- `go vet ./pkg/cmd/projects`
- `go run ./cmd/depot projects create --help`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DEP-5626](https://linear.app/depot/issue/DEP-5626/feature-request-add-cache-retention-policy-ttl-flag-to-depot-projects)

<div><a href="https://cursor.com/agents/bc-3926c933-61ae-4cd4-b80e-1fad293c4f35?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3926c933-61ae-4cd4-b80e-1fad293c4f35&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

