### PR TITLE
Validate remote cache output IDs

### DIFF
--- a/pkg/cmd/gocache/gocache.go
+++ b/pkg/cmd/gocache/gocache.go
@@ -402,6 +402,12 @@ func (c *RemoteCache) Get(ctx context.Context, actionID string) (outputID, diskP
 			return "", "", nil
 		}
 		outputID = string(outputIDBuf)
+		if !validOutputID(outputID) {
+			if c.Verbose {
+				log.Printf("invalid outputID for actionID %s", actionID)
+			}
+			return "", "", nil
+		}
 
 		err = binary.Read(res.Body, binary.LittleEndian, &size)
 		if err != nil {
@@ -438,6 +444,14 @@ func (c *RemoteCache) Get(ctx context.Context, actionID string) (outputID, diskP
 		log.Printf("GET /gocache/v1/%s: %d bytes in %v", actionID, size, dur)
 	}
 	return outputID, diskPath, nil
+}
+
+func validOutputID(outputID string) bool {
+	if len(outputID) < 2 || len(outputID) > 255 {
+		return false
+	}
+	_, err := hex.DecodeString(outputID)
+	return err == nil
 }
 
 func (c *RemoteCache) Put(ctx context.Context, actionID, outputID string, size int64, body io.Reader) (diskPath string, _ error) {

--- a/pkg/cmd/gocache/gocache_test.go
+++ b/pkg/cmd/gocache/gocache_test.go
@@ -1,0 +1,30 @@
+package gocache
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidOutputID(t *testing.T) {
+	valid := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	if !validOutputID(valid) {
+		t.Fatal("valid output ID rejected")
+	}
+	if !validOutputID("E" + valid[1:]) {
+		t.Fatal("uppercase output ID rejected")
+	}
+	if !validOutputID(strings.Repeat("ab", 127)) {
+		t.Fatal("long output ID rejected")
+	}
+
+	invalid := []string{
+		"../../tmp/some/path",
+		"a",
+		strings.Repeat("ab", 128),
+	}
+	for _, outputID := range invalid {
+		if validOutputID(outputID) {
+			t.Errorf("invalid output ID accepted: %q", outputID)
+		}
+	}
+}


### PR DESCRIPTION
Validate that output IDs for Go cache are hex strings, to ensure files are written to the expected destination path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive validation on the remote GET path with no behavior change for legitimate hex output IDs; reduces path-manipulation risk from untrusted cache responses.
> 
> **Overview**
> Remote **GET** responses from the Depot gocache server are now checked before any body is written to disk. After reading `outputID` from the response, **`validOutputID`** requires length 2–255 and successful **`hex.DecodeString`**; invalid values are logged (when verbose) and treated as a **cache miss** instead of flowing into **`Disk.Put`**.
> 
> This mirrors the existing disk-index guard in **`DiskCache.Get`** and closes a gap where a malicious or malformed remote `outputID` (e.g. path-like strings) could influence **`fileNameOutput`** path construction.
> 
> **`TestValidOutputID`** covers valid hex (including uppercase and max length), and rejects too-short, too-long, and path-like IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c6ecaa32a7d799fe6cf640dbb5489111ee5ac5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->