### PR TITLE
Warn when report OIDC is unavailable after passing tests

### DIFF
--- a/pkg/cmd/tests/credentials.go
+++ b/pkg/cmd/tests/credentials.go
@@ -19,6 +19,8 @@ const (
 
 var oidcDebugWriter io.Writer = os.Stderr
 
+var errMissingOIDCCredential = errors.New("missing OIDC credential; ensure this command is running in a supported CI environment with OIDC enabled")
+
 func resolveOIDCCredential(ctx context.Context) (string, error) {
 	return resolveOIDCCredentialWithDepotCIEnv(ctx, oidc.Providers)
 }
@@ -50,7 +52,7 @@ func resolveOIDCCredentialWithProviders(ctx context.Context, providers []oidc.OI
 			return strings.TrimSpace(token), nil
 		}
 	}
-	return "", fmt.Errorf("missing OIDC credential; ensure this command is running in a supported CI environment with OIDC enabled")
+	return "", errMissingOIDCCredential
 }
 
 func configureDepotCIOIDCEnv() func() {

--- a/pkg/cmd/tests/credentials_test.go
+++ b/pkg/cmd/tests/credentials_test.go
@@ -48,6 +48,9 @@ func TestResolveOIDCCredentialIgnoresProviderErrors(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
+	if !errors.Is(err, errMissingOIDCCredential) {
+		t.Fatalf("expected missing OIDC credential sentinel, got %v", err)
+	}
 	if !strings.Contains(err.Error(), "missing OIDC credential") {
 		t.Fatalf("expected missing credential error, got %q", err.Error())
 	}

--- a/pkg/cmd/tests/report_cmd_test.go
+++ b/pkg/cmd/tests/report_cmd_test.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -242,6 +243,21 @@ func TestReportRejectsUnknownOutput(t *testing.T) {
 	_, _, err := executeCommandOutput("report", "--report-path", "reports/junit.xml", "--output", "auto")
 	if err == nil || !strings.Contains(err.Error(), "Requires text or json") {
 		t.Fatalf("expected output validation error, got %v", err)
+	}
+}
+
+func TestReportMissingOIDCRemainsFailure(t *testing.T) {
+	resetTestHooks(t)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeTempFileAt(t, workspace, "reports/junit.xml", "<testsuite/>")
+	resolveOIDCCredentialFunc = func(context.Context) (string, error) {
+		return "", errMissingOIDCCredential
+	}
+
+	_, _, err := executeCommandOutput("report", "--report-path", "reports/junit.xml")
+	if !errors.Is(err, errMissingOIDCCredential) {
+		t.Fatalf("expected standalone report to fail without OIDC, got %v", err)
 	}
 }
 

--- a/pkg/cmd/tests/run.go
+++ b/pkg/cmd/tests/run.go
@@ -155,6 +155,13 @@ func runTestsRun(cmd *cobra.Command, opts runOptions) error {
 		}
 		return commandErr
 	}
+	if errors.Is(reportErr, errMissingOIDCCredential) {
+		if err := ctx.Err(); err != nil {
+			return cancellationErrorOr(err)
+		}
+		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: test command passed, but Depot skipped test report upload: %v\n", reportErr)
+		return nil
+	}
 	if reportErr != nil {
 		return reportErr
 	}

--- a/pkg/cmd/tests/run_test.go
+++ b/pkg/cmd/tests/run_test.go
@@ -921,6 +921,82 @@ func TestRunFailsWhenReportUploadFailsAfterSuccessfulCommand(t *testing.T) {
 	}
 }
 
+func TestRunWarnsWhenReportUploadLacksOIDCAfterSuccessfulCommand(t *testing.T) {
+	resetTestHooks(t)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeTempFileAt(t, workspace, "reports/junit.xml", "<testsuite/>")
+	runShellCommandFunc = func(context.Context, string, []string, io.Writer, io.Writer) (int, error) {
+		writeRunReport(t, workspace)
+		return 0, nil
+	}
+	resolveOIDCCredentialFunc = func(context.Context) (string, error) {
+		return "", errMissingOIDCCredential
+	}
+	reportTestResultsFunc = func(context.Context, string, *testresultsv1.ReportTestResultsRequest) (*testresultsv1.ReportTestResultsResponse, error) {
+		t.Fatal("report upload should not run without an OIDC credential")
+		return nil, nil
+	}
+
+	_, stderr, err := executeCommandWithInputOutput(
+		"a.test.ts\n",
+		"run",
+		"--index", "0",
+		"--total", "1",
+		"--command", "test-command",
+		"--report-path", "reports/junit.xml",
+	)
+	if err != nil {
+		t.Fatalf("expected successful test command to remain successful, got %v", err)
+	}
+	if !strings.Contains(stderr, "Warning: test command passed, but Depot skipped test report upload") ||
+		!strings.Contains(stderr, "missing OIDC credential") {
+		t.Fatalf("expected missing OIDC warning, got %q", stderr)
+	}
+}
+
+func TestRunMissingOIDCDoesNotMaskCancellationDuringReportUpload(t *testing.T) {
+	resetTestHooks(t)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeTempFileAt(t, workspace, "reports/junit.xml", "<testsuite/>")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runShellCommandFunc = func(context.Context, string, []string, io.Writer, io.Writer) (int, error) {
+		writeRunReport(t, workspace)
+		return 0, nil
+	}
+	resolveOIDCCredentialFunc = func(context.Context) (string, error) {
+		cancel()
+		return "", errMissingOIDCCredential
+	}
+
+	cmd := newCmdTestsRun()
+	var stdout, stderr bytes.Buffer
+	cmd.SetContext(ctx)
+	cmd.SetIn(strings.NewReader("a.test.ts\n"))
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"--index", "0",
+		"--total", "1",
+		"--command", "test-command",
+		"--report-path", "reports/junit.xml",
+	})
+
+	err := cmd.Execute()
+	statusErr, ok := err.(cli.StatusError)
+	if !ok {
+		t.Fatalf("expected cli.StatusError, got %T: %v", err, err)
+	}
+	if statusErr.StatusCode != 1 || !strings.Contains(statusErr.Status, "context canceled") {
+		t.Fatalf("expected cancellation status, got %#v", statusErr)
+	}
+	if strings.Contains(stderr.String(), "Warning:") {
+		t.Fatalf("expected cancellation without missing OIDC warning, got %q", stderr.String())
+	}
+}
+
 func TestRunRejectsWhenNoReportFileWasUpdatedByCommand(t *testing.T) {
 	resetTestHooks(t)
 	workspace := t.TempDir()


### PR DESCRIPTION
## What changed

- Add a typed missing-OIDC credential error.
- Treat that error as a warning only in `depot tests run` after the test command succeeds.
- Preserve test failures, cancellation, other upload errors, split failures, and standalone `depot tests report` failures.
- Add regression coverage for the success, cancellation, and standalone-report boundaries.

## Why

A successful test command should not make the CI step fail solely because Depot cannot obtain OIDC credentials for the follow-up report upload.

## Root cause

`depot tests run` returned every report-upload error after a zero test exit code, and the credential resolver did not expose a typed error that allowed the caller to distinguish missing OIDC from other failures.

## Validation

- `go test ./pkg/cmd/tests`
- Local `codex review --uncommitted` (clean after addressing its cancellation finding)

Context: T-10528 / DEP-5706

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is scoped to post-success report upload in `tests run`; auth paths and failure modes outside missing OIDC are unchanged.
> 
> **Overview**
> Introduces a sentinel **`errMissingOIDCCredential`** from the OIDC resolver so callers can distinguish “no OIDC in CI” from other credential failures.
> 
> **`depot tests run`**: when the test command exits 0 but report upload cannot get OIDC, the step **warns on stderr and succeeds** instead of failing the job. Cancellation during that path still fails with **`context canceled`** (no warning). Failed tests, other upload errors, and combined command+report failures behave as before.
> 
> **`depot tests report`** still **errors** on missing OIDC.
> 
> Tests cover the sentinel, standalone report failure, success-with-warning, and cancellation-not-masked cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53c91ac8ac0a96f51cdbff306650ab7799ba8b7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->