### PR TITLE
fix(bake): preserve compose build options

### DIFF
--- a/pkg/buildx/bake/bake.go
+++ b/pkg/buildx/bake/bake.go
@@ -471,7 +471,7 @@ func (c Config) newOverrides(v []string) (map[string]map[string]Override, error)
 			// IMPORTANT: if you add more fields here, do not forget to update
 			// docs/reference/buildx_bake.md (--set) and https://docs.docker.com/build/bake/overrides/
 			switch keys[1] {
-			case "output", "cache-to", "cache-from", "tags", "platform", "secrets", "ssh", "attest":
+			case "output", "cache-to", "cache-from", "tags", "platform", "secrets", "ssh", "attest", "no-cache-filter":
 				if len(parts) == 2 {
 					override.Append = appendTo
 					override.ArrValue = append(override.ArrValue, parts[1])
@@ -866,7 +866,11 @@ func (t *Target) AddOverrides(overrides map[string]Override) error {
 			}
 			t.NoCache = &noCache
 		case "no-cache-filter":
-			t.NoCacheFilter = o.ArrValue
+			if o.Append {
+				t.NoCacheFilter = append(t.NoCacheFilter, o.ArrValue...)
+			} else {
+				t.NoCacheFilter = o.ArrValue
+			}
 		case "shm-size":
 			t.ShmSize = &value
 		case "network":

--- a/pkg/buildx/bake/buildflags/attests.go
+++ b/pkg/buildx/bake/buildflags/attests.go
@@ -119,9 +119,8 @@ func (a *Attest) UnmarshalText(text []byte) error {
 		if !ok {
 			return errors.Errorf("invalid value %s", field)
 		}
-		key = strings.TrimSpace(strings.ToLower(key))
 
-		switch key {
+		switch strings.TrimSpace(strings.ToLower(key)) {
 		case "type":
 			a.Type = value
 		case "disabled":

--- a/pkg/buildx/bake/buildflags/export.go
+++ b/pkg/buildx/bake/buildflags/export.go
@@ -223,9 +223,17 @@ func (w *csvBuilder) Write(key, value string) {
 	if w.sb.Len() > 0 {
 		w.sb.WriteByte(',')
 	}
-	w.sb.WriteString(key)
-	w.sb.WriteByte('=')
-	w.sb.WriteString(value)
+
+	pair := key + "=" + value
+	if strings.ContainsRune(pair, ',') || strings.ContainsRune(pair, '"') {
+		var attr strings.Builder
+		writer := csv.NewWriter(&attr)
+		writer.Write([]string{pair})
+		writer.Flush()
+		pair = strings.TrimSpace(attr.String())
+	}
+
+	w.sb.WriteString(pair)
 }
 
 func (w *csvBuilder) WriteAttributes(attrs map[string]string) {

--- a/pkg/buildx/bake/compose.go
+++ b/pkg/buildx/bake/compose.go
@@ -129,6 +129,18 @@ func ParseCompose(cfgs []compose.ConfigFile, envs map[string]string) (*Config, e
 				return nil, err
 			}
 
+			var inAttests []string
+			if s.Build.SBOM != "" {
+				inAttests = append(inAttests, buildflags.CanonicalizeAttest("sbom", s.Build.SBOM))
+			}
+			if s.Build.Provenance != "" {
+				inAttests = append(inAttests, buildflags.CanonicalizeAttest("provenance", s.Build.Provenance))
+			}
+			attests, err := parseArrValue[buildflags.Attest](inAttests)
+			if err != nil {
+				return nil, err
+			}
+
 			g.Targets = append(g.Targets, targetName)
 			t := &Target{
 				Name:             targetName,
@@ -145,12 +157,14 @@ func ParseCompose(cfgs []compose.ConfigFile, envs map[string]string) (*Config, e
 					val, ok := cfg.Environment[val]
 					return val, ok
 				})),
-				CacheFrom:   cacheFrom,
-				CacheTo:     cacheTo,
-				NetworkMode: &s.Build.Network,
-				Platforms:   s.Build.Platforms,
-				SSH:         ssh,
-				Secrets:     secrets,
+				CacheFrom:     cacheFrom,
+				CacheTo:       cacheTo,
+				NetworkMode:   &s.Build.Network,
+				Platforms:     s.Build.Platforms,
+				SSH:           ssh,
+				Secrets:       secrets,
+				Attest:        attests,
+				NoCacheFilter: s.Build.NoCacheFilter,
 			}
 			if err = t.composeExtTarget(s.Build.Extensions); err != nil {
 				return nil, err


### PR DESCRIPTION
## Summary

- map Compose `provenance` and `sbom` settings into Bake attestations
- preserve Compose `no_cache_filter` and support Bake override replacement and append
- preserve custom attestation attribute casing and CSV-quote comma-containing values

## Why

The compose-go v2.14 update merged in #551 makes these Compose build fields valid. Depot's Compose-to-Bake adapter did not carry them into the resolved target, so builds could succeed while silently dropping requested provenance, SBOM, or selective cache invalidation.

The attestation parsing and serialization changes port docker/buildx@6da88e1555db601a28291777ab592193fe5c868b. The Compose attestation mapping follows upstream `bake/compose.go` using Depot's local `parseArrValue` equivalent. Native Compose cache-filter mapping and its override classification are Depot-specific additions.

## Validation

- `go test ./...`
- `go test -race ./pkg/buildx/bake ./pkg/compose`
- `go vet ./...`
- `go mod verify`
- `go mod tidy -diff`
- `git diff --check`
- direct `depot bake --print` checks for provenance/SBOM metadata and Compose + x-bake + CLI cache-filter merging

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Compose build options flow into actual build configuration; mis-mapping could alter provenance/SBOM or cache behavior, but scope is limited to bake/compose adapters and flag parsing.
> 
> **Overview**
> Fixes **silent loss** of Compose build settings when converting Compose files to Bake targets after compose-go v2.14 made fields like provenance, SBOM, and `no_cache_filter` valid.
> 
> **Compose → Bake mapping** now sets `Attest` from `build.sbom` and `build.provenance` (via `CanonicalizeAttest`) and copies `NoCacheFilter` from Compose onto the resolved target.
> 
> **Bake `--set` overrides** treat `no-cache-filter` like other list fields: supports append (`+`) vs full replacement, and the override key is classified for array-style parsing.
> 
> **Attestation / CSV serialization** (ported from upstream buildx): custom attestation attribute names keep their original casing when parsed from CSV; values containing commas or quotes are CSV-quoted when attestations/exports are stringified so round-trips stay valid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99067e6848aba3105bc74c69360ef54cce00c44f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->