### PR TITLE
feat(ci): add forge-aware workflow migration analysis

### DIFF
--- a/pkg/cmd/ci/migrate.go
+++ b/pkg/cmd/ci/migrate.go
@@ -432,6 +432,7 @@ func workflowsWithContext(ctx context.Context, opts migrateOptions) error {
 	out = colorprofile.NewWriter(out, os.Environ())
 
 	bold := lipgloss.NewStyle().Bold(true)
+	migrationRemote := "origin"
 
 	githubDir := filepath.Join(workDir, ".github")
 	workflowsDir := filepath.Join(githubDir, "workflows")
@@ -588,11 +589,14 @@ func workflowsWithContext(ctx context.Context, opts migrateOptions) error {
 	}
 
 	if effectiveMigrationForge(opts.forge) == migrationForgeCursor {
-		if _, repositoryURL, err := analyzeCursorOriginWorkflows(ctx, opts, selectedWorkflows); err != nil {
+		analysis, err := analyzeCursorOriginWorkflows(ctx, opts, selectedWorkflows)
+		if err != nil {
 			return err
-		} else {
-			fmt.Fprintf(out, "\nDetected repository: %s\n", bold.Render(repositoryURL))
 		}
+		// DEP-6082 owns rendering the structured findings. Keep them non-blocking here.
+		_ = analysis.response
+		migrationRemote = analysis.remote
+		fmt.Fprintf(out, "\nDetected repository: %s\n", bold.Render(analysis.repositoryURL))
 	}
 
 	// Copy .github/actions/ to .depot/actions/
@@ -704,14 +708,20 @@ func workflowsWithContext(ctx context.Context, opts migrateOptions) error {
 		return fmt.Errorf("failed to detect variables: %w", err)
 	}
 
-	defaultBranch := detectDefaultBranch(workDir)
+	defaultBranch := detectDefaultBranch(workDir, migrationRemote)
 
 	fmt.Fprintln(out, "")
 	fmt.Fprintf(out, "%s\n\n", bold.Render("Next steps:"))
 
 	if len(detectedSecrets) > 0 || len(detectedVariables) > 0 {
-		fmt.Fprintf(out, "  1. Your workflows depend on %d secret(s) and %d variable(s) which need to be imported from GitHub:\n", len(detectedSecrets), len(detectedVariables))
-		fmt.Fprintln(out, "     - Import them automatically with `depot ci migrate secrets-and-vars`")
+		secretsSource := "GitHub"
+		secretMigrationCommand := "depot ci migrate secrets-and-vars"
+		if effectiveMigrationForge(opts.forge) == migrationForgeCursor {
+			secretsSource = "the source repository"
+			secretMigrationCommand += " --forge=cursor"
+		}
+		fmt.Fprintf(out, "  1. Your workflows depend on %d secret(s) and %d variable(s) which need to be imported from %s:\n", len(detectedSecrets), len(detectedVariables), secretsSource)
+		fmt.Fprintf(out, "     - Import them automatically with `%s`\n", secretMigrationCommand)
 		fmt.Fprintln(out, "     - Or import them manually with `depot ci secrets add` and `depot ci vars add`")
 		if defaultBranch != "" {
 			fmt.Fprintf(out, "  2. Activate these workflows by pushing and merging them into %s\n", bold.Render(defaultBranch))
@@ -732,11 +742,14 @@ func workflowsWithContext(ctx context.Context, opts migrateOptions) error {
 }
 
 // detectDefaultBranch returns the default branch name (e.g. "main") or empty string.
-func detectDefaultBranch(dir string) string {
-	// Try symbolic-ref first (works when origin/HEAD is set)
-	if out, err := exec.Command("git", "-C", dir, "symbolic-ref", "refs/remotes/origin/HEAD").Output(); err == nil {
+func detectDefaultBranch(dir, remote string) string {
+	if strings.TrimSpace(remote) == "" {
+		remote = "origin"
+	}
+	// Try symbolic-ref first (works when the remote's HEAD is set)
+	if out, err := exec.Command("git", "-C", dir, "symbolic-ref", "refs/remotes/"+remote+"/HEAD").Output(); err == nil {
 		branch := strings.TrimSpace(string(out))
-		branch = strings.TrimPrefix(branch, "refs/remotes/origin/")
+		branch = strings.TrimPrefix(branch, "refs/remotes/"+remote+"/")
 		if branch != "" {
 			return branch
 		}
@@ -744,7 +757,7 @@ func detectDefaultBranch(dir string) string {
 
 	// Fall back to checking for common default branch names
 	for _, name := range []string{"main", "master"} {
-		if err := exec.Command("git", "-C", dir, "rev-parse", "--verify", "refs/remotes/origin/"+name).Run(); err == nil {
+		if err := exec.Command("git", "-C", dir, "rev-parse", "--verify", "refs/remotes/"+remote+"/"+name).Run(); err == nil {
 			return name
 		}
 	}

--- a/pkg/cmd/ci/migrate.go
+++ b/pkg/cmd/ci/migrate.go
@@ -23,12 +23,53 @@ import (
 	"github.com/depot/cli/pkg/helpers"
 	"github.com/depot/cli/pkg/oidc"
 	civ1 "github.com/depot/cli/pkg/proto/depot/ci/v1"
+	civ2 "github.com/depot/cli/pkg/proto/depot/ci/v2"
 	"github.com/spf13/cobra"
 )
+
+type migrationForge string
+
+const (
+	migrationForgeGitHub migrationForge = "github"
+	migrationForgeCursor migrationForge = "cursor"
+)
+
+func (f *migrationForge) String() string {
+	if f == nil || *f == "" {
+		return string(migrationForgeGitHub)
+	}
+	return string(*f)
+}
+
+func (f *migrationForge) Set(value string) error {
+	switch migrationForge(value) {
+	case migrationForgeGitHub, migrationForgeCursor:
+		*f = migrationForge(value)
+		return nil
+	default:
+		return fmt.Errorf("must be one of github, cursor")
+	}
+}
+
+func (f *migrationForge) Type() string {
+	return "forge"
+}
+
+func effectiveMigrationForge(forge migrationForge) migrationForge {
+	if forge == "" {
+		return migrationForgeGitHub
+	}
+	return forge
+}
+
+type repositoryAnalysisClient interface {
+	GetRepositoryAnalysis(context.Context, *connect.Request[civ2.GetRepositoryMigrationAnalysisRequest]) (*connect.Response[civ2.GetRepositoryMigrationAnalysisResponse], error)
+}
 
 type migrateOptions struct {
 	token                       string
 	orgID                       string
+	forge                       migrationForge
 	yes                         bool
 	overwrite                   bool
 	dir                         string
@@ -38,10 +79,11 @@ type migrateOptions struct {
 	secretMigrationBranchPrefix string
 	secretMigrationRegistrar    secretMigrationIntentRegistrar
 	secretMigrationNow          time.Time
+	repositoryAnalysisClient    repositoryAnalysisClient
 }
 
 func NewCmdMigrate() *cobra.Command {
-	var opts migrateOptions
+	opts := migrateOptions{forge: migrationForgeGitHub}
 
 	cmd := &cobra.Command{
 		Use:   "migrate",
@@ -58,6 +100,7 @@ func NewCmdMigrate() *cobra.Command {
 	pf := cmd.PersistentFlags()
 	pf.StringVar(&opts.token, "token", "", "Depot API token")
 	pf.StringVar(&opts.orgID, "org", "", "Depot organization ID")
+	pf.Var(&opts.forge, "forge", "Source-code forge to migrate from (github or cursor)")
 	pf.BoolVarP(&opts.yes, "yes", "y", false, "Run in non-interactive mode")
 
 	cmd.Flags().BoolVar(&opts.overwrite, "overwrite", false, "Overwrite existing .depot/ directory")
@@ -104,7 +147,7 @@ func secretsAndVars(ctx context.Context, opts migrateOptions) error {
 	if err != nil {
 		return err
 	}
-	remote, _, err := detectSecretMigrationRemote(ctx, workDir)
+	remote, _, err := detectSecretMigrationRemote(ctx, workDir, effectiveMigrationForge(opts.forge))
 	if err != nil {
 		return err
 	}
@@ -206,7 +249,7 @@ func newCmdWorkflows(parentOpts *migrateOptions) *cobra.Command {
 			opts := *parentOpts
 			opts.dir = "."
 			opts.stdout = os.Stdout
-			return workflows(opts)
+			return workflowsWithContext(cmd.Context(), opts)
 		},
 	}
 
@@ -218,8 +261,8 @@ func newCmdWorkflows(parentOpts *migrateOptions) *cobra.Command {
 func newCmdPreflight(parentOpts *migrateOptions) *cobra.Command {
 	return &cobra.Command{
 		Use:   "preflight",
-		Short: "Check that the Depot Code Access app is installed and configured",
-		Long:  "Validates authentication, detects the repository from the git remote, and checks that the Depot Code Access GitHub App is installed with the correct permissions and repository access.",
+		Short: "Check authentication and repository access for migration",
+		Long:  "Validates authentication, detects a repository for the selected forge, and checks the access required to migrate it. GitHub checks the Depot Code Access app; Cursor checks that the Origin repository is available to the Depot organization.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts := *parentOpts
 			opts.dir = "."
@@ -269,6 +312,13 @@ type preflightResult struct {
 // Returns nil result (and nil error) when the check fails with a user-facing
 // message that has already been printed.
 func preflight(ctx context.Context, opts migrateOptions) (*preflightResult, error) {
+	if effectiveMigrationForge(opts.forge) == migrationForgeCursor {
+		return cursorPreflight(ctx, opts)
+	}
+	return githubPreflight(ctx, opts)
+}
+
+func githubPreflight(ctx context.Context, opts migrateOptions) (*preflightResult, error) {
 	workDir := opts.dir
 	if strings.TrimSpace(workDir) == "" {
 		workDir = "."
@@ -348,6 +398,10 @@ func preflight(ctx context.Context, opts migrateOptions) (*preflightResult, erro
 }
 
 func runMigrate(ctx context.Context, opts migrateOptions) error {
+	if effectiveMigrationForge(opts.forge) == migrationForgeCursor {
+		return workflowsWithContext(ctx, opts)
+	}
+
 	result, err := preflight(ctx, opts)
 	if err != nil {
 		return err
@@ -358,10 +412,14 @@ func runMigrate(ctx context.Context, opts migrateOptions) error {
 
 	_ = result // auth info available for future use
 
-	return workflows(opts)
+	return workflowsWithContext(ctx, opts)
 }
 
 func workflows(opts migrateOptions) error {
+	return workflowsWithContext(context.Background(), opts)
+}
+
+func workflowsWithContext(ctx context.Context, opts migrateOptions) error {
 	workDir := opts.dir
 	if strings.TrimSpace(workDir) == "" {
 		workDir = "."
@@ -527,6 +585,14 @@ func workflows(opts migrateOptions) error {
 		}
 	} else if !os.IsNotExist(err) {
 		return fmt.Errorf("failed to inspect .depot directory: %w", err)
+	}
+
+	if effectiveMigrationForge(opts.forge) == migrationForgeCursor {
+		if _, repositoryURL, err := analyzeCursorOriginWorkflows(ctx, opts, selectedWorkflows); err != nil {
+			return err
+		} else {
+			fmt.Fprintf(out, "\nDetected repository: %s\n", bold.Render(repositoryURL))
+		}
 	}
 
 	// Copy .github/actions/ to .depot/actions/

--- a/pkg/cmd/ci/migrate_origin_analysis.go
+++ b/pkg/cmd/ci/migrate_origin_analysis.go
@@ -13,8 +13,14 @@ import (
 	civ2 "github.com/depot/cli/pkg/proto/depot/ci/v2"
 )
 
+type cursorOriginAnalysis struct {
+	response      *connect.Response[civ2.GetRepositoryMigrationAnalysisResponse]
+	remote        string
+	repositoryURL string
+}
+
 func cursorPreflight(ctx context.Context, opts migrateOptions) (*preflightResult, error) {
-	_, repositoryURL, err := analyzeCursorOriginWorkflows(ctx, opts, nil)
+	analysis, err := analyzeCursorOriginWorkflows(ctx, opts, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -27,33 +33,33 @@ func cursorPreflight(ctx context.Context, opts migrateOptions) (*preflightResult
 	if out == nil {
 		out = os.Stdout
 	}
-	fmt.Fprintf(out, "\nDetected repository: %s\n", repositoryURL)
+	fmt.Fprintf(out, "\nDetected repository: %s\n", analysis.repositoryURL)
 	fmt.Fprintln(out, "Cursor Origin repository is available to this Depot organization.")
-	return &preflightResult{token: token, orgID: orgID, repo: repositoryURL}, nil
+	return &preflightResult{token: token, orgID: orgID, repo: analysis.repositoryURL}, nil
 }
 
 func analyzeCursorOriginWorkflows(
 	ctx context.Context,
 	opts migrateOptions,
 	workflows []*migrate.WorkflowFile,
-) (*connect.Response[civ2.GetRepositoryMigrationAnalysisResponse], string, error) {
+) (*cursorOriginAnalysis, error) {
 	token, orgID, err := resolveAuth(ctx, opts)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
 	workDir := opts.dir
 	if strings.TrimSpace(workDir) == "" {
 		workDir = "."
 	}
-	_, repositoryURL, err := detectMigrationRemote(ctx, workDir, migrationForgeCursor, false)
+	remote, repositoryURL, err := detectMigrationRemote(ctx, workDir, migrationForgeCursor, false)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
 	workflowFiles, err := migrationWorkflowFiles(workDir, workflows)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
 	client := opts.repositoryAnalysisClient
@@ -67,9 +73,9 @@ func analyzeCursorOriginWorkflows(
 	}), token, orgID)
 	response, err := client.GetRepositoryAnalysis(ctx, request)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to analyze Cursor Origin compatibility for %s: %w", repositoryURL, err)
+		return nil, fmt.Errorf("failed to analyze Cursor Origin compatibility for %s: %w", repositoryURL, err)
 	}
-	return response, repositoryURL, nil
+	return &cursorOriginAnalysis{response: response, remote: remote, repositoryURL: repositoryURL}, nil
 }
 
 func migrationWorkflowFiles(workDir string, workflows []*migrate.WorkflowFile) ([]*civ2.MigrationWorkflowFile, error) {

--- a/pkg/cmd/ci/migrate_origin_analysis.go
+++ b/pkg/cmd/ci/migrate_origin_analysis.go
@@ -1,0 +1,123 @@
+package ci
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"connectrpc.com/connect"
+	"github.com/depot/cli/pkg/api"
+	"github.com/depot/cli/pkg/ci/migrate"
+	civ2 "github.com/depot/cli/pkg/proto/depot/ci/v2"
+)
+
+func cursorPreflight(ctx context.Context, opts migrateOptions) (*preflightResult, error) {
+	_, repositoryURL, err := analyzeCursorOriginWorkflows(ctx, opts, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	token, orgID, err := resolveAuth(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := opts.stdout
+	if out == nil {
+		out = os.Stdout
+	}
+	fmt.Fprintf(out, "\nDetected repository: %s\n", repositoryURL)
+	fmt.Fprintln(out, "Cursor Origin repository is available to this Depot organization.")
+	return &preflightResult{token: token, orgID: orgID, repo: repositoryURL}, nil
+}
+
+func analyzeCursorOriginWorkflows(
+	ctx context.Context,
+	opts migrateOptions,
+	workflows []*migrate.WorkflowFile,
+) (*connect.Response[civ2.GetRepositoryMigrationAnalysisResponse], string, error) {
+	token, orgID, err := resolveAuth(ctx, opts)
+	if err != nil {
+		return nil, "", err
+	}
+
+	workDir := opts.dir
+	if strings.TrimSpace(workDir) == "" {
+		workDir = "."
+	}
+	_, repositoryURL, err := detectMigrationRemote(ctx, workDir, migrationForgeCursor, false)
+	if err != nil {
+		return nil, "", err
+	}
+
+	workflowFiles, err := migrationWorkflowFiles(workDir, workflows)
+	if err != nil {
+		return nil, "", err
+	}
+
+	client := opts.repositoryAnalysisClient
+	if client == nil {
+		client = api.NewWorkflowMigrationClient()
+	}
+	request := api.WithAuthenticationAndOrg(connect.NewRequest(&civ2.GetRepositoryMigrationAnalysisRequest{
+		Forge:         civ2.MigrationForge_MIGRATION_FORGE_CURSOR_ORIGIN,
+		RepositoryUrl: repositoryURL,
+		WorkflowFiles: &civ2.MigrationWorkflowFiles{Workflows: workflowFiles},
+	}), token, orgID)
+	response, err := client.GetRepositoryAnalysis(ctx, request)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to analyze Cursor Origin compatibility for %s: %w", repositoryURL, err)
+	}
+	return response, repositoryURL, nil
+}
+
+func migrationWorkflowFiles(workDir string, workflows []*migrate.WorkflowFile) ([]*civ2.MigrationWorkflowFile, error) {
+	root, err := filepath.Abs(workDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve repository directory: %w", err)
+	}
+	resolvedRoot, err := filepath.EvalSymlinks(workDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve repository directory: %w", err)
+	}
+	resolvedRoot, err = filepath.Abs(resolvedRoot)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve repository directory: %w", err)
+	}
+
+	files := make([]*civ2.MigrationWorkflowFile, 0, len(workflows))
+	for _, workflow := range workflows {
+		path, err := filepath.Abs(workflow.Path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve workflow path %s: %w", workflow.Path, err)
+		}
+		requestPath, err := filepath.Rel(root, path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve workflow path %s: %w", workflow.Path, err)
+		}
+
+		resolvedPath, err := filepath.EvalSymlinks(path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve workflow path %s: %w", workflow.Path, err)
+		}
+		resolvedPath, err = filepath.Abs(resolvedPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve workflow path %s: %w", workflow.Path, err)
+		}
+		resolvedRelative, err := filepath.Rel(resolvedRoot, resolvedPath)
+		if err != nil || resolvedRelative == ".." || strings.HasPrefix(resolvedRelative, ".."+string(filepath.Separator)) {
+			return nil, fmt.Errorf("workflow %s resolves outside the repository and cannot be sent for analysis", workflow.Path)
+		}
+
+		content, err := os.ReadFile(resolvedPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read %s for analysis: %w", workflow.Path, err)
+		}
+		files = append(files, &civ2.MigrationWorkflowFile{
+			Path:    filepath.ToSlash(requestPath),
+			Content: string(content),
+		})
+	}
+	return files, nil
+}

--- a/pkg/cmd/ci/migrate_origin_analysis_test.go
+++ b/pkg/cmd/ci/migrate_origin_analysis_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -35,8 +34,15 @@ func (c *recordingRepositoryAnalysisClient) GetRepositoryAnalysis(
 
 func TestCursorMigrationAnalyzesSelectedLocalWorkflowsBeforeMigrating(t *testing.T) {
 	dir, workflow := newMigrationTestRepository(t)
+	runSecretMigrationTestCommand(t, dir, "git", "add", ".")
+	runSecretMigrationTestCommand(t, dir, "git", "-c", "user.name=Depot Test", "-c", "user.email=test@depot.dev", "commit", "-m", "base")
+	sha := runSecretMigrationTestCommand(t, dir, "git", "rev-parse", "HEAD")
 	runSecretMigrationTestCommand(t, dir, "git", "remote", "add", "origin", "https://github.com/acme/widgets.git")
 	runSecretMigrationTestCommand(t, dir, "git", "remote", "add", "cursor", "git@origin.cursor.com:git/acme/widgets.git")
+	runSecretMigrationTestCommand(t, dir, "git", "update-ref", "refs/remotes/origin/main", sha)
+	runSecretMigrationTestCommand(t, dir, "git", "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+	runSecretMigrationTestCommand(t, dir, "git", "update-ref", "refs/remotes/cursor/trunk", sha)
+	runSecretMigrationTestCommand(t, dir, "git", "symbolic-ref", "refs/remotes/cursor/HEAD", "refs/remotes/cursor/trunk")
 
 	client := &recordingRepositoryAnalysisClient{response: &civ2.GetRepositoryMigrationAnalysisResponse{
 		Workflows: []*civ2.RepositoryWorkflowMigration{{
@@ -86,6 +92,15 @@ func TestCursorMigrationAnalyzesSelectedLocalWorkflowsBeforeMigrating(t *testing
 	}
 	if _, err := os.Stat(filepath.Join(dir, ".depot", "workflows", "ci.yml")); err != nil {
 		t.Fatalf("diagnostic findings must not stop migration: %v", err)
+	}
+	if !strings.Contains(output.String(), "depot ci migrate secrets-and-vars --forge=cursor") {
+		t.Fatalf("Cursor follow-up command dropped the selected forge:\n%s", output.String())
+	}
+	if !strings.Contains(output.String(), "pushing and merging them into trunk") {
+		t.Fatalf("next steps did not use the selected Cursor remote's default branch:\n%s", output.String())
+	}
+	if strings.Contains(output.String(), "imported from GitHub") {
+		t.Fatalf("Cursor next steps incorrectly describe the source as GitHub:\n%s", output.String())
 	}
 }
 
@@ -216,20 +231,6 @@ func TestMigrateForgeFlagRejectsUnsupportedValueOnSubcommands(t *testing.T) {
 	}
 }
 
-func TestMigrateForgeFlagAcceptsSupportedValues(t *testing.T) {
-	for _, forge := range []string{"github", "cursor"} {
-		t.Run(forge, func(t *testing.T) {
-			cmd := NewCmdMigrate()
-			cmd.SetOut(io.Discard)
-			cmd.SetErr(io.Discard)
-			cmd.SetArgs([]string{"workflows", "--forge", forge, "--help"})
-			if err := cmd.ExecuteContext(context.Background()); err != nil {
-				t.Fatalf("--forge=%s was rejected: %v", forge, err)
-			}
-		})
-	}
-}
-
 func newMigrationTestRepository(t *testing.T) (string, string) {
 	t.Helper()
 	dir := t.TempDir()
@@ -238,7 +239,7 @@ func newMigrationTestRepository(t *testing.T) (string, string) {
 	if err := os.MkdirAll(workflowsDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	workflow := "name: CI\non: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n"
+	workflow := "name: CI\non: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n      - run: echo ${{ secrets.MY_SECRET }}\n"
 	if err := os.WriteFile(filepath.Join(workflowsDir, "ci.yml"), []byte(workflow), 0644); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cmd/ci/migrate_origin_analysis_test.go
+++ b/pkg/cmd/ci/migrate_origin_analysis_test.go
@@ -1,0 +1,246 @@
+package ci
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	civ2 "github.com/depot/cli/pkg/proto/depot/ci/v2"
+)
+
+type recordingRepositoryAnalysisClient struct {
+	request  *connect.Request[civ2.GetRepositoryMigrationAnalysisRequest]
+	response *civ2.GetRepositoryMigrationAnalysisResponse
+	err      error
+	calls    int
+}
+
+func (c *recordingRepositoryAnalysisClient) GetRepositoryAnalysis(
+	_ context.Context,
+	request *connect.Request[civ2.GetRepositoryMigrationAnalysisRequest],
+) (*connect.Response[civ2.GetRepositoryMigrationAnalysisResponse], error) {
+	c.calls++
+	c.request = request
+	if c.err != nil {
+		return nil, c.err
+	}
+	return connect.NewResponse(c.response), nil
+}
+
+func TestCursorMigrationAnalyzesSelectedLocalWorkflowsBeforeMigrating(t *testing.T) {
+	dir, workflow := newMigrationTestRepository(t)
+	runSecretMigrationTestCommand(t, dir, "git", "remote", "add", "origin", "https://github.com/acme/widgets.git")
+	runSecretMigrationTestCommand(t, dir, "git", "remote", "add", "cursor", "git@origin.cursor.com:git/acme/widgets.git")
+
+	client := &recordingRepositoryAnalysisClient{response: &civ2.GetRepositoryMigrationAnalysisResponse{
+		Workflows: []*civ2.RepositoryWorkflowMigration{{
+			Path: ".github/workflows/ci.yml",
+			Analysis: &civ2.WorkflowAnalysis{Blockers: []*civ2.MigrationDiagnostic{{
+				Code:     "origin.unsupported",
+				Severity: civ2.MigrationDiagnosticSeverity_MIGRATION_DIAGNOSTIC_SEVERITY_FAILS,
+			}}},
+		}},
+	}}
+	var output bytes.Buffer
+	err := workflowsWithContext(context.Background(), migrateOptions{
+		dir:                      dir,
+		stdout:                   &output,
+		yes:                      true,
+		forge:                    migrationForgeCursor,
+		token:                    "depot_api_token",
+		orgID:                    "org-id",
+		repositoryAnalysisClient: client,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if client.calls != 1 {
+		t.Fatalf("analysis calls = %d, want 1", client.calls)
+	}
+	request := client.request
+	if request.Header().Get("Authorization") != "Bearer depot_api_token" {
+		t.Fatalf("unexpected authorization header: %q", request.Header().Get("Authorization"))
+	}
+	if request.Header().Get("x-depot-org") != "org-id" {
+		t.Fatalf("unexpected organization header: %q", request.Header().Get("x-depot-org"))
+	}
+	if request.Msg.GetForge() != civ2.MigrationForge_MIGRATION_FORGE_CURSOR_ORIGIN {
+		t.Fatalf("forge = %s, want Cursor Origin", request.Msg.GetForge())
+	}
+	if request.Msg.GetRepositoryUrl() != "origin.cursor.com/acme/widgets" {
+		t.Fatalf("repository URL = %q", request.Msg.GetRepositoryUrl())
+	}
+	if request.Msg.GetInstallationId() != "" || request.Msg.GetWorkflowRepoId() != "" {
+		t.Fatal("Depot-authenticated analysis must not send caller-supplied installation or repository IDs")
+	}
+	files := request.Msg.GetWorkflowFiles().GetWorkflows()
+	if len(files) != 1 || files[0].GetPath() != ".github/workflows/ci.yml" || files[0].GetContent() != workflow {
+		t.Fatalf("unexpected local workflow payload: %#v", files)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".depot", "workflows", "ci.yml")); err != nil {
+		t.Fatalf("diagnostic findings must not stop migration: %v", err)
+	}
+}
+
+func TestGitHubMigrationDoesNotRequestOriginAnalysis(t *testing.T) {
+	dir, _ := newMigrationTestRepository(t)
+	client := &recordingRepositoryAnalysisClient{err: errors.New("must not be called")}
+	if err := workflows(migrateOptions{
+		dir:                      dir,
+		yes:                      true,
+		repositoryAnalysisClient: client,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if client.calls != 0 {
+		t.Fatalf("Origin analysis calls = %d, want 0", client.calls)
+	}
+}
+
+func TestCursorMigrationReportsAnalysisFailureBeforeWritingFiles(t *testing.T) {
+	dir, _ := newMigrationTestRepository(t)
+	runSecretMigrationTestCommand(t, dir, "git", "remote", "add", "origin", "https://origin.cursor.com/git/acme/widgets")
+	client := &recordingRepositoryAnalysisClient{err: connect.NewError(connect.CodePermissionDenied, errors.New("repository is not available to this organization"))}
+
+	err := workflowsWithContext(context.Background(), migrateOptions{
+		dir:                      dir,
+		yes:                      true,
+		forge:                    migrationForgeCursor,
+		token:                    "depot_api_token",
+		orgID:                    "org-id",
+		repositoryAnalysisClient: client,
+	})
+	if err == nil || !strings.Contains(err.Error(), "failed to analyze Cursor Origin compatibility for origin.cursor.com/acme/widgets") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, ".depot")); !os.IsNotExist(statErr) {
+		t.Fatalf("migration wrote files after analysis failure: %v", statErr)
+	}
+}
+
+func TestCursorPreflightUsesOriginAnalysisInsteadOfGitHubCodeAccess(t *testing.T) {
+	dir, _ := newMigrationTestRepository(t)
+	runSecretMigrationTestCommand(t, dir, "git", "remote", "add", "origin", "https://origin.cursor.com/git/acme/widgets")
+	client := &recordingRepositoryAnalysisClient{response: &civ2.GetRepositoryMigrationAnalysisResponse{}}
+	var output bytes.Buffer
+
+	result, err := preflight(context.Background(), migrateOptions{
+		dir:                      dir,
+		stdout:                   &output,
+		forge:                    migrationForgeCursor,
+		token:                    "depot_org_token",
+		repositoryAnalysisClient: client,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result == nil || result.repo != "origin.cursor.com/acme/widgets" {
+		t.Fatalf("unexpected preflight result: %#v", result)
+	}
+	if client.calls != 1 || len(client.request.Msg.GetWorkflowFiles().GetWorkflows()) != 0 {
+		t.Fatal("Cursor preflight must validate repository access with an empty local analysis request")
+	}
+	if client.request.Header().Get("Authorization") != "Bearer depot_org_token" || client.request.Header().Get("x-depot-org") != "" {
+		t.Fatalf("unexpected organization-token authentication headers: %#v", client.request.Header())
+	}
+	if !strings.Contains(output.String(), "Cursor Origin repository is available") {
+		t.Fatalf("unexpected output: %s", output.String())
+	}
+}
+
+func TestCursorMigrationReportsMissingOriginRemote(t *testing.T) {
+	dir, _ := newMigrationTestRepository(t)
+	runSecretMigrationTestCommand(t, dir, "git", "remote", "add", "origin", "https://github.com/acme/widgets.git")
+	client := &recordingRepositoryAnalysisClient{response: &civ2.GetRepositoryMigrationAnalysisResponse{}}
+
+	err := workflowsWithContext(context.Background(), migrateOptions{
+		dir:                      dir,
+		yes:                      true,
+		forge:                    migrationForgeCursor,
+		token:                    "depot_org_token",
+		repositoryAnalysisClient: client,
+	})
+	if err == nil || !strings.Contains(err.Error(), "configure a remote pointing to origin.cursor.com/namespace/repo") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if client.calls != 0 {
+		t.Fatal("analysis request was made without a Cursor Origin remote")
+	}
+}
+
+func TestCursorMigrationDoesNotUploadWorkflowOutsideRepository(t *testing.T) {
+	dir, _ := newMigrationTestRepository(t)
+	runSecretMigrationTestCommand(t, dir, "git", "remote", "add", "origin", "https://origin.cursor.com/git/acme/widgets")
+	external := filepath.Join(t.TempDir(), "external.yml")
+	if err := os.WriteFile(external, []byte("on: push\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	workflowPath := filepath.Join(dir, ".github", "workflows", "ci.yml")
+	if err := os.Remove(workflowPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, workflowPath); err != nil {
+		t.Fatal(err)
+	}
+	client := &recordingRepositoryAnalysisClient{response: &civ2.GetRepositoryMigrationAnalysisResponse{}}
+
+	err := workflowsWithContext(context.Background(), migrateOptions{
+		dir:                      dir,
+		yes:                      true,
+		forge:                    migrationForgeCursor,
+		token:                    "depot_api_token",
+		orgID:                    "org-id",
+		repositoryAnalysisClient: client,
+	})
+	if err == nil || !strings.Contains(err.Error(), "resolves outside the repository") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if client.calls != 0 {
+		t.Fatal("analysis client received content from outside the repository")
+	}
+}
+
+func TestMigrateForgeFlagRejectsUnsupportedValueOnSubcommands(t *testing.T) {
+	cmd := NewCmdMigrate()
+	cmd.SetArgs([]string{"workflows", "--forge", "gitlab", "--yes"})
+	err := cmd.ExecuteContext(context.Background())
+	if err == nil || !strings.Contains(err.Error(), `invalid argument "gitlab" for "--forge" flag`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestMigrateForgeFlagAcceptsSupportedValues(t *testing.T) {
+	for _, forge := range []string{"github", "cursor"} {
+		t.Run(forge, func(t *testing.T) {
+			cmd := NewCmdMigrate()
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+			cmd.SetArgs([]string{"workflows", "--forge", forge, "--help"})
+			if err := cmd.ExecuteContext(context.Background()); err != nil {
+				t.Fatalf("--forge=%s was rejected: %v", forge, err)
+			}
+		})
+	}
+}
+
+func newMigrationTestRepository(t *testing.T) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	runSecretMigrationTestCommand(t, "", "git", "init", dir)
+	workflowsDir := filepath.Join(dir, ".github", "workflows")
+	if err := os.MkdirAll(workflowsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	workflow := "name: CI\non: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n"
+	if err := os.WriteFile(filepath.Join(workflowsDir, "ci.yml"), []byte(workflow), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return dir, workflow
+}

--- a/pkg/cmd/ci/migrate_secret_intent.go
+++ b/pkg/cmd/ci/migrate_secret_intent.go
@@ -214,7 +214,11 @@ func resolveSecretMigrationCommit(ctx context.Context, dir, ref string) (string,
 	return runGit(ctx, dir, "rev-parse", "--verify", ref+"^{commit}")
 }
 
-func detectSecretMigrationRemote(ctx context.Context, dir string) (string, string, error) {
+func detectSecretMigrationRemote(ctx context.Context, dir string, forge migrationForge) (string, string, error) {
+	return detectMigrationRemote(ctx, dir, forge, true)
+}
+
+func detectMigrationRemote(ctx context.Context, dir string, forge migrationForge, push bool) (string, string, error) {
 	remotes, err := runGit(ctx, dir, "remote")
 	if err != nil {
 		return "", "", fmt.Errorf("failed to list git remotes: %w", err)
@@ -228,16 +232,39 @@ func detectSecretMigrationRemote(ctx context.Context, dir string) (string, strin
 		}
 	}
 	for _, name := range names {
-		remoteURL, err := runGit(ctx, dir, "remote", "get-url", "--push", name)
+		args := []string{"remote", "get-url"}
+		if push {
+			args = append(args, "--push")
+		}
+		remoteURL, err := runGit(ctx, dir, append(args, name)...)
 		if err != nil {
 			continue
 		}
 		repositoryURL, _, err := normalizeSecretMigrationRemoteURL(remoteURL)
-		if err == nil {
+		if err == nil && repositoryURLMatchesForge(repositoryURL, forge) {
 			return name, repositoryURL, nil
 		}
 	}
-	return "", "", fmt.Errorf("could not detect a supported repository from git push remotes")
+	forgeName := "GitHub"
+	host := "github.com/owner/repo"
+	if forge == migrationForgeCursor {
+		forgeName = "Cursor Origin"
+		host = "origin.cursor.com/namespace/repo"
+	}
+	remoteKind := "git remotes"
+	if push {
+		remoteKind = "git push remotes"
+	}
+	return "", "", fmt.Errorf("could not detect a %s repository from %s — configure a remote pointing to %s", forgeName, remoteKind, host)
+}
+
+func repositoryURLMatchesForge(repositoryURL string, forge migrationForge) bool {
+	switch forge {
+	case migrationForgeCursor:
+		return strings.HasPrefix(repositoryURL, "origin.cursor.com/")
+	default:
+		return strings.HasPrefix(repositoryURL, "github.com/")
+	}
 }
 
 func normalizeSecretMigrationRemoteURL(value string) (string, string, error) {

--- a/pkg/cmd/ci/migrate_secret_intent_test.go
+++ b/pkg/cmd/ci/migrate_secret_intent_test.go
@@ -226,11 +226,16 @@ func testSecretsAndVarsCreatesIntentAndLocalBranch(t *testing.T, pushURL, reposi
 	}, intentID: intentID}
 
 	var output bytes.Buffer
+	forge := migrationForgeGitHub
+	if strings.HasPrefix(repositoryURL, "origin.cursor.com/") {
+		forge = migrationForgeCursor
+	}
 	err := secretsAndVars(context.Background(), migrateOptions{
 		dir:                         repoDir,
 		stdout:                      &output,
 		token:                       "depot_api_token",
 		orgID:                       "org-id",
+		forge:                       forge,
 		secretMigrationBranchPrefix: branchPrefix,
 		secretMigrationNow:          time.Unix(1_700_000_000, 0),
 		secretMigrationRegistrar:    registrar,

--- a/pkg/cmd/ci/migrate_test.go
+++ b/pkg/cmd/ci/migrate_test.go
@@ -189,6 +189,12 @@ jobs:
 	if !strings.Contains(output, "variable(s)") {
 		t.Errorf("expected variables count in summary, got:\n%s", output)
 	}
+	if !strings.Contains(output, "depot ci migrate secrets-and-vars`") {
+		t.Errorf("expected the default GitHub follow-up command, got:\n%s", output)
+	}
+	if strings.Contains(output, "--forge=cursor") {
+		t.Errorf("default GitHub migration unexpectedly selected Cursor, got:\n%s", output)
+	}
 }
 
 func TestRunMigrate_DisabledJob(t *testing.T) {


### PR DESCRIPTION
## Summary

- add an inherited `--forge=github|cursor` migration flag while preserving GitHub as the default
- resolve Cursor Origin remotes and submit the selected local workflows through the authenticated v2 analysis API
- keep findings non-blocking, make access failures actionable, and avoid the GitHub Code Access preflight for Origin
- make secret migration remote selection respect the chosen forge

## Testing

- `go test ./...`
- `golangci-lint run --timeout 5m`
- `go mod verify`
- `go mod tidy -diff`
- `goreleaser build --clean --snapshot`
- `go build ./cmd/depot`
- `pnpm fmt:check`
- `pnpm type-check`

Linear: DEP-6081

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit d3e5b76ebeefa979975dfd7640d74a09890fb280. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->