### PR TITLE
feat(ci): render Cursor Origin compatibility diagnostics

### DIFF
--- a/pkg/cmd/ci/migrate.go
+++ b/pkg/cmd/ci/migrate.go
@@ -433,6 +433,7 @@ func workflowsWithContext(ctx context.Context, opts migrateOptions) error {
 
 	bold := lipgloss.NewStyle().Bold(true)
 	migrationRemote := "origin"
+	var originAnalysis *cursorOriginAnalysis
 
 	githubDir := filepath.Join(workDir, ".github")
 	workflowsDir := filepath.Join(githubDir, "workflows")
@@ -593,8 +594,7 @@ func workflowsWithContext(ctx context.Context, opts migrateOptions) error {
 		if err != nil {
 			return err
 		}
-		// DEP-6082 owns rendering the structured findings. Keep them non-blocking here.
-		_ = analysis.response
+		originAnalysis = analysis
 		migrationRemote = analysis.remote
 		fmt.Fprintf(out, "\nDetected repository: %s\n", bold.Render(analysis.repositoryURL))
 	}
@@ -695,6 +695,9 @@ func workflowsWithContext(ctx context.Context, opts migrateOptions) error {
 			status = fmt.Sprintf("%d change(s) applied", len(r.result.Changes))
 		}
 		fmt.Fprintf(out, "  %s — %s\n", r.filename, status)
+	}
+	if originAnalysis != nil && originAnalysis.response != nil {
+		renderCursorOriginDiagnostics(out, originAnalysis.response.Msg)
 	}
 
 	// Detect secrets and variables

--- a/pkg/cmd/ci/migrate_origin_analysis_test.go
+++ b/pkg/cmd/ci/migrate_origin_analysis_test.go
@@ -48,8 +48,15 @@ func TestCursorMigrationAnalyzesSelectedLocalWorkflowsBeforeMigrating(t *testing
 		Workflows: []*civ2.RepositoryWorkflowMigration{{
 			Path: ".github/workflows/ci.yml",
 			Analysis: &civ2.WorkflowAnalysis{Blockers: []*civ2.MigrationDiagnostic{{
-				Code:     "origin.unsupported",
-				Severity: civ2.MigrationDiagnosticSeverity_MIGRATION_DIAGNOSTIC_SEVERITY_FAILS,
+				Code:       "unsupported_github_releases",
+				Message:    "Cursor Origin does not provide GitHub release APIs.",
+				Action:     "softprops/action-gh-release",
+				Job:        "release",
+				Step:       "Publish release",
+				Mode:       "publish-release",
+				Capability: "github-releases",
+				Severity:   civ2.MigrationDiagnosticSeverity_MIGRATION_DIAGNOSTIC_SEVERITY_FAILS,
+				Workaround: "Publish releases from a GitHub workflow.",
 			}}},
 		}},
 	}}
@@ -92,6 +99,11 @@ func TestCursorMigrationAnalyzesSelectedLocalWorkflowsBeforeMigrating(t *testing
 	}
 	if _, err := os.Stat(filepath.Join(dir, ".depot", "workflows", "ci.yml")); err != nil {
 		t.Fatalf("diagnostic findings must not stop migration: %v", err)
+	}
+	if !strings.Contains(output.String(), "FAILS — .depot/workflows/ci.yml") ||
+		!strings.Contains(output.String(), "Action: softprops/action-gh-release") ||
+		!strings.Contains(output.String(), "Workaround: Publish releases from a GitHub workflow.") {
+		t.Fatalf("structured Origin finding was not rendered:\n%s", output.String())
 	}
 	if !strings.Contains(output.String(), "depot ci migrate secrets-and-vars --forge=cursor") {
 		t.Fatalf("Cursor follow-up command dropped the selected forge:\n%s", output.String())

--- a/pkg/cmd/ci/migrate_origin_diagnostics.go
+++ b/pkg/cmd/ci/migrate_origin_diagnostics.go
@@ -1,0 +1,123 @@
+package ci
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"unicode"
+
+	civ2 "github.com/depot/cli/pkg/proto/depot/ci/v2"
+)
+
+var internalLinearURL = regexp.MustCompile(`(?i)(?:https?://)?(?:www\.)?linear\.app(?:/[^\s]*)?`)
+
+type originDiagnosticFinding struct {
+	workflow   string
+	diagnostic *civ2.MigrationDiagnostic
+}
+
+func renderCursorOriginDiagnostics(out io.Writer, response *civ2.GetRepositoryMigrationAnalysisResponse) {
+	findings := cursorOriginDiagnosticFindings(response)
+	if len(findings) == 0 {
+		return
+	}
+
+	fmt.Fprintln(out, "\nCursor Origin compatibility findings:")
+	for _, finding := range findings {
+		diagnostic := finding.diagnostic
+		fmt.Fprintf(out, "\n  %s — %s\n", originDiagnosticSeverityLabel(diagnostic.GetSeverity()), originWorkflowDisplayPath(finding.workflow))
+		writeOriginDiagnosticField(out, "Job", diagnostic.GetJob())
+		writeOriginDiagnosticField(out, "Step", diagnostic.GetStep())
+		writeOriginDiagnosticField(out, "Action", diagnostic.GetAction())
+		writeOriginDiagnosticField(out, "Mode", diagnostic.GetMode())
+		writeOriginDiagnosticField(out, "Missing capability", diagnostic.GetCapability())
+		writeOriginDiagnosticField(out, "Explanation", diagnostic.GetMessage())
+		writeOriginDiagnosticField(out, "Workaround", diagnostic.GetWorkaround())
+	}
+}
+
+func cursorOriginDiagnosticFindings(response *civ2.GetRepositoryMigrationAnalysisResponse) []originDiagnosticFinding {
+	if response == nil {
+		return nil
+	}
+
+	var findings []originDiagnosticFinding
+	for _, workflow := range response.GetWorkflows() {
+		if workflow == nil || workflow.GetAnalysis() == nil {
+			continue
+		}
+		diagnostics := append(
+			append([]*civ2.MigrationDiagnostic(nil), workflow.GetAnalysis().GetBlockers()...),
+			workflow.GetAnalysis().GetCaveats()...,
+		)
+		for _, diagnostic := range diagnostics {
+			if !isCursorOriginCompatibilityDiagnostic(diagnostic) {
+				continue
+			}
+			findings = append(findings, originDiagnosticFinding{
+				workflow:   workflow.GetPath(),
+				diagnostic: diagnostic,
+			})
+		}
+	}
+	return findings
+}
+
+func isCursorOriginCompatibilityDiagnostic(diagnostic *civ2.MigrationDiagnostic) bool {
+	if diagnostic == nil || strings.TrimSpace(diagnostic.GetCapability()) == "" {
+		return false
+	}
+	switch diagnostic.GetSeverity() {
+	case civ2.MigrationDiagnosticSeverity_MIGRATION_DIAGNOSTIC_SEVERITY_FAILS,
+		civ2.MigrationDiagnosticSeverity_MIGRATION_DIAGNOSTIC_SEVERITY_SILENTLY_DEGRADES,
+		civ2.MigrationDiagnosticSeverity_MIGRATION_DIAGNOSTIC_SEVERITY_CONDITIONALLY_UNSUPPORTED:
+		return true
+	default:
+		return false
+	}
+}
+
+func originDiagnosticSeverityLabel(severity civ2.MigrationDiagnosticSeverity) string {
+	switch severity {
+	case civ2.MigrationDiagnosticSeverity_MIGRATION_DIAGNOSTIC_SEVERITY_FAILS:
+		return "FAILS"
+	case civ2.MigrationDiagnosticSeverity_MIGRATION_DIAGNOSTIC_SEVERITY_SILENTLY_DEGRADES:
+		return "SILENT DEGRADATION"
+	case civ2.MigrationDiagnosticSeverity_MIGRATION_DIAGNOSTIC_SEVERITY_CONDITIONALLY_UNSUPPORTED:
+		return "CONDITIONALLY UNSUPPORTED"
+	default:
+		return ""
+	}
+}
+
+func originWorkflowDisplayPath(source string) string {
+	const sourcePrefix = ".github/workflows/"
+	const destinationPrefix = ".depot/workflows/"
+
+	source = strings.TrimSpace(source)
+	name, found := strings.CutPrefix(source, sourcePrefix)
+	if found && name != "" && !strings.Contains(name, "/") && (strings.HasSuffix(name, ".yml") || strings.HasSuffix(name, ".yaml")) {
+		return fmt.Sprintf("%s%s (from %s)", destinationPrefix, safeOriginDiagnosticText(name), safeOriginDiagnosticText(source))
+	}
+	return safeOriginDiagnosticText(source)
+}
+
+func writeOriginDiagnosticField(out io.Writer, label, value string) {
+	value = safeOriginDiagnosticText(value)
+	if value == "" {
+		return
+	}
+	fmt.Fprintf(out, "    %s: %s\n", label, value)
+}
+
+func safeOriginDiagnosticText(value string) string {
+	value = internalLinearURL.ReplaceAllString(value, "[internal reference omitted]")
+	value = strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return ' '
+		}
+		return r
+	}, value)
+	return strings.Join(strings.Fields(value), " ")
+}

--- a/pkg/cmd/ci/migrate_origin_diagnostics.go
+++ b/pkg/cmd/ci/migrate_origin_diagnostics.go
@@ -3,6 +3,7 @@ package ci
 import (
 	"fmt"
 	"io"
+	"path"
 	"regexp"
 	"strings"
 	"unicode"
@@ -97,10 +98,18 @@ func originWorkflowDisplayPath(source string) string {
 
 	source = strings.TrimSpace(source)
 	name, found := strings.CutPrefix(source, sourcePrefix)
-	if found && name != "" && !strings.Contains(name, "/") && (strings.HasSuffix(name, ".yml") || strings.HasSuffix(name, ".yaml")) {
+	if found && isSafeOriginWorkflowRelativePath(name) {
 		return fmt.Sprintf("%s%s (from %s)", destinationPrefix, safeOriginDiagnosticText(name), safeOriginDiagnosticText(source))
 	}
 	return safeOriginDiagnosticText(source)
+}
+
+func isSafeOriginWorkflowRelativePath(name string) bool {
+	if name == "" || path.IsAbs(name) || strings.Contains(name, "\\") || path.Clean(name) != name || strings.HasPrefix(name, "../") {
+		return false
+	}
+	ext := path.Ext(name)
+	return ext == ".yml" || ext == ".yaml"
 }
 
 func writeOriginDiagnosticField(out io.Writer, label, value string) {

--- a/pkg/cmd/ci/migrate_origin_diagnostics_test.go
+++ b/pkg/cmd/ci/migrate_origin_diagnostics_test.go
@@ -1,0 +1,152 @@
+package ci
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	civ2 "github.com/depot/cli/pkg/proto/depot/ci/v2"
+)
+
+func TestRenderCursorOriginDiagnosticsShowsStructuredFindings(t *testing.T) {
+	response := &civ2.GetRepositoryMigrationAnalysisResponse{
+		Workflows: []*civ2.RepositoryWorkflowMigration{
+			{
+				Path: ".github/workflows/ci.yml",
+				Analysis: &civ2.WorkflowAnalysis{
+					Blockers: []*civ2.MigrationDiagnostic{
+						{
+							Message:    "Cursor Origin does not provide GitHub release APIs.",
+							Action:     "softprops/action-gh-release",
+							Job:        "release",
+							Step:       "Publish release",
+							Mode:       "publish-release",
+							Capability: "github-releases",
+							Severity:   civ2.MigrationDiagnosticSeverity_MIGRATION_DIAGNOSTIC_SEVERITY_FAILS,
+							Workaround: "Publish releases from a GitHub workflow.",
+						},
+					},
+					Caveats: []*civ2.MigrationDiagnostic{
+						{
+							Message:    "The action can report success without publishing results.",
+							Action:     "aquasecurity/trivy-action",
+							Job:        "scan",
+							Step:       "Upload dependency snapshot",
+							Mode:       "dependency-snapshot",
+							Capability: "dependency-snapshots",
+							Severity:   civ2.MigrationDiagnosticSeverity_MIGRATION_DIAGNOSTIC_SEVERITY_SILENTLY_DEGRADES,
+							Workaround: "Use another output format.",
+						},
+						{
+							Message:    "Runtime input determines whether this mode is supported.",
+							Action:     "github/codeql-action/analyze",
+							Job:        "codeql",
+							Step:       "Analyze",
+							Mode:       "upload-analysis",
+							Capability: "code-scanning-sarif",
+							Severity:   civ2.MigrationDiagnosticSeverity_MIGRATION_DIAGNOSTIC_SEVERITY_CONDITIONALLY_UNSUPPORTED,
+							Workaround: "Set upload to never.",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var output bytes.Buffer
+	renderCursorOriginDiagnostics(&output, response)
+	text := output.String()
+
+	for _, expected := range []string{
+		"Cursor Origin compatibility findings:",
+		"FAILS — .depot/workflows/ci.yml (from .github/workflows/ci.yml)",
+		"SILENT DEGRADATION — .depot/workflows/ci.yml (from .github/workflows/ci.yml)",
+		"CONDITIONALLY UNSUPPORTED — .depot/workflows/ci.yml (from .github/workflows/ci.yml)",
+		"Job: release",
+		"Step: Publish release",
+		"Action: softprops/action-gh-release",
+		"Mode: publish-release",
+		"Missing capability: github-releases",
+		"Explanation: Cursor Origin does not provide GitHub release APIs.",
+		"Workaround: Publish releases from a GitHub workflow.",
+		"Job: scan",
+		"Step: Upload dependency snapshot",
+		"Action: aquasecurity/trivy-action",
+		"Mode: dependency-snapshot",
+		"Missing capability: dependency-snapshots",
+		"Workaround: Use another output format.",
+		"Job: codeql",
+		"Step: Analyze",
+		"Action: github/codeql-action/analyze",
+		"Mode: upload-analysis",
+		"Missing capability: code-scanning-sarif",
+		"Workaround: Set upload to never.",
+	} {
+		if !strings.Contains(text, expected) {
+			t.Errorf("output does not contain %q:\n%s", expected, text)
+		}
+	}
+}
+
+func TestRenderCursorOriginDiagnosticsOmitsGeneralAndAbsentFields(t *testing.T) {
+	response := &civ2.GetRepositoryMigrationAnalysisResponse{
+		Workflows: []*civ2.RepositoryWorkflowMigration{
+			{
+				Path: ".github/workflows/ci.yml",
+				Analysis: &civ2.WorkflowAnalysis{
+					Blockers: []*civ2.MigrationDiagnostic{
+						{
+							Code:     "workflow_parse_failed",
+							Message:  "This general readiness finding must stay quiet.",
+							Severity: civ2.MigrationDiagnosticSeverity_MIGRATION_DIAGNOSTIC_SEVERITY_FAILS,
+						},
+						{
+							Code:       "internal_tracking_code",
+							Message:    "See https://linear.app/depot/issue/DEP-1234\nfor internal details.\x1b[31m",
+							Capability: "github-graphql",
+							Severity:   civ2.MigrationDiagnosticSeverity_MIGRATION_DIAGNOSTIC_SEVERITY_FAILS,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var output bytes.Buffer
+	renderCursorOriginDiagnostics(&output, response)
+	text := output.String()
+
+	if strings.Contains(text, "general readiness") {
+		t.Fatalf("general migration diagnostic was rendered:\n%s", text)
+	}
+	for _, forbidden := range []string{"internal_tracking_code", "linear.app", "DEP-1234", "\x1b", "Job:", "Step:", "Action:", "Mode:", "Workaround:"} {
+		if strings.Contains(text, forbidden) {
+			t.Errorf("output contains %q:\n%s", forbidden, text)
+		}
+	}
+	if !strings.Contains(text, "Explanation: See [internal reference omitted] for internal details. [31m") {
+		t.Errorf("sanitized explanation is missing:\n%s", text)
+	}
+}
+
+func TestRenderCursorOriginDiagnosticsKeepsCompatibleWorkflowsQuiet(t *testing.T) {
+	responses := []*civ2.GetRepositoryMigrationAnalysisResponse{
+		nil,
+		{},
+		{Workflows: []*civ2.RepositoryWorkflowMigration{{Path: ".github/workflows/ci.yml"}}},
+		{
+			Workflows: []*civ2.RepositoryWorkflowMigration{{
+				Path:     ".github/workflows/ci.yml",
+				Analysis: &civ2.WorkflowAnalysis{},
+			}},
+		},
+	}
+
+	for index, response := range responses {
+		var output bytes.Buffer
+		renderCursorOriginDiagnostics(&output, response)
+		if output.Len() != 0 {
+			t.Errorf("response %d unexpectedly produced output: %q", index, output.String())
+		}
+	}
+}

--- a/pkg/cmd/ci/migrate_origin_diagnostics_test.go
+++ b/pkg/cmd/ci/migrate_origin_diagnostics_test.go
@@ -129,6 +129,45 @@ func TestRenderCursorOriginDiagnosticsOmitsGeneralAndAbsentFields(t *testing.T) 
 	}
 }
 
+func TestRenderCursorOriginDiagnosticsMapsSafeNestedWorkflowDestinations(t *testing.T) {
+	diagnostic := func() *civ2.MigrationDiagnostic {
+		return &civ2.MigrationDiagnostic{
+			Capability: "github-releases",
+			Severity:   civ2.MigrationDiagnosticSeverity_MIGRATION_DIAGNOSTIC_SEVERITY_FAILS,
+		}
+	}
+	response := &civ2.GetRepositoryMigrationAnalysisResponse{
+		Workflows: []*civ2.RepositoryWorkflowMigration{
+			{
+				Path: ".github/workflows/release/publish.yml",
+				Analysis: &civ2.WorkflowAnalysis{
+					Blockers: []*civ2.MigrationDiagnostic{diagnostic()},
+				},
+			},
+			{
+				Path: ".github/workflows/../outside.yml",
+				Analysis: &civ2.WorkflowAnalysis{
+					Blockers: []*civ2.MigrationDiagnostic{diagnostic()},
+				},
+			},
+		},
+	}
+
+	var output bytes.Buffer
+	renderCursorOriginDiagnostics(&output, response)
+	text := output.String()
+
+	if !strings.Contains(text, "FAILS — .depot/workflows/release/publish.yml (from .github/workflows/release/publish.yml)") {
+		t.Errorf("nested workflow destination was not mapped:\n%s", text)
+	}
+	if !strings.Contains(text, "FAILS — .github/workflows/../outside.yml") {
+		t.Errorf("unsafe workflow path was not left as its source path:\n%s", text)
+	}
+	if strings.Contains(text, ".depot/workflows/../outside.yml") {
+		t.Errorf("unsafe workflow path was mapped into the destination directory:\n%s", text)
+	}
+}
+
 func TestRenderCursorOriginDiagnosticsKeepsCompatibleWorkflowsQuiet(t *testing.T) {
 	responses := []*civ2.GetRepositoryMigrationAnalysisResponse{
 		nil,


### PR DESCRIPTION
## Summary

- render structured Cursor Origin compatibility findings after workflow migration
- distinguish failures, silent degradation, and conditional support while showing workflow, job, step, action, mode, capability, explanation, and workaround context
- keep findings non-blocking, omit general readiness diagnostics and empty fields, and suppress internal metadata or Linear URLs

## Testing

- go mod verify and go mod download
- go formatting and go mod tidy drift checks
- golangci-lint run --timeout 5m
- go test ./...
- pnpm fmt:check and pnpm type-check
- goreleaser build --clean --snapshot
- DEPOT_CLI_VERSION=v0.0.0-dev make npm

Linear: DEP-6082

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to non-blocking CLI output during Cursor forge migration; no auth, data persistence, or migration control-flow changes beyond printing diagnostics.
> 
> **Overview**
> **Cursor Origin workflow migration** now prints structured compatibility findings after the per-workflow migration summary instead of discarding the analysis response.
> 
> The new renderer surfaces **blockers and caveats** that include a **missing capability**, labeled as **FAILS**, **SILENT DEGRADATION**, or **CONDITIONALLY UNSUPPORTED**, with optional job, step, action, mode, explanation, and workaround lines. Workflow paths are shown as **`.depot/workflows/… (from .github/workflows/…)`** when applicable. General readiness diagnostics (no capability) stay hidden, empty fields are omitted, and message text is sanitized (e.g. Linear URLs and control characters). **Migration still completes** when findings are present.
> 
> Tests cover the renderer and assert the end-to-end Cursor migrate command emits the structured output without blocking writes to **`.depot/workflows/`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca6f1929176727982217ee0058b1b897206da1ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->