### PR TITLE
test(ci): cover forge-aware migration behavior

### DIFF
--- a/pkg/cmd/ci/migrate.go
+++ b/pkg/cmd/ci/migrate.go
@@ -83,17 +83,20 @@ type migrateOptions struct {
 }
 
 func NewCmdMigrate() *cobra.Command {
-	opts := migrateOptions{forge: migrationForgeGitHub}
+	return newCmdMigrate(migrateOptions{})
+}
+
+func newCmdMigrate(opts migrateOptions) *cobra.Command {
+	if opts.forge == "" {
+		opts.forge = migrationForgeGitHub
+	}
 
 	cmd := &cobra.Command{
 		Use:   "migrate",
 		Short: "Migrate GitHub Actions workflows to Depot CI",
 		Long:  "Optimistically migrates GitHub Actions workflows into .depot/workflows/ with inline corrections and comments.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			runOpts := opts
-			runOpts.dir = "."
-			runOpts.stdout = os.Stdout
-			return runMigrate(cmd.Context(), runOpts)
+			return runMigrate(cmd.Context(), migrateCommandOptions(cmd, opts))
 		},
 	}
 
@@ -112,16 +115,23 @@ func NewCmdMigrate() *cobra.Command {
 	return cmd
 }
 
+func migrateCommandOptions(cmd *cobra.Command, opts migrateOptions) migrateOptions {
+	if strings.TrimSpace(opts.dir) == "" {
+		opts.dir = "."
+	}
+	if opts.stdout == nil {
+		opts.stdout = cmd.OutOrStdout()
+	}
+	return opts
+}
+
 func newCmdSecretsAndVars(parentOpts *migrateOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "secrets-and-vars",
 		Short: "Import GitHub Actions secrets and variables into Depot CI",
 		Long:  "Creates a one-shot GitHub Actions workflow that reads secrets and variables from the source repo and imports them into Depot CI via the depot CLI.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts := *parentOpts
-			opts.dir = "."
-			opts.stdout = os.Stdout
-			return secretsAndVars(cmd.Context(), opts)
+			return secretsAndVars(cmd.Context(), migrateCommandOptions(cmd, *parentOpts))
 		},
 	}
 
@@ -246,10 +256,7 @@ func newCmdWorkflows(parentOpts *migrateOptions) *cobra.Command {
 		Short: "Migrate and transform GitHub Actions workflows to .depot/workflows/",
 		Long:  "Copies .github/workflows/ into .depot/workflows/, applying Depot CI transformations and compatibility fixes.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts := *parentOpts
-			opts.dir = "."
-			opts.stdout = os.Stdout
-			return workflowsWithContext(cmd.Context(), opts)
+			return workflowsWithContext(cmd.Context(), migrateCommandOptions(cmd, *parentOpts))
 		},
 	}
 
@@ -264,9 +271,7 @@ func newCmdPreflight(parentOpts *migrateOptions) *cobra.Command {
 		Short: "Check authentication and repository access for migration",
 		Long:  "Validates authentication, detects a repository for the selected forge, and checks the access required to migrate it. GitHub checks the Depot Code Access app; Cursor checks that the Origin repository is available to the Depot organization.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts := *parentOpts
-			opts.dir = "."
-			opts.stdout = os.Stdout
+			opts := migrateCommandOptions(cmd, *parentOpts)
 			_, err := preflight(cmd.Context(), opts)
 			return err
 		},

--- a/pkg/cmd/ci/migrate_origin_analysis_test.go
+++ b/pkg/cmd/ci/migrate_origin_analysis_test.go
@@ -4,13 +4,19 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"connectrpc.com/connect"
+	civ1 "github.com/depot/cli/pkg/proto/depot/ci/v1"
+	"github.com/depot/cli/pkg/proto/depot/ci/v1/civ1connect"
 	civ2 "github.com/depot/cli/pkg/proto/depot/ci/v2"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 )
 
 type recordingRepositoryAnalysisClient struct {
@@ -18,6 +24,33 @@ type recordingRepositoryAnalysisClient struct {
 	response *civ2.GetRepositoryMigrationAnalysisResponse
 	err      error
 	calls    int
+}
+
+type recordingGitHubMigrationService struct {
+	civ1connect.UnimplementedMigrationServiceHandler
+	requests []*connect.Request[civ1.GetInstallationRequest]
+}
+
+func (s *recordingGitHubMigrationService) GetInstallation(
+	_ context.Context,
+	request *connect.Request[civ1.GetInstallationRequest],
+) (*connect.Response[civ1.GetInstallationResponse], error) {
+	s.requests = append(s.requests, request)
+	return connect.NewResponse(&civ1.GetInstallationResponse{
+		Installations: []*civ1.Installation{{Owner: "acme", RepoAccessible: true}},
+	}), nil
+}
+
+func useGitHubMigrationTestServer(t *testing.T) *recordingGitHubMigrationService {
+	t.Helper()
+	service := &recordingGitHubMigrationService{}
+	path, handler := civ1connect.NewMigrationServiceHandler(service)
+	mux := http.NewServeMux()
+	mux.Handle(path, handler)
+	server := httptest.NewServer(h2c.NewHandler(mux, &http2.Server{}))
+	t.Cleanup(server.Close)
+	t.Setenv("DEPOT_API_URL", server.URL)
+	return service
 }
 
 func (c *recordingRepositoryAnalysisClient) GetRepositoryAnalysis(
@@ -32,7 +65,50 @@ func (c *recordingRepositoryAnalysisClient) GetRepositoryAnalysis(
 	return connect.NewResponse(c.response), nil
 }
 
-func TestCursorMigrationAnalyzesSelectedLocalWorkflowsBeforeMigrating(t *testing.T) {
+func representativeOriginAnalysisResponse() *civ2.GetRepositoryMigrationAnalysisResponse {
+	return &civ2.GetRepositoryMigrationAnalysisResponse{
+		Workflows: []*civ2.RepositoryWorkflowMigration{{
+			Path: ".github/workflows/ci.yml",
+			Analysis: &civ2.WorkflowAnalysis{
+				Blockers: []*civ2.MigrationDiagnostic{{
+					Code:       "internal_tracking_DEP-1234",
+					Message:    "Cursor Origin does not provide GitHub release APIs.",
+					Action:     "softprops/action-gh-release",
+					Job:        "release",
+					Step:       "Publish release",
+					Mode:       "publish-release",
+					Capability: "github-releases",
+					Severity:   civ2.MigrationDiagnosticSeverity_MIGRATION_DIAGNOSTIC_SEVERITY_FAILS,
+					Workaround: "Publish releases from a GitHub workflow.",
+				}},
+				Caveats: []*civ2.MigrationDiagnostic{
+					{
+						Message:    "Dependency submission can appear successful without publishing.",
+						Action:     "aquasecurity/trivy-action",
+						Job:        "scan",
+						Step:       "Publish dependency snapshot",
+						Mode:       "dependency-snapshot",
+						Capability: "dependency-snapshots",
+						Severity:   civ2.MigrationDiagnosticSeverity_MIGRATION_DIAGNOSTIC_SEVERITY_SILENTLY_DEGRADES,
+						Workaround: "Use another output format.",
+					},
+					{
+						Message:    "Runtime input determines whether SARIF upload is attempted.",
+						Action:     "github/codeql-action/analyze",
+						Job:        "codeql",
+						Step:       "Analyze",
+						Mode:       "upload-analysis",
+						Capability: "code-scanning-sarif",
+						Severity:   civ2.MigrationDiagnosticSeverity_MIGRATION_DIAGNOSTIC_SEVERITY_CONDITIONALLY_UNSUPPORTED,
+						Workaround: "Set upload to never.",
+					},
+				},
+			},
+		}},
+	}
+}
+
+func TestMigrateCommandCursorAnalyzesAndRendersSelectedWorkflows(t *testing.T) {
 	dir, workflow := newMigrationTestRepository(t)
 	runSecretMigrationTestCommand(t, dir, "git", "add", ".")
 	runSecretMigrationTestCommand(t, dir, "git", "-c", "user.name=Depot Test", "-c", "user.email=test@depot.dev", "commit", "-m", "base")
@@ -44,33 +120,15 @@ func TestCursorMigrationAnalyzesSelectedLocalWorkflowsBeforeMigrating(t *testing
 	runSecretMigrationTestCommand(t, dir, "git", "update-ref", "refs/remotes/cursor/trunk", sha)
 	runSecretMigrationTestCommand(t, dir, "git", "symbolic-ref", "refs/remotes/cursor/HEAD", "refs/remotes/cursor/trunk")
 
-	client := &recordingRepositoryAnalysisClient{response: &civ2.GetRepositoryMigrationAnalysisResponse{
-		Workflows: []*civ2.RepositoryWorkflowMigration{{
-			Path: ".github/workflows/ci.yml",
-			Analysis: &civ2.WorkflowAnalysis{Blockers: []*civ2.MigrationDiagnostic{{
-				Code:       "unsupported_github_releases",
-				Message:    "Cursor Origin does not provide GitHub release APIs.",
-				Action:     "softprops/action-gh-release",
-				Job:        "release",
-				Step:       "Publish release",
-				Mode:       "publish-release",
-				Capability: "github-releases",
-				Severity:   civ2.MigrationDiagnosticSeverity_MIGRATION_DIAGNOSTIC_SEVERITY_FAILS,
-				Workaround: "Publish releases from a GitHub workflow.",
-			}}},
-		}},
-	}}
+	client := &recordingRepositoryAnalysisClient{response: representativeOriginAnalysisResponse()}
 	var output bytes.Buffer
-	err := workflowsWithContext(context.Background(), migrateOptions{
+	cmd := newCmdMigrate(migrateOptions{
 		dir:                      dir,
-		stdout:                   &output,
-		yes:                      true,
-		forge:                    migrationForgeCursor,
-		token:                    "depot_api_token",
-		orgID:                    "org-id",
 		repositoryAnalysisClient: client,
 	})
-	if err != nil {
+	cmd.SetOut(&output)
+	cmd.SetArgs([]string{"--yes", "--forge=cursor", "--token=depot_api_token", "--org=org-id"})
+	if err := cmd.ExecuteContext(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -100,10 +158,38 @@ func TestCursorMigrationAnalyzesSelectedLocalWorkflowsBeforeMigrating(t *testing
 	if _, err := os.Stat(filepath.Join(dir, ".depot", "workflows", "ci.yml")); err != nil {
 		t.Fatalf("diagnostic findings must not stop migration: %v", err)
 	}
-	if !strings.Contains(output.String(), "FAILS — .depot/workflows/ci.yml") ||
-		!strings.Contains(output.String(), "Action: softprops/action-gh-release") ||
-		!strings.Contains(output.String(), "Workaround: Publish releases from a GitHub workflow.") {
-		t.Fatalf("structured Origin finding was not rendered:\n%s", output.String())
+	for _, finding := range []string{
+		`  FAILS — .depot/workflows/ci.yml (from .github/workflows/ci.yml)
+    Job: release
+    Step: Publish release
+    Action: softprops/action-gh-release
+    Mode: publish-release
+    Missing capability: github-releases
+    Explanation: Cursor Origin does not provide GitHub release APIs.
+    Workaround: Publish releases from a GitHub workflow.`,
+		`  SILENT DEGRADATION — .depot/workflows/ci.yml (from .github/workflows/ci.yml)
+    Job: scan
+    Step: Publish dependency snapshot
+    Action: aquasecurity/trivy-action
+    Mode: dependency-snapshot
+    Missing capability: dependency-snapshots
+    Explanation: Dependency submission can appear successful without publishing.
+    Workaround: Use another output format.`,
+		`  CONDITIONALLY UNSUPPORTED — .depot/workflows/ci.yml (from .github/workflows/ci.yml)
+    Job: codeql
+    Step: Analyze
+    Action: github/codeql-action/analyze
+    Mode: upload-analysis
+    Missing capability: code-scanning-sarif
+    Explanation: Runtime input determines whether SARIF upload is attempted.
+    Workaround: Set upload to never.`,
+	} {
+		if !strings.Contains(output.String(), finding) {
+			t.Errorf("command output does not contain finding:\n%s\n\nfull output:\n%s", finding, output.String())
+		}
+	}
+	if strings.Contains(output.String(), "internal_tracking_DEP-1234") {
+		t.Fatalf("command output exposed machine-only diagnostic metadata:\n%s", output.String())
 	}
 	if !strings.Contains(output.String(), "depot ci migrate secrets-and-vars --forge=cursor") {
 		t.Fatalf("Cursor follow-up command dropped the selected forge:\n%s", output.String())
@@ -116,18 +202,70 @@ func TestCursorMigrationAnalyzesSelectedLocalWorkflowsBeforeMigrating(t *testing
 	}
 }
 
-func TestGitHubMigrationDoesNotRequestOriginAnalysis(t *testing.T) {
+func TestMigrateCommandGitHubModesDoNotRequestOriginAnalysis(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "default", args: []string{"--yes", "--token=depot_api_token", "--org=org-id"}},
+		{name: "explicit", args: []string{"--yes", "--forge=github", "--token=depot_api_token", "--org=org-id"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir, _ := newMigrationTestRepository(t)
+			runSecretMigrationTestCommand(t, dir, "git", "remote", "add", "origin", "https://github.com/acme/widgets.git")
+			githubService := useGitHubMigrationTestServer(t)
+			client := &recordingRepositoryAnalysisClient{err: errors.New("must not be called")}
+			var output bytes.Buffer
+			cmd := newCmdMigrate(migrateOptions{
+				dir:                      dir,
+				repositoryAnalysisClient: client,
+			})
+			cmd.SetOut(&output)
+			cmd.SetArgs(test.args)
+
+			if err := cmd.ExecuteContext(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+			if client.calls != 0 {
+				t.Fatalf("Origin analysis calls = %d, want 0", client.calls)
+			}
+			if len(githubService.requests) != 1 || githubService.requests[0].Msg.GetRepo() != "acme/widgets" {
+				t.Fatalf("unexpected GitHub preflight requests: %#v", githubService.requests)
+			}
+			if _, err := os.Stat(filepath.Join(dir, ".depot", "workflows", "ci.yml")); err != nil {
+				t.Fatalf("GitHub workflow was not migrated: %v", err)
+			}
+			if !strings.Contains(output.String(), "Migrated 1 workflow(s)") || strings.Contains(output.String(), "Cursor Origin") {
+				t.Fatalf("unexpected GitHub migration output:\n%s", output.String())
+			}
+		})
+	}
+}
+
+func TestMigrateCommandCompatibleCursorWorkflowStaysQuiet(t *testing.T) {
 	dir, _ := newMigrationTestRepository(t)
-	client := &recordingRepositoryAnalysisClient{err: errors.New("must not be called")}
-	if err := workflows(migrateOptions{
+	runSecretMigrationTestCommand(t, dir, "git", "remote", "add", "origin", "https://origin.cursor.com/git/acme/widgets")
+	client := &recordingRepositoryAnalysisClient{response: &civ2.GetRepositoryMigrationAnalysisResponse{}}
+	var output bytes.Buffer
+	cmd := newCmdMigrate(migrateOptions{
 		dir:                      dir,
-		yes:                      true,
 		repositoryAnalysisClient: client,
-	}); err != nil {
+	})
+	cmd.SetOut(&output)
+	cmd.SetArgs([]string{"--yes", "--forge=cursor", "--token=depot_org_token"})
+
+	if err := cmd.ExecuteContext(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	if client.calls != 0 {
-		t.Fatalf("Origin analysis calls = %d, want 0", client.calls)
+	if client.calls != 1 {
+		t.Fatalf("Origin analysis calls = %d, want 1", client.calls)
+	}
+	if strings.Contains(output.String(), "Cursor Origin compatibility findings:") {
+		t.Fatalf("compatible workflow produced compatibility output:\n%s", output.String())
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".depot", "workflows", "ci.yml")); err != nil {
+		t.Fatalf("compatible Cursor workflow was not migrated: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add a command-construction seam that preserves production defaults while allowing full Cobra execution in tests
- cover omitted and explicit GitHub modes through a local Connect preflight server and prove they never request Origin analysis
- cover Cursor request mapping, all three diagnostic severities, compatible-mode silence, metadata suppression, and non-blocking workflow generation

## Testing

- go mod verify and go mod download
- go formatting and go mod tidy drift checks
- golangci-lint run --timeout 5m
- go test ./...
- pnpm fmt:check and pnpm type-check
- goreleaser build --clean --snapshot
- DEPOT_CLI_VERSION=v0.0.0-dev make npm

Linear: DEP-6083

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 597160c52f83c43118ebc33ba18f110063b1b185. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->