### PR TITLE
fix(ci): rename migrate forge option to origin

### DIFF
--- a/pkg/cmd/ci/migrate.go
+++ b/pkg/cmd/ci/migrate.go
@@ -31,7 +31,7 @@ type migrationForge string
 
 const (
 	migrationForgeGitHub migrationForge = "github"
-	migrationForgeCursor migrationForge = "cursor"
+	migrationForgeOrigin migrationForge = "origin"
 )
 
 func (f *migrationForge) String() string {
@@ -43,11 +43,11 @@ func (f *migrationForge) String() string {
 
 func (f *migrationForge) Set(value string) error {
 	switch migrationForge(value) {
-	case migrationForgeGitHub, migrationForgeCursor:
+	case migrationForgeGitHub, migrationForgeOrigin:
 		*f = migrationForge(value)
 		return nil
 	default:
-		return fmt.Errorf("must be one of github, cursor")
+		return fmt.Errorf("must be one of github, origin")
 	}
 }
 
@@ -103,7 +103,7 @@ func newCmdMigrate(opts migrateOptions) *cobra.Command {
 	pf := cmd.PersistentFlags()
 	pf.StringVar(&opts.token, "token", "", "Depot API token")
 	pf.StringVar(&opts.orgID, "org", "", "Depot organization ID")
-	pf.Var(&opts.forge, "forge", "Source-code forge to migrate from (github or cursor)")
+	pf.Var(&opts.forge, "forge", "Source-code forge to migrate from (github or origin)")
 	pf.BoolVarP(&opts.yes, "yes", "y", false, "Run in non-interactive mode")
 
 	cmd.Flags().BoolVar(&opts.overwrite, "overwrite", false, "Overwrite existing .depot/ directory")
@@ -317,7 +317,7 @@ type preflightResult struct {
 // Returns nil result (and nil error) when the check fails with a user-facing
 // message that has already been printed.
 func preflight(ctx context.Context, opts migrateOptions) (*preflightResult, error) {
-	if effectiveMigrationForge(opts.forge) == migrationForgeCursor {
+	if effectiveMigrationForge(opts.forge) == migrationForgeOrigin {
 		return cursorPreflight(ctx, opts)
 	}
 	return githubPreflight(ctx, opts)
@@ -403,7 +403,7 @@ func githubPreflight(ctx context.Context, opts migrateOptions) (*preflightResult
 }
 
 func runMigrate(ctx context.Context, opts migrateOptions) error {
-	if effectiveMigrationForge(opts.forge) == migrationForgeCursor {
+	if effectiveMigrationForge(opts.forge) == migrationForgeOrigin {
 		return workflowsWithContext(ctx, opts)
 	}
 
@@ -594,7 +594,7 @@ func workflowsWithContext(ctx context.Context, opts migrateOptions) error {
 		return fmt.Errorf("failed to inspect .depot directory: %w", err)
 	}
 
-	if effectiveMigrationForge(opts.forge) == migrationForgeCursor {
+	if effectiveMigrationForge(opts.forge) == migrationForgeOrigin {
 		analysis, err := analyzeCursorOriginWorkflows(ctx, opts, selectedWorkflows)
 		if err != nil {
 			return err
@@ -724,9 +724,9 @@ func workflowsWithContext(ctx context.Context, opts migrateOptions) error {
 	if len(detectedSecrets) > 0 || len(detectedVariables) > 0 {
 		secretsSource := "GitHub"
 		secretMigrationCommand := "depot ci migrate secrets-and-vars"
-		if effectiveMigrationForge(opts.forge) == migrationForgeCursor {
+		if effectiveMigrationForge(opts.forge) == migrationForgeOrigin {
 			secretsSource = "the source repository"
-			secretMigrationCommand += " --forge=cursor"
+			secretMigrationCommand += " --forge=origin"
 		}
 		fmt.Fprintf(out, "  1. Your workflows depend on %d secret(s) and %d variable(s) which need to be imported from %s:\n", len(detectedSecrets), len(detectedVariables), secretsSource)
 		fmt.Fprintf(out, "     - Import them automatically with `%s`\n", secretMigrationCommand)

--- a/pkg/cmd/ci/migrate_origin_analysis.go
+++ b/pkg/cmd/ci/migrate_origin_analysis.go
@@ -52,7 +52,7 @@ func analyzeCursorOriginWorkflows(
 	if strings.TrimSpace(workDir) == "" {
 		workDir = "."
 	}
-	remote, repositoryURL, err := detectMigrationRemote(ctx, workDir, migrationForgeCursor, false)
+	remote, repositoryURL, err := detectMigrationRemote(ctx, workDir, migrationForgeOrigin, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/ci/migrate_origin_analysis_test.go
+++ b/pkg/cmd/ci/migrate_origin_analysis_test.go
@@ -127,7 +127,7 @@ func TestMigrateCommandCursorAnalyzesAndRendersSelectedWorkflows(t *testing.T) {
 		repositoryAnalysisClient: client,
 	})
 	cmd.SetOut(&output)
-	cmd.SetArgs([]string{"--yes", "--forge=cursor", "--token=depot_api_token", "--org=org-id"})
+	cmd.SetArgs([]string{"--yes", "--forge=origin", "--token=depot_api_token", "--org=org-id"})
 	if err := cmd.ExecuteContext(context.Background()); err != nil {
 		t.Fatal(err)
 	}
@@ -191,7 +191,7 @@ func TestMigrateCommandCursorAnalyzesAndRendersSelectedWorkflows(t *testing.T) {
 	if strings.Contains(output.String(), "internal_tracking_DEP-1234") {
 		t.Fatalf("command output exposed machine-only diagnostic metadata:\n%s", output.String())
 	}
-	if !strings.Contains(output.String(), "depot ci migrate secrets-and-vars --forge=cursor") {
+	if !strings.Contains(output.String(), "depot ci migrate secrets-and-vars --forge=origin") {
 		t.Fatalf("Cursor follow-up command dropped the selected forge:\n%s", output.String())
 	}
 	if !strings.Contains(output.String(), "pushing and merging them into trunk") {
@@ -253,7 +253,7 @@ func TestMigrateCommandCompatibleCursorWorkflowStaysQuiet(t *testing.T) {
 		repositoryAnalysisClient: client,
 	})
 	cmd.SetOut(&output)
-	cmd.SetArgs([]string{"--yes", "--forge=cursor", "--token=depot_org_token"})
+	cmd.SetArgs([]string{"--yes", "--forge=origin", "--token=depot_org_token"})
 
 	if err := cmd.ExecuteContext(context.Background()); err != nil {
 		t.Fatal(err)
@@ -277,7 +277,7 @@ func TestCursorMigrationReportsAnalysisFailureBeforeWritingFiles(t *testing.T) {
 	err := workflowsWithContext(context.Background(), migrateOptions{
 		dir:                      dir,
 		yes:                      true,
-		forge:                    migrationForgeCursor,
+		forge:                    migrationForgeOrigin,
 		token:                    "depot_api_token",
 		orgID:                    "org-id",
 		repositoryAnalysisClient: client,
@@ -299,7 +299,7 @@ func TestCursorPreflightUsesOriginAnalysisInsteadOfGitHubCodeAccess(t *testing.T
 	result, err := preflight(context.Background(), migrateOptions{
 		dir:                      dir,
 		stdout:                   &output,
-		forge:                    migrationForgeCursor,
+		forge:                    migrationForgeOrigin,
 		token:                    "depot_org_token",
 		repositoryAnalysisClient: client,
 	})
@@ -328,7 +328,7 @@ func TestCursorMigrationReportsMissingOriginRemote(t *testing.T) {
 	err := workflowsWithContext(context.Background(), migrateOptions{
 		dir:                      dir,
 		yes:                      true,
-		forge:                    migrationForgeCursor,
+		forge:                    migrationForgeOrigin,
 		token:                    "depot_org_token",
 		repositoryAnalysisClient: client,
 	})
@@ -359,7 +359,7 @@ func TestCursorMigrationDoesNotUploadWorkflowOutsideRepository(t *testing.T) {
 	err := workflowsWithContext(context.Background(), migrateOptions{
 		dir:                      dir,
 		yes:                      true,
-		forge:                    migrationForgeCursor,
+		forge:                    migrationForgeOrigin,
 		token:                    "depot_api_token",
 		orgID:                    "org-id",
 		repositoryAnalysisClient: client,

--- a/pkg/cmd/ci/migrate_secret_intent.go
+++ b/pkg/cmd/ci/migrate_secret_intent.go
@@ -247,7 +247,7 @@ func detectMigrationRemote(ctx context.Context, dir string, forge migrationForge
 	}
 	forgeName := "GitHub"
 	host := "github.com/owner/repo"
-	if forge == migrationForgeCursor {
+	if forge == migrationForgeOrigin {
 		forgeName = "Cursor Origin"
 		host = "origin.cursor.com/namespace/repo"
 	}
@@ -260,7 +260,7 @@ func detectMigrationRemote(ctx context.Context, dir string, forge migrationForge
 
 func repositoryURLMatchesForge(repositoryURL string, forge migrationForge) bool {
 	switch forge {
-	case migrationForgeCursor:
+	case migrationForgeOrigin:
 		return strings.HasPrefix(repositoryURL, "origin.cursor.com/")
 	default:
 		return strings.HasPrefix(repositoryURL, "github.com/")

--- a/pkg/cmd/ci/migrate_secret_intent_test.go
+++ b/pkg/cmd/ci/migrate_secret_intent_test.go
@@ -228,7 +228,7 @@ func testSecretsAndVarsCreatesIntentAndLocalBranch(t *testing.T, pushURL, reposi
 	var output bytes.Buffer
 	forge := migrationForgeGitHub
 	if strings.HasPrefix(repositoryURL, "origin.cursor.com/") {
-		forge = migrationForgeCursor
+		forge = migrationForgeOrigin
 	}
 	err := secretsAndVars(context.Background(), migrateOptions{
 		dir:                         repoDir,

--- a/pkg/cmd/ci/migrate_test.go
+++ b/pkg/cmd/ci/migrate_test.go
@@ -192,7 +192,7 @@ jobs:
 	if !strings.Contains(output, "depot ci migrate secrets-and-vars`") {
 		t.Errorf("expected the default GitHub follow-up command, got:\n%s", output)
 	}
-	if strings.Contains(output, "--forge=cursor") {
+	if strings.Contains(output, "--forge=origin") {
 		t.Errorf("default GitHub migration unexpectedly selected Cursor, got:\n%s", output)
 	}
 }


### PR DESCRIPTION
## Summary

- rename the depot ci migrate --forge value from cursor to origin
- update flag help, validation text, and the emitted secrets migration follow-up command
- update existing tests to use the renamed value; no compatibility alias is retained

## Testing

- go test ./...
- go mod verify
- go build ./cmd/depot
- go run ./cmd/depot ci migrate --help

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI flag rename only; behavior is unchanged aside from a breaking value change with no compatibility alias.
> 
> **Overview**
> Renames the `depot ci migrate --forge` value from `cursor` to `origin`. Flag help, validation, and the printed `secrets-and-vars` follow-up command now use `--forge=origin`.
> 
> Internal comparisons and tests follow the same rename. There is **no alias** for the old `cursor` value, so existing scripts that pass `--forge=cursor` will fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc93c2180a777b353aca69c38893eb276ab4fd2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->