### PR TITLE
build(deps): update GitHub Actions and migrate pnpm setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,14 @@ jobs:
           check-latest: true
           cache: true
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
+      - name: Install pnpm and Node
+        uses: pnpm/setup@v1
         with:
           version: 11.22.0
-
-      - name: Install Node 24
-        uses: actions/setup-node@v7
-        with:
-          node-version: "24"
-          cache: pnpm
+          runtime: node@24
+          cache: true
           cache-dependency-path: npm/pnpm-lock.yaml
+          install: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
@@ -76,17 +73,14 @@ jobs:
           check-latest: true
           cache: true
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
+      - name: Install pnpm and Node
+        uses: pnpm/setup@v1
         with:
           version: 11.22.0
-
-      - name: Install Node 24
-        uses: actions/setup-node@v7
-        with:
-          node-version: "24"
-          cache: pnpm
+          runtime: node@24
+          cache: true
           cache-dependency-path: npm/pnpm-lock.yaml
+          install: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,15 @@ jobs:
     runs-on: depot-ubuntu-latest-16
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: "1.25.14"
           check-latest: true
           cache: true
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
         with:
           version: 11.22.0
 
@@ -69,15 +69,15 @@ jobs:
     runs-on: depot-ubuntu-latest-16
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: "1.25.14"
           check-latest: true
           cache: true
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
         with:
           version: 11.22.0
 
@@ -104,8 +104,8 @@ jobs:
   test:
     runs-on: depot-ubuntu-latest-16
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: "1.25"
           check-latest: true
@@ -123,7 +123,7 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: depot/setup-action@v1
       - uses: docker/metadata-action@v6
         id: meta

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
           cache: true
 
       - name: Install pnpm and Node
-        uses: pnpm/setup@v1
+        uses: pnpm/setup@v2
         with:
           version: 11.22.0
           runtime: node@24
@@ -74,7 +74,7 @@ jobs:
           cache: true
 
       - name: Install pnpm and Node
-        uses: pnpm/setup@v1
+        uses: pnpm/setup@v2
         with:
           version: 11.22.0
           runtime: node@24

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,7 +24,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,9 +76,10 @@ jobs:
           cache: true
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/setup@v1
         with:
           version: 11.22.0
+          install: false
 
       - name: Install Node 24
         uses: actions/setup-node@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
           cache: true
 
       - name: Install pnpm
-        uses: pnpm/setup@v1
+        uses: pnpm/setup@v2
         with:
           version: 11.22.0
           install: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: depot/setup-action@v1
       - uses: docker/metadata-action@v6
         id: meta
@@ -67,16 +67,16 @@ jobs:
     needs: package
     if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev-')
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version: "1.25.14"
           check-latest: true
           cache: true
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
         with:
           version: 11.22.0
 


### PR DESCRIPTION
## Summary

- bump actions/checkout from v6 to v7
- bump actions/setup-go from v6 to v7
- replace pnpm/action-setup v5 with the successor pnpm/setup v2
- use pnpm/setup for pnpm 11.22, Node 24, and caching in CI
- preserve actions/setup-node in the release job for npm registry configuration

## Validation

- verified all referenced action tags exist upstream
- passed the pnpm 11.22 frozen-lockfile install, formatting check, and type check
- passed actionlint with known pre-existing custom-runner and untouched legacy-command diagnostics excluded
- parsed all workflow YAML files successfully
- passed git diff --check
- completed a supply-chain and credential-boundary review with no new high or medium findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI and release workflows (including npm publish setup). Risk is mainly pipeline breakage if the new action versions or pnpm/setup inputs misbehave; no application or auth logic changes.
> 
> **Overview**
> Bumps CI/release GitHub Actions and consolidates Node/pnpm setup.
> 
> `actions/checkout` and `actions/setup-go` move from v6 to v7 across `ci.yml`, `release.yml`, and `claude.yml`. Lint and build jobs replace `pnpm/action-setup` plus `actions/setup-node` with a single `pnpm/setup@v2` step that installs pnpm 11.22, Node 24, and cache (with `install: false` so deps still install via frozen lockfile). The release job still uses `setup-node` for the npm registry URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e1d64e9224f4403bc463b511dda01ab55b9653a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

