### PR TITLE
fix(ci): change cursor origin to origin in user-facing text

### DIFF
--- a/pkg/cmd/ci/migrate.go
+++ b/pkg/cmd/ci/migrate.go
@@ -269,7 +269,7 @@ func newCmdPreflight(parentOpts *migrateOptions) *cobra.Command {
 	return &cobra.Command{
 		Use:   "preflight",
 		Short: "Check authentication and repository access for migration",
-		Long:  "Validates authentication, detects a repository for the selected forge, and checks the access required to migrate it. GitHub checks the Depot Code Access app; Cursor checks that the Origin repository is available to the Depot organization.",
+		Long:  "Validates authentication, detects a repository for the selected forge, and checks the access required to migrate it. GitHub checks the Depot Code Access app; Origin checks that the repository is available to the Depot organization.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts := migrateCommandOptions(cmd, *parentOpts)
 			_, err := preflight(cmd.Context(), opts)

--- a/pkg/cmd/ci/migrate_origin_analysis.go
+++ b/pkg/cmd/ci/migrate_origin_analysis.go
@@ -34,7 +34,7 @@ func cursorPreflight(ctx context.Context, opts migrateOptions) (*preflightResult
 		out = os.Stdout
 	}
 	fmt.Fprintf(out, "\nDetected repository: %s\n", analysis.repositoryURL)
-	fmt.Fprintln(out, "Cursor Origin repository is available to this Depot organization.")
+	fmt.Fprintln(out, "Origin repository is available to this Depot organization.")
 	return &preflightResult{token: token, orgID: orgID, repo: analysis.repositoryURL}, nil
 }
 
@@ -73,7 +73,7 @@ func analyzeCursorOriginWorkflows(
 	}), token, orgID)
 	response, err := client.GetRepositoryAnalysis(ctx, request)
 	if err != nil {
-		return nil, fmt.Errorf("failed to analyze Cursor Origin compatibility for %s: %w", repositoryURL, err)
+		return nil, fmt.Errorf("failed to analyze Origin compatibility for %s: %w", repositoryURL, err)
 	}
 	return &cursorOriginAnalysis{response: response, remote: remote, repositoryURL: repositoryURL}, nil
 }

--- a/pkg/cmd/ci/migrate_origin_analysis_test.go
+++ b/pkg/cmd/ci/migrate_origin_analysis_test.go
@@ -236,7 +236,7 @@ func TestMigrateCommandGitHubModesDoNotRequestOriginAnalysis(t *testing.T) {
 			if _, err := os.Stat(filepath.Join(dir, ".depot", "workflows", "ci.yml")); err != nil {
 				t.Fatalf("GitHub workflow was not migrated: %v", err)
 			}
-			if !strings.Contains(output.String(), "Migrated 1 workflow(s)") || strings.Contains(output.String(), "Cursor Origin") {
+			if !strings.Contains(output.String(), "Migrated 1 workflow(s)") || strings.Contains(output.String(), "Origin compatibility findings:") {
 				t.Fatalf("unexpected GitHub migration output:\n%s", output.String())
 			}
 		})
@@ -261,7 +261,7 @@ func TestMigrateCommandCompatibleCursorWorkflowStaysQuiet(t *testing.T) {
 	if client.calls != 1 {
 		t.Fatalf("Origin analysis calls = %d, want 1", client.calls)
 	}
-	if strings.Contains(output.String(), "Cursor Origin compatibility findings:") {
+	if strings.Contains(output.String(), "Origin compatibility findings:") {
 		t.Fatalf("compatible workflow produced compatibility output:\n%s", output.String())
 	}
 	if _, err := os.Stat(filepath.Join(dir, ".depot", "workflows", "ci.yml")); err != nil {
@@ -282,7 +282,7 @@ func TestCursorMigrationReportsAnalysisFailureBeforeWritingFiles(t *testing.T) {
 		orgID:                    "org-id",
 		repositoryAnalysisClient: client,
 	})
-	if err == nil || !strings.Contains(err.Error(), "failed to analyze Cursor Origin compatibility for origin.cursor.com/acme/widgets") {
+	if err == nil || !strings.Contains(err.Error(), "failed to analyze Origin compatibility for origin.cursor.com/acme/widgets") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if _, statErr := os.Stat(filepath.Join(dir, ".depot")); !os.IsNotExist(statErr) {
@@ -315,7 +315,7 @@ func TestCursorPreflightUsesOriginAnalysisInsteadOfGitHubCodeAccess(t *testing.T
 	if client.request.Header().Get("Authorization") != "Bearer depot_org_token" || client.request.Header().Get("x-depot-org") != "" {
 		t.Fatalf("unexpected organization-token authentication headers: %#v", client.request.Header())
 	}
-	if !strings.Contains(output.String(), "Cursor Origin repository is available") {
+	if !strings.Contains(output.String(), "Origin repository is available") {
 		t.Fatalf("unexpected output: %s", output.String())
 	}
 }

--- a/pkg/cmd/ci/migrate_origin_diagnostics.go
+++ b/pkg/cmd/ci/migrate_origin_diagnostics.go
@@ -24,7 +24,7 @@ func renderCursorOriginDiagnostics(out io.Writer, response *civ2.GetRepositoryMi
 		return
 	}
 
-	fmt.Fprintln(out, "\nCursor Origin compatibility findings:")
+	fmt.Fprintln(out, "\nOrigin compatibility findings:")
 	for _, finding := range findings {
 		diagnostic := finding.diagnostic
 		fmt.Fprintf(out, "\n  %s — %s\n", originDiagnosticSeverityLabel(diagnostic.GetSeverity()), originWorkflowDisplayPath(finding.workflow))

--- a/pkg/cmd/ci/migrate_origin_diagnostics_test.go
+++ b/pkg/cmd/ci/migrate_origin_diagnostics_test.go
@@ -58,7 +58,7 @@ func TestRenderCursorOriginDiagnosticsShowsStructuredFindings(t *testing.T) {
 	text := output.String()
 
 	for _, expected := range []string{
-		"Cursor Origin compatibility findings:",
+		"Origin compatibility findings:",
 		"FAILS — .depot/workflows/ci.yml (from .github/workflows/ci.yml)",
 		"SILENT DEGRADATION — .depot/workflows/ci.yml (from .github/workflows/ci.yml)",
 		"CONDITIONALLY UNSUPPORTED — .depot/workflows/ci.yml (from .github/workflows/ci.yml)",

--- a/pkg/cmd/ci/migrate_secret_intent.go
+++ b/pkg/cmd/ci/migrate_secret_intent.go
@@ -246,16 +246,18 @@ func detectMigrationRemote(ctx context.Context, dir string, forge migrationForge
 		}
 	}
 	forgeName := "GitHub"
+	forgeArticle := "a"
 	host := "github.com/owner/repo"
 	if forge == migrationForgeOrigin {
-		forgeName = "Cursor Origin"
+		forgeName = "Origin"
+		forgeArticle = "an"
 		host = "origin.cursor.com/namespace/repo"
 	}
 	remoteKind := "git remotes"
 	if push {
 		remoteKind = "git push remotes"
 	}
-	return "", "", fmt.Errorf("could not detect a %s repository from %s — configure a remote pointing to %s", forgeName, remoteKind, host)
+	return "", "", fmt.Errorf("could not detect %s %s repository from %s — configure a remote pointing to %s", forgeArticle, forgeName, remoteKind, host)
 }
 
 func repositoryURLMatchesForge(repositoryURL string, forge migrationForge) bool {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Copy-only changes to CLI messages and tests; no behavior, auth, or migration logic is modified.
> 
> **Overview**
> Renames user-facing migrate CLI copy from **Cursor Origin** to **Origin**, including preflight help, success/error messages, compatibility findings, and remote-detection errors (with article grammar: “an Origin repository”). Tests are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fa7528af20d86244be8f6ad528bcf7d19e32b42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->